### PR TITLE
do not use time increment for book moves

### DIFF
--- a/projects/lib/src/chessplayer.cpp
+++ b/projects/lib/src/chessplayer.cpp
@@ -136,7 +136,7 @@ void ChessPlayer::makeBookMove(const Chess::Move& move)
 {
 	m_timeControl.startTimer();
 	makeMove(move);
-	m_timeControl.update();
+	m_timeControl.update(false);
 	m_eval.setBookEval(true);
 
 	emit moveMade(move);

--- a/projects/lib/src/timecontrol.cpp
+++ b/projects/lib/src/timecontrol.cpp
@@ -321,7 +321,7 @@ void TimeControl::startTimer()
 	m_time.start();
 }
 
-void TimeControl::update()
+void TimeControl::update(bool applyIncrement)
 {
 	/*
 	 * This will overflow after roughly 49 days however it's unlikely
@@ -336,7 +336,10 @@ void TimeControl::update()
 		setTimeLeft(m_timePerMove);
 	else
 	{
-		setTimeLeft(m_timeLeft + m_increment - m_lastMoveTime);
+	        int newTimeLeft = m_timeLeft - m_lastMoveTime;
+		if (applyIncrement)
+			newTimeLeft += m_increment;
+		setTimeLeft(newTimeLeft);
 		
 		if (m_movesPerTc > 0)
 		{

--- a/projects/lib/src/timecontrol.h
+++ b/projects/lib/src/timecontrol.h
@@ -173,8 +173,14 @@ class LIB_EXPORT TimeControl
 		/*! Start the timer. */
 		void startTimer();
 		
-		/*! Update the time control with the elapsed time. */
-		void update();
+		/*!
+		 * Update the time control with the elapsed time.
+		 * A move time increment will only be applied if
+		 * \a applyIncrement is true. This is the default.
+		 * Set this value to false if no increment is necessary for
+		 * the current move, e.g. for a book move.
+		 */
+		void update(bool applyIncrement = true);
 
 		/*! Returns the last elapsed move time. */
 		int lastMoveTime() const;


### PR DESCRIPTION
Some users prefer to not increase available time if book moves are applied. Currently, any move causes a pre-defined time increment.  #9 

This simple patch does not have configurable settings.