### PR TITLE
begin support for Racing Kings variant

### DIFF
--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -4,6 +4,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/square.cpp \
     $$PWD/standardboard.cpp \
     $$PWD/berolinaboard.cpp \
+    $$PWD/racingkingsboard.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/zobrist.cpp \
@@ -27,6 +28,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/square.h \
     $$PWD/standardboard.h \
     $$PWD/berolinaboard.h \
+    $$PWD/racingkingsboard.h \
     $$PWD/capablancaboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/zobrist.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -26,6 +26,7 @@
 #include "standardboard.h"
 #include "berolinaboard.h"
 #include "kingofthehillboard.h"
+#include "racingkingsboard.h"
 
 namespace Chess {
 
@@ -38,6 +39,7 @@ REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(LosersBoard, "losers")
+REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(StandardBoard, "standard")
 
 

--- a/projects/lib/src/board/racingkingsboard.cpp
+++ b/projects/lib/src/board/racingkingsboard.cpp
@@ -1,0 +1,128 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "racingkingsboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+RacingKingsBoard::RacingKingsBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+Board* RacingKingsBoard::copy() const
+{
+	return new RacingKingsBoard(*this);
+}
+
+QString RacingKingsBoard::variant() const
+{
+	return "racingkings";
+}
+
+QString RacingKingsBoard::defaultFenString() const
+{
+	return "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1";
+}
+
+bool RacingKingsBoard::isLegalPosition()
+{
+	Side side = sideToMove();
+	if (inCheck(side))
+		return false;
+
+	return WesternBoard::isLegalPosition();
+}
+
+/*! Returns true if the king of \a side is on the eighth rank */
+bool RacingKingsBoard::finished(Side side) const
+{
+	Square ksq = chessSquare(kingSquare(side));
+	return (ksq.rank() == 7);
+}
+
+/*! Returns true if the king of \a side can reach the eighth rank */
+bool RacingKingsBoard::canFinish(Side side)
+{
+	QVarLengthArray<Move> moves;
+	WesternBoard::generateMovesForPiece(moves, King, kingSquare(side));
+	for (const Move& m: moves)
+	{
+		Square targetSq = chessSquare(m.targetSquare());
+		if (targetSq.rank() == 7
+		&&  vIsLegalMove(m) )
+			return true;
+	}
+	return false;
+}
+
+Result RacingKingsBoard::result()
+{
+	QString str;
+	bool blackFinished = finished(Side::Black);
+	bool whiteFinished = finished(Side::White);
+
+	// Finishing on eighth rank
+	if (blackFinished && whiteFinished)
+	{
+		str = tr("Drawn race");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	if (blackFinished)
+	{
+		str = tr("Black wins the race");
+		return Result(Result::Win, Side::Black, str);
+	}
+
+	Side side = sideToMove();
+	bool mobile = canMove();
+
+	// White finished but Black cannot finish or forfeited the chance
+	if (whiteFinished
+	&& ((mobile && !canFinish(Side::Black)) || side == Side::White))
+	{
+		str = tr("White wins the race");
+		return Result(Result::Win, Side::White, str);
+	}
+
+	// Stalemate
+	if (!mobile)
+	{
+		str = tr("Draw by stalemate");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// 50 move rule
+	if (reversibleMoveCount() >= 100)
+	{
+		str = tr("Draw by fifty moves rule");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+	{
+		str = tr("Draw by 3-fold repetition");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/racingkingsboard.h
+++ b/projects/lib/src/board/racingkingsboard.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef RACINGKINGSBOARD_H
+#define RACINGKINGSBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Racing Kings Chess
+ *
+ * Racing Kings Chess (originally named Dodo Chess) is a variant of standard
+ * chess by Vernon R. Parton, UK, 1961.
+ *
+ * This race game is played without pawns. The starting position has pieces on
+ * ranks one and two. Moving the king to the eighth rank wins. However, the
+ * game is drawn when the black king reaches the eighth rank immediately after
+ * the white king. Giving check and entering check is forbidden.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/V._R._Parton#Racing_Kings
+ * */
+class LIB_EXPORT RacingKingsBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new RacingKingsBoard object. */
+		RacingKingsBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual Result result();
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual bool isLegalPosition();
+
+	private:
+		bool finished(Side side) const;
+		bool canFinish(Side side);
+};
+
+} // namespace Chess
+#endif // RACINGKINGSBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -351,6 +351,25 @@ void tst_Board::results_data() const
 		<< "1q6/8/2B2p2/4k3/P1p5/1p1pn3/5K2/8 w - - 1 71"
 		<< "0-1";
 
+	variant = "racingkings";
+
+	QTest::newRow("Race black win")
+		<< variant
+		<< "6k1/3K4/3B4/8/8/8/8/8 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("Race unfinished")
+		<< variant
+		<< "6K1/3k4/3b4/8/8/8/8/8 b - - 0 1"
+		<< "*";
+	QTest::newRow("Race white win")
+		<< variant
+		<< "6K1/8/3bk3/8/8/8/8/8 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("Race drawn")
+		<< variant
+		<< "3k2K1/8/3b4/8/8/8/8/8 w - - 1 1"
+		<< "1/2-1/2";
+
 }
 
 void tst_Board::results()
@@ -451,6 +470,14 @@ void tst_Board::perft_data() const
 		<< "3k1r2/1pp3p1/3P2p1/PR4p1/6p1/2P2Pn1/b3r1BP/3KN3 b - - 1 26"
 		<< 4  //4 plies: 909365, 5 plies: 37601709
 		<< Q_UINT64_C(909365);
+
+	variant = "racingkings";
+	QTest::newRow("racingkings startpos")
+		<< variant
+		<< "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
+		<< 4  //4 plies: 296242, 5 plies: 9472927
+		<< Q_UINT64_C(296242);
+
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This adds support for the variant racingkings ("Racing Kings") to the library.  Racing Kings Chess is a race game and a checkless chess variant.

This software has been tested with a recent version of the multi-variant fork of the Stockfish engine  https://github.com/ddugovic/Stockfish.git. It also works with lichess.org PGN game files (after patching the variant name "Racing Kings" to "racingkings", but this is a topic already listed in the issues list).