### PR TITLE
begin support for variant King of the Hill

### DIFF
--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -5,6 +5,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/standardboard.cpp \
     $$PWD/berolinaboard.cpp \
     $$PWD/capablancaboard.cpp \
+    $$PWD/kingofthehillboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
     $$PWD/frcboard.cpp \
@@ -27,6 +28,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/standardboard.h \
     $$PWD/berolinaboard.h \
     $$PWD/capablancaboard.h \
+    $$PWD/kingofthehillboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \
     $$PWD/frcboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -25,6 +25,7 @@
 #include "losersboard.h"
 #include "standardboard.h"
 #include "berolinaboard.h"
+#include "kingofthehillboard.h"
 
 namespace Chess {
 
@@ -35,6 +36,7 @@ REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
+REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(StandardBoard, "standard")
 

--- a/projects/lib/src/board/kingofthehillboard.cpp
+++ b/projects/lib/src/board/kingofthehillboard.cpp
@@ -1,0 +1,55 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "kingofthehillboard.h"
+
+namespace Chess {
+
+KingOfTheHillBoard::KingOfTheHillBoard()
+	: StandardBoard(),
+	  m_centralSquares { 54, 55, 64, 65 } // Squares d5, e5, d4, and e4
+{
+}
+
+Board* KingOfTheHillBoard::copy() const
+{
+	return new KingOfTheHillBoard(*this);
+}
+
+QString KingOfTheHillBoard::variant() const
+{
+	return "kingofthehill";
+}
+
+Result KingOfTheHillBoard::result()
+{
+	if (kingInCenter(Side::White))
+		return Result(Result::Win, Side::White,
+			      tr("White wins with king in the center"));
+	if (kingInCenter(Side::Black))
+		return Result(Result::Win, Side::Black,
+			      tr("Black wins with king in the center"));
+	return StandardBoard::result();
+}
+
+/*! Returns true if the king of \a side is occupying a central square */
+bool KingOfTheHillBoard::kingInCenter(Side side) const
+{
+	return m_centralSquares.contains(kingSquare(side));
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/kingofthehillboard.h
+++ b/projects/lib/src/board/kingofthehillboard.h
@@ -1,0 +1,55 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KINGOFTHEHILLBOARD_H
+#define KINGOFTHEHILLBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for King of the Hill Chess
+ *
+ * King of the Hill chess is a variant of standard chess with an additional rule.
+ * Moving the king to one of the four central squares wins.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Chess_variant
+ *
+ * KingOfTheHillBoard uses Polyglot-compatible zobrist position keys,
+ * so King of the Hill (and standard) opening books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT KingOfTheHillBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new KingOfTheHillBoard object. */
+		KingOfTheHillBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual Result result();
+	private:
+		bool kingInCenter(Side side) const;
+		const QList<int> m_centralSquares;
+};
+
+} // namespace Chess
+#endif // KINGOFTHEHILLBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -335,6 +335,22 @@ void tst_Board::results_data() const
 		<< variant
 		<< "2K5/4B3/2k2B2/8/8/4b3/8/8 b - - 0 1"
 		<< "1/2-1/2";
+
+	variant = "kingofthehill";
+
+	QTest::newRow("KOTH unfinished #1")
+		<< variant
+		<< "r1b3nr/1pp2ppp/p7/2kp4/BP1p4/2PK1N2/P4PPP/R1R5 b - - 0 18"
+		<< "*";
+	QTest::newRow("KOTH center #1")
+		<< variant
+		<< "r1b3nr/1pp2ppp/pk6/3p4/BP1K4/2P2N2/P4PPP/R1R5 b - - 0 19"
+		<< "1-0";
+	QTest::newRow("KOTH center #2")
+		<< variant
+		<< "1q6/8/2B2p2/4k3/P1p5/1p1pn3/5K2/8 w - - 1 71"
+		<< "0-1";
+
 }
 
 void tst_Board::results()
@@ -423,6 +439,7 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4888832);
+
 	variant = "berolina";
 	QTest::newRow("berolina startpos")
 		<< variant


### PR DESCRIPTION
This adds support for the variant kingofthehill ("King of the Hill")  to the library. It uses `StandardBoard` as base. So it is only necessary to apply the one extra rule and test for a win for a king on a center field.

It has been tested manually and using Sjaak II version 1.3.1a and a recent version of the Stockfish multi-variant fork of D. Dugovic and team https://github.com/ddugovic/Stockfish.git .
