### PR TITLE
apply clang-tidy modernize-use-nullptr on some files

### DIFF
--- a/projects/gui/src/engineconfigurationdlg.cpp
+++ b/projects/gui/src/engineconfigurationdlg.cpp
@@ -38,7 +38,7 @@ EngineConfigurationDialog::EngineConfigurationDialog(
 	EngineConfigurationDialog::DialogMode mode, QWidget* parent)
 	: QDialog(parent),
 	  m_engineOptionModel(new EngineOptionModel(this)),
-	  m_engine(0),
+	  m_engine(nullptr),
 	  ui(new Ui::EngineConfigurationDialog)
 {
 	ui->setupUi(this);
@@ -229,7 +229,7 @@ void EngineConfigurationDialog::browseWorkingDir()
 
 void EngineConfigurationDialog::detectEngineOptions()
 {
-	if (m_engine != 0)
+	if (m_engine != nullptr)
 		return;
 
 	if (QObject::sender() != ui->m_detectBtn
@@ -251,9 +251,9 @@ void EngineConfigurationDialog::detectEngineOptions()
 
 	EngineBuilder builder(engineConfiguration());
 	QString error;
-	m_engine = qobject_cast<ChessEngine*>(builder.create(0, 0, this, &error));
+	m_engine = qobject_cast<ChessEngine*>(builder.create(nullptr, nullptr, this, &error));
 
-	if (m_engine != 0)
+	if (m_engine != nullptr)
 	{
 		connect(m_engine, SIGNAL(ready()),
 			this, SLOT(onEngineReady()));
@@ -279,7 +279,7 @@ void EngineConfigurationDialog::detectEngineOptions()
 
 void EngineConfigurationDialog::onEngineReady()
 {
-	Q_ASSERT(m_engine != 0);
+	Q_ASSERT(m_engine != nullptr);
 	Q_ASSERT(m_engine->state() != ChessPlayer::Disconnected);
 
 	qDeleteAll(m_options);
@@ -297,14 +297,14 @@ void EngineConfigurationDialog::onEngineReady()
 
 void EngineConfigurationDialog::onEngineQuit()
 {
-	Q_ASSERT(m_engine != 0);
+	Q_ASSERT(m_engine != nullptr);
 	Q_ASSERT(m_engine->state() == ChessPlayer::Disconnected);
 
-	disconnect(m_optionDetectionTimer, 0, m_engine, 0);
+	disconnect(m_optionDetectionTimer, nullptr, m_engine, nullptr);
 	m_optionDetectionTimer->stop();
 
 	m_engine->deleteLater();
-	m_engine = 0;
+	m_engine = nullptr;
 
 	ui->m_detectBtn->setEnabled(true);
 	ui->m_restoreBtn->setDisabled(m_options.isEmpty());

--- a/projects/gui/src/engineconfigurationmodel.cpp
+++ b/projects/gui/src/engineconfigurationmodel.cpp
@@ -22,7 +22,7 @@
 EngineConfigurationModel::EngineConfigurationModel(EngineManager* engineManager, QObject* parent)
 	: QAbstractListModel(parent), m_engineManager(engineManager)
 {
-	Q_ASSERT(m_engineManager != 0);
+	Q_ASSERT(m_engineManager != nullptr);
 
 	connect(m_engineManager, SIGNAL(engineAdded(int)), this,
 		SLOT(onEngineAdded(int)));

--- a/projects/gui/src/engineselectiondlg.cpp
+++ b/projects/gui/src/engineselectiondlg.cpp
@@ -25,7 +25,7 @@ EngineSelectionDialog::EngineSelectionDialog(EngineConfigurationProxyModel* mode
 	  m_model(model),
 	  ui(new Ui::EngineSelectionDialog)
 {
-	Q_ASSERT(model != 0);
+	Q_ASSERT(model != nullptr);
 	ui->setupUi(this);
 
 	ui->m_enginesList->setModel(m_model);


### PR DESCRIPTION
This is for demonstration purposes, the result of:
```
ralf@ark:~/cutechess> clang-tidy -p compile_commands.json projects/gui/src/engine* -checks=modernize-use-nullptr -fix
```
I used newest svn of llvm/clang/clang-extras and the Bear utility to generate the json.

`nullptr` is one of the useful C++11 modernizations because of clarity and type-safety.
