### PR TITLE
Variants1

### DIFF
--- a/cutechess.pro
+++ b/cutechess.pro
@@ -1,6 +1,6 @@
-contains(QT_VERSION, ^4\\..*|^5\\.[0-1]\\..*) {
+contains(QT_VERSION, ^4\\..*|^5\\.[0-2]\\..*) {
     message("Cannot build Cute Chess with Qt version $${QT_VERSION}.")
-    error("Qt version 5.2 or later is required.")
+    error("Qt version 5.3 or later is required.")
 }
 
 TEMPLATE = subdirs

--- a/cutechess.pro
+++ b/cutechess.pro
@@ -1,6 +1,6 @@
-contains(QT_VERSION, ^4\\..*|^5\\.[0-2]\\..*) {
+contains(QT_VERSION, ^4\\..*|^5\\.[0-1]\\..*) {
     message("Cannot build Cute Chess with Qt version $${QT_VERSION}.")
-    error("Qt version 5.3 or later is required.")
+    error("Qt version 5.2 or later is required.")
 }
 
 TEMPLATE = subdirs

--- a/projects/lib/src/chessengine.cpp
+++ b/projects/lib/src/chessengine.cpp
@@ -201,6 +201,13 @@ void ChessEngine::addVariant(const QString& variant)
 		m_variants << variant;
 }
 
+void ChessEngine::addVariantsFromList(const QStringList& variantsList)
+{
+	for ( const QString& variant: variantsList )
+		if (!variant.isEmpty() && !m_variants.contains(variant))
+		  {m_variants << variant;}
+}
+
 void ChessEngine::clearVariants()
 {
 	m_variants.clear();

--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -196,6 +196,11 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 
 		/*! Adds \a variant to the list of supported variants. */
 		void addVariant(const QString& variant);
+		/*!
+		 * Adds variants from \a variantsList to the list of
+		 * supported variants.
+		 */
+		void addVariantsFromList(const QStringList& variantsList);
 		/*! Clears the list of supported variants. */
 		void clearVariants();
 

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -133,14 +133,12 @@ void UciEngine::startGame()
 	
 
 	EngineComboOption *opv = (EngineComboOption *)getOption("UCI_Variant");
-	if ( opv && opv->choices().size() > 0 )
+	if ( opv && opv->choices().size() > 0 &&
+	            opv->choices().contains(board()->variant()) )
 	{
 		qDebug("Use UCI_Variant %s", qPrintable(board()->variant()));
-		if (opv->choices().contains(board()->variant()))
-		{
-			opv->setValue(board()->variant());
-			sendOption(opv->name(), opv->value());
-		}
+		opv->setValue(board()->variant());
+		sendOption(opv->name(), opv->value());
 	}
 	else
 	{


### PR DESCRIPTION
For UCI engines variants often are selected by setting check options _UCI_VariantName_ like UCI_Chess960, UCI_Crazyhouse, UCI_Horde etc. (Using prefix UCI_ for all of this is a bit unlucky).

Another way is to use combo option "UCI_Variant" with a list of supported options.   
Some engines support dozens of variants, e.g. Sjaak II. This engine also uses the UCI_Variant combo box option.

This patch adds support of combo option UCI_Variant.
