### PR TITLE
Berolina 1

### DIFF
--- a/cutechess.pro
+++ b/cutechess.pro
@@ -1,6 +1,6 @@
-contains(QT_VERSION, ^4\\..*|^5\\.[0-1]\\..*) {
+contains(QT_VERSION, ^4\\..*|^5\\.[0-2]\\..*) {
     message("Cannot build Cute Chess with Qt version $${QT_VERSION}.")
-    error("Qt version 5.2 or later is required.")
+    error("Qt version 5.3 or later is required.")
 }
 
 TEMPLATE = subdirs

--- a/cutechess.pro
+++ b/cutechess.pro
@@ -1,6 +1,6 @@
-contains(QT_VERSION, ^4\\..*|^5\\.[0-2]\\..*) {
+contains(QT_VERSION, ^4\\..*|^5\\.[0-1]\\..*) {
     message("Cannot build Cute Chess with Qt version $${QT_VERSION}.")
-    error("Qt version 5.3 or later is required.")
+    error("Qt version 5.2 or later is required.")
 }
 
 TEMPLATE = subdirs

--- a/projects/lib/src/board/berolinaboard.cpp
+++ b/projects/lib/src/board/berolinaboard.cpp
@@ -1,0 +1,44 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "berolinaboard.h"
+#include "westernzobrist.h"
+#include "gaviotatablebase.h"
+
+namespace Chess {
+
+BerolinaBoard::BerolinaBoard()
+	: StandardBoard()
+{
+ /*
+  * Berolina pawns move one square diagonally forward and they capture
+  * one square straight ahead.
+  */
+	pawnSteps = { { Free, -1 }, { Capture, 0 }, { Free, 1 } };
+}
+
+Board* BerolinaBoard::copy() const
+{
+	return new BerolinaBoard(*this);
+}
+
+QString BerolinaBoard::variant() const
+{
+	return "berolina";
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/berolinaboard.h
+++ b/projects/lib/src/board/berolinaboard.h
@@ -1,0 +1,52 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BEROLINABOARD_H
+#define BEROLINABOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Berolina Chess
+ *
+ * Berolina chess is a variant of standard chess with modified pawn moves.
+ * Pawns move one square diagonally forward and they capture one square straight ahead.
+ * Introduced by Edmund Nebermann, Berlin 1926.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Berolina_chess
+ *
+ * BerolinaBoard uses Polyglot-compatible zobrist position keys,
+ * so Berolina opening books in Polyglot format could be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT BerolinaBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new BerolinaBoard object. */
+		BerolinaBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+};
+
+} // namespace Chess
+#endif // BEROLINABOARD_H

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -319,14 +319,15 @@ QString Board::moveString(const Move& move, MoveNotation notation)
 	return lanMoveString(move);
 }
 
-Move Board::moveFromLanString(const QString& str)
+Move Board::moveFromLanString(const QString& istr)
 {
+	QString str(istr);
+	str.remove(QRegExp("[x+#!?]"));
 	int len = str.length();
 	if (len < 4)
 		return Move();
 
 	Piece promotion;
-
 	int drop = str.indexOf('@');
 	if (drop > 0)
 	{

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -3,6 +3,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/westernboard.cpp \
     $$PWD/square.cpp \
     $$PWD/standardboard.cpp \
+    $$PWD/berolinaboard.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
@@ -24,6 +25,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/westernboard.h \
     $$PWD/square.h \
     $$PWD/standardboard.h \
+    $$PWD/berolinaboard.h \
     $$PWD/capablancaboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -24,10 +24,12 @@
 #include "gothicboard.h"
 #include "losersboard.h"
 #include "standardboard.h"
+#include "berolinaboard.h"
 
 namespace Chess {
 
 REGISTER_BOARD(AtomicBoard, "atomic")
+REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -28,6 +28,7 @@ WesternBoard::WesternBoard(WesternZobrist* zobrist)
 	  m_arwidth(0),
 	  m_sign(1),
 	  m_enpassantSquare(0),
+	  m_enpassantTarget(0),
 	  m_reversibleMoveCount(0),
 	  m_kingCanCapture(true),
 	  m_zobrist(zobrist)
@@ -94,6 +95,13 @@ void WesternBoard::vInitialize()
 	m_rookOffsets[1] = -1;
 	m_rookOffsets[2] = 1;
 	m_rookOffsets[3] = m_arwidth;
+
+	m_pawnAmbiguous = pawnAmbiguity(StepType::Free);
+}
+
+inline int WesternBoard::getPawnPush(const PawnStep& ps, int sign) const
+{
+	return sign * ps.file - sign * m_arwidth * 1;
 }
 
 int WesternBoard::captureType(const Move& move) const
@@ -165,6 +173,11 @@ QString WesternBoard::sanMoveString(const Move& move)
 
 	if (piece.type() == Pawn)
 	{
+		if ( m_pawnAmbiguous )
+		{
+			needFile = true;
+			needRank = true; // for Xboard-compatibility
+		}
 		if (target == m_enpassantSquare)
 			capture = Piece(side.opposite(), Pawn);
 		if (capture.isValid())
@@ -297,10 +310,11 @@ Move WesternBoard::moveFromSanString(const QString& str)
 	QString::const_iterator it = mstr.begin();
 
 	// A SAN move can't start with the capture mark, and
-	// a pawn move must not specify the piece type
-	if (*it == 'x' || pieceFromSymbol(*it) == Pawn)
+	if (*it == 'x')
 		return Move();
-
+	// a pawn move should not specify the piece type
+	if (pieceFromSymbol(*it) == Pawn)
+		it++; // ignore charavter
 	// Piece type
 	Piece piece = pieceFromSymbol(*it);
 	if (piece.side() != Side::White)
@@ -496,6 +510,15 @@ QString WesternBoard::castlingRightsString(FenNotation notation) const
 	return str;
 }
 
+bool WesternBoard::pawnAmbiguity( StepType t ) const
+{
+	int count = 0;
+	for (auto a: pawnSteps)
+		if (a.type == t)
+			++count;
+	return count > 1;
+}
+
 QString WesternBoard::vFenString(FenNotation notation) const
 {
 	// Castling rights
@@ -504,6 +527,7 @@ QString WesternBoard::vFenString(FenNotation notation) const
 	// En-passant square
 	if (m_enpassantSquare != 0)
 		fen += squareString(m_enpassantSquare);
+		//TODO:  HOW to achieve Berolina disambiguation?
 	else
 		fen += '-';
 
@@ -631,17 +655,32 @@ bool WesternBoard::vSetFenString(const QStringList& fen)
 	m_sign = (side == Side::White) ? 1 : -1;
 	if (*token != "-")
 	{
-		setEnpassantSquare(squareIndex(*token));
+		int epSq = squareIndex(*token);
+		setEnpassantSquare(epSq);
 		if (m_enpassantSquare == 0)
 			return false;
 
+		Piece ownPawn(side, Pawn);
+		Piece opPawn(side.opposite(), Pawn);
+		int matchesOwn = 0;
+		int epTgt = 0;
+
+		for ( PawnStep pStep: pawnSteps )
+		{
+			int sq = epSq - getPawnPush( pStep, m_sign );
+			Piece piece = pieceAt(sq);
+			if (pStep.type == Capture && piece == ownPawn)
+					matchesOwn++;
+			else if (pStep.type == Free && piece == opPawn)
+					epTgt = epTgt ? sq : sq;
+		}
 		// Ignore the en-passant square if an en-passant
 		// capture isn't possible.
-		int pawnSq = m_enpassantSquare + m_arwidth * m_sign;
-		Piece ownPawn(side, Pawn);
-		if (pieceAt(pawnSq - 1) != ownPawn
-		&&  pieceAt(pawnSq + 1) != ownPawn)
+		if (!matchesOwn)
 			setEnpassantSquare(0);
+		else
+			// set ep square and target
+			setEnpassantSquare(epSq, epTgt);
 	}
 
 	// Reversible halfmove count
@@ -663,8 +702,10 @@ bool WesternBoard::vSetFenString(const QStringList& fen)
 	return true;
 }
 
-void WesternBoard::setEnpassantSquare(int square)
+void WesternBoard::setEnpassantSquare(int square, int target)
 {
+
+	m_enpassantTarget = square ? target : 0;
 	if (square == m_enpassantSquare)
 		return;
 
@@ -715,13 +756,14 @@ void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)
 	int promotionType = move.promotion();
 	int pieceType = pieceAt(source).type();
 	int epSq = m_enpassantSquare;
+	int epTgt = m_enpassantTarget;
 	int* rookSq = m_castlingRights.rookSquare[side];
 	bool clearSource = true;
 	bool isReversible = true;
 
 	Q_ASSERT(target != 0);
 
-	MoveData md = { capture, epSq, m_castlingRights,
+	MoveData md = { capture, epSq, epTgt, m_castlingRights,
 			NoCastlingSide, m_reversibleMoveCount };
 
 	if (source == 0)
@@ -771,7 +813,7 @@ void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)
 		// Make an en-passant capture
 		if (target == epSq)
 		{
-			int epTarget = target + m_arwidth * m_sign;
+			int epTarget = epTgt;
 			setSquare(epTarget, Piece::NoPiece);
 
 			if (transition != nullptr)
@@ -779,12 +821,16 @@ void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)
 		}
 		// Push a pawn two squares ahead, creating an en-passant
 		// opportunity for the opponent.
-		else if ((source - target) * m_sign == m_arwidth * 2)
+		else if ((source / m_arwidth - target / m_arwidth) * m_sign == 2)
 		{
+			int epSq = (source + target) / 2;
 			Piece opPawn(side.opposite(), Pawn);
-			if (pieceAt(target - 1) == opPawn
-			||  pieceAt(target + 1) == opPawn)
-				setEnpassantSquare(source - m_arwidth * m_sign);
+			for ( PawnStep pstep: pawnSteps )
+				if ( pstep.type == StepType::Capture && opPawn ==
+					pieceAt( epSq + getPawnPush( pstep, m_sign ) ) )
+				{
+					setEnpassantSquare(epSq, target);
+				}
 		}
 		else if (promotionType != Piece::NoPiece)
 			pieceType = promotionType;
@@ -841,7 +887,7 @@ void WesternBoard::vUndoMove(const Move& move)
 	m_sign *= -1;
 	Side side = sideToMove();
 
-	setEnpassantSquare(md.enpassantSquare);
+	setEnpassantSquare(md.enpassantSquare, md.enpassantTarget);
 	m_reversibleMoveCount = md.reversibleMoveCount;
 	m_castlingRights = md.castlingRights;
 
@@ -867,7 +913,7 @@ void WesternBoard::vUndoMove(const Move& move)
 	else if (target == m_enpassantSquare)
 	{
 		// Restore the pawn captured by the en-passant move
-		int epTarget = target + m_arwidth * m_sign;
+		int epTarget = m_enpassantTarget;
 		setSquare(epTarget, Piece(side.opposite(), Pawn));
 	}
 
@@ -912,13 +958,15 @@ bool WesternBoard::inCheck(Side side, int square) const
 		square = m_kingSquare[side];
 	
 	// Pawn attacks
-	int step = (side == Side::White) ? -m_arwidth : m_arwidth;
-	// Left side
-	if (pieceAt(square + step - 1) == Piece(opSide, Pawn))
-		return true;
-	// Right side
-	if (pieceAt(square + step + 1) == Piece(opSide, Pawn))
-		return true;
+	int sign = (side == Side::White) ? 1 : -1;
+
+	for ( PawnStep pStep: pawnSteps )
+		if (pStep.type == StepType::Capture )
+		{
+			int fromSquare = square - getPawnPush( pStep, -sign );
+			if (pieceAt(fromSquare) == Piece(opSide, Pawn))
+				return true;
+		}
 
 	Piece piece;
 	
@@ -1051,41 +1099,33 @@ void WesternBoard::generatePawnMoves(int sourceSquare,
 	int step = m_sign * m_arwidth;
 	bool isPromotion = pieceAt(sourceSquare - step * 2).isWall();
 
-	// One square ahead
-	targetSquare = sourceSquare - step;
-	capture = pieceAt(targetSquare);
-	if (capture.isEmpty())
-	{
-		if (isPromotion)
-			addPromotions(sourceSquare, targetSquare, moves);
-		else
-		{
-			moves.append(Move(sourceSquare, targetSquare));
-
-			// Two squares ahead
-			if (pieceAt(sourceSquare + step * 2).isWall())
-			{
-				targetSquare -= step;
-				capture = pieceAt(targetSquare);
-				if (capture.isEmpty())
-					moves.append(Move(sourceSquare, targetSquare));
-			}
-		}
-	}
-
-	// Captures, including en-passant moves
+	// Normal moves, Captures, including en-passant moves
 	Side opSide(sideToMove().opposite());
-	for (int i = -1; i <= 1; i += 2)
+
+	for (PawnStep pStep: pawnSteps)
 	{
-		targetSquare = sourceSquare - step + i;
+		targetSquare = sourceSquare + getPawnPush( pStep, m_sign );
 		capture = pieceAt(targetSquare);
-		if (capture.side() == opSide
-		||  targetSquare == m_enpassantSquare)
+		bool isCapture = capture.side() == opSide
+				||  targetSquare == enpassantSquare();
+		bool isNormalStep = capture.isEmpty();
+
+		if (  (isNormalStep && pStep.type == StepType::Free )
+		   || (isCapture && pStep.type == StepType::Capture ) )
 		{
 			if (isPromotion)
 				addPromotions(sourceSquare, targetSquare, moves);
 			else
 				moves.append(Move(sourceSquare, targetSquare));
+
+			// Double step
+			if (isNormalStep && pieceAt(sourceSquare + step * 2).isWall())
+			{
+				targetSquare += getPawnPush( pStep, m_sign );
+				capture = pieceAt(targetSquare);
+				if (capture.isEmpty())
+					moves.append(Move(sourceSquare, targetSquare));
+			}
 		}
 	}
 }

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -76,6 +76,29 @@ class LIB_EXPORT WesternBoard : public Board
 		/*! Movement mask for Rook moves. */
 		static const unsigned RookMovement = 8;
 
+		/*! Types of Pawn moves. */
+		enum StepType: const char
+		{
+			 Free = (char) 1,      //!< May move if target is empty
+			 Capture = (char) 2,   //!< Capture opposing piece only
+			 /* FreeOrCapture = Free|Capture, //!< like King or Sergeant */
+			 None =(char) 0        //!< Cannot move here
+		} stepTypeEnum;
+
+		/*!
+		 * Movement mask for Pawn moves.
+		 * Forward: Left diagonal, straight, right diagonal.
+		 * \sa BerolinaBoard
+		 *
+		 * Default: A pawn can step straight ahead onto a free square or
+		 * capture diagonally forward.
+		 */
+		struct PawnStep { StepType type; int file; };
+		QList<PawnStep>  pawnSteps = { {Capture, -1}, {Free, 0}, {Capture, 1} }; 
+		/*! Helper function for Pawn moves. Returns true if two or more
+		 * moves of the given \a type are specified in pawnSteps. */
+		bool pawnAmbiguity( StepType type = StepType::Free ) const;
+
 		/*!
 		 * Returns true if the king can capture opposing pieces.
 		 * The default value is true.
@@ -150,6 +173,7 @@ class LIB_EXPORT WesternBoard : public Board
 		{
 			Piece capture;
 			int enpassantSquare;
+			int enpassantTarget;
 			CastlingRights castlingRights;
 			CastlingSide castlingSide;
 			int reversibleMoveCount;
@@ -163,17 +187,22 @@ class LIB_EXPORT WesternBoard : public Board
 		QString castlingRightsString(FenNotation notation) const;
 		bool parseCastlingRights(QChar c);
 		CastlingSide castlingSide(const Move& move) const;
-		void setEnpassantSquare(int square);
+		void setEnpassantSquare(int square, int target=0);
 		void setCastlingSquare(Side side,
 				       CastlingSide cside,
 				       int square);
+		/*! Helper for Pawn moves. Returns square offset for the
+		 *  given \a step with orientation \a sign. */
+		inline int getPawnPush( const PawnStep& ps, int sign ) const;
 
 		int m_arwidth;
 		int m_sign;
 		int m_kingSquare[2];
 		int m_enpassantSquare;
+		int m_enpassantTarget;
 		int m_reversibleMoveCount;
 		bool m_kingCanCapture;
+		bool m_pawnAmbiguous;
 		QVector<MoveData> m_history;
 		CastlingRights m_castlingRights;
 		int m_castleTarget[2][2];

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -223,6 +223,36 @@ void tst_Board::moveStrings_data() const
 		<< ""
 		<< "r1bqkbnr/pp3ppp/2ppp3/8/2BQP3/2N5/PPP2PPP/R1B2RK1[] b kq - 0 1"
 		<< "r1bqkbnr/pp3ppp/2ppp3/8/2BQP3/2N5/PPP2PPP/R1B2RK1[-] b kq - 0 1";
+	QTest::newRow("berolina san1a")
+		<< "berolina"
+		<< "e2c4 Nc6 c4d5 e7c5 d5xd6 Bxd6 Qe2+ Nge7 a2c4 O-O"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "r1bq1rk1/ppppnppp/2nb4/8/2P5/8/1PPPQPPP/RNB1KBNR w KQ - 0 6";
+	QTest::newRow("berolina san1b")
+		<< "berolina"
+		<< "ec4 Nc6 cd5 ec5 dxd6 Bxd6 Qe2+ Nge7 ac4 O-O"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "r1bq1rk1/ppppnppp/2nb4/8/2P5/8/1PPPQPPP/RNB1KBNR w KQ - 0 6";
+	QTest::newRow("berolina san1c")
+		<< "berolina"
+		<< "ec4 Nc6 d5 ec5 dxd6 Bxd6 Qe2 Nge7 c4 O-O"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "r1bq1rk1/ppppnppp/2nb4/8/2P5/8/1PPPQPPP/RNB1KBNR w KQ - 0 6";
+	QTest::newRow("berolina coord1")
+		<< "berolina"
+		<< "e2c4 b8c6 c4d5 e7c5"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "r1bqkbnr/pppp1ppp/2n5/2pP4/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3";
+	QTest::newRow("berolina san2")
+		<< "berolina"
+		<< "Qd4"
+		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+	QTest::newRow("berolina san3")
+		<< "berolina"
+		<< "Qd4"
+		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
 }
 
 void tst_Board::moveStrings()
@@ -398,6 +428,17 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4888832);
+	variant = "berolina";
+	QTest::newRow("berolina startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4  //4 plies: 882717, 5 plies: 29119802
+		<< Q_UINT64_C(882717);
+	QTest::newRow("berolina1")
+		<< variant
+		<< "3k1r2/1pp3p1/3P2p1/PR4p1/6p1/2P2Pn1/b3r1BP/3KN3 b - - 1 26"
+		<< 4  //4 plies: 909365, 5 plies: 37601709
+		<< Q_UINT64_C(909365);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a proposal to support variants with different pawn movements, like the Berolina chess variant.

Initially I intended only to override the pawn move generation of standard board. However, the legality and in-check handling and the support for reading and writing moves and positions from and to files had to be done in base classes.

This version was tested with Sjaak II 1.3.1a and with Fairy-Max 4.8Q. Files were also transferred from and to xboard versions 4.7.3 and 4.9.1. All perft tests of the cutechess berolina variant were identical with the corresponding Sjaak results.

I hope this is useful.
