### PR TITLE
support Horde Chess

### DIFF
--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -7,6 +7,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/racingkingsboard.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/kingofthehillboard.cpp \
+    $$PWD/hordeboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
     $$PWD/frcboard.cpp \
@@ -31,6 +32,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/racingkingsboard.h \
     $$PWD/capablancaboard.h \
     $$PWD/kingofthehillboard.h \
+    $$PWD/hordeboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \
     $$PWD/frcboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -22,6 +22,7 @@
 #include "crazyhouseboard.h"
 #include "frcboard.h"
 #include "gothicboard.h"
+#include "hordeboard.h"
 #include "losersboard.h"
 #include "standardboard.h"
 #include "berolinaboard.h"
@@ -37,6 +38,7 @@ REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
+REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")

--- a/projects/lib/src/board/hordeboard.cpp
+++ b/projects/lib/src/board/hordeboard.cpp
@@ -1,0 +1,100 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hordeboard.h"
+
+namespace Chess {
+
+HordeBoard::HordeBoard()
+	: StandardBoard()
+{
+}
+
+Board* HordeBoard::copy() const
+{
+	return new HordeBoard(*this);
+}
+
+QString HordeBoard::variant() const
+{
+	return "horde";
+}
+
+/*!
+ * Horde chess, lichess.org variant has 36 white pawns and starting FEN
+ * rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1
+ * Dunsany's chess only has 32 white pawns and black starts with FEN
+ * rnbqkbnr/pppppppp/8/8/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP b kq - 0 1
+ * Original Horde chess has 32 black pawns vs a white standard set of pieces
+ * ppp2ppp/pppppppp/pppppppp/pppppppp/3pp3/8/PPPPPPPP/RNBQKBNR w KQ - 0 1
+ */
+QString HordeBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1";
+}
+
+bool HordeBoard::vIsLegalMove(const Move& m)
+{
+	if (!StandardBoard::vIsLegalMove(m))
+		return false;
+
+	/*
+	 * Workaround for Stockfish (lichess.org) asymmetry:
+	 * accept en passant on 3rd (6th) rank only.
+	 */
+	int src = m.sourceSquare();
+	int tgt = m.targetSquare();
+	Piece piece = pieceAt(src);
+
+	if (piece.type() != Pawn
+	|| tgt != enpassantSquare())
+		return true;
+
+	int targetRank = chessSquare(tgt).rank();
+	return targetRank == 2 || targetRank == height() - 3;
+}
+
+bool HordeBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings + blackKings == 1;
+}
+
+Result HordeBoard::result()
+{
+	Side side = sideToMove();
+	Side opp = side.opposite();
+	if (!hasMaterial(side))
+		return Result(Result::Win, opp, tr("%1 wins").arg(opp));
+
+	return StandardBoard::result();
+}
+
+/*!
+ * Returns true if \a side has material else false.
+ */
+bool HordeBoard::hasMaterial(Side side) const
+{
+	for (int i = 0; i < arraySize(); i++)
+	{
+		if  (side == pieceAt(i).side()
+		&&   pieceAt(i).isValid())
+			return true;
+	}
+	return false;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/hordeboard.h
+++ b/projects/lib/src/board/hordeboard.h
@@ -1,0 +1,67 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HORDEBOARD_H
+#define HORDEBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Horde Chess and Dunsany's Chess
+ * (Defaults are set to lichess.org (SF) variant)
+ *
+ * Horde chess is a variant of standard chess with different setup.
+ * It is similar to a variant introduced by Lord Dunsany in 1942.
+ *
+ * The black side plays with a standard set of pieces. However white has
+ * 36 pawns and no other pieces.
+ *
+ * White has to mate the black king, black has to capture all pawns of the
+ * white horde in order to win. Standard chess rules apply. White pawns on
+ * the first and second ranks can make a double step.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Dunsany%27s_chess#Horde_Chess
+ *
+ * HordeBoard uses Polyglot-compatible zobrist position keys,
+ * so Horde Chess opening books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT HordeBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new HordeBoard object. */
+		HordeBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+	protected:
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool vIsLegalMove(const Move& m);
+	private:
+		bool hasMaterial(Side side) const;
+};
+
+} // namespace Chess
+#endif // HORDEBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -55,6 +55,11 @@ int WesternBoard::height() const
 	return 8;
 }
 
+bool WesternBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings == 1 && blackKings == 1;
+}
+
 bool WesternBoard::kingCanCapture() const
 {
 	return true;
@@ -636,9 +641,9 @@ bool WesternBoard::vSetFenString(const QStringList& fen)
 			kingCount[tmp.side()]++;
 		}
 	}
-	if (kingCount[Side::White] != 1 || kingCount[Side::Black] != 1)
+	if (!kingsCountAssertion(kingCount[Side::White],
+				 kingCount[Side::Black]))
 		return false;
-
 	// Castling rights
 	m_castlingRights.rookSquare[Side::White][QueenSide] = 0;
 	m_castlingRights.rookSquare[Side::White][KingSide] = 0;
@@ -963,8 +968,13 @@ bool WesternBoard::inCheck(Side side, int square) const
 {
 	Side opSide = side.opposite();
 	if (square == 0)
+	{
 		square = m_kingSquare[side];
-	
+		// In the "horde" variant the horde side has no king
+		if (square == 0)
+			return false;
+	}
+
 	// Pawn attacks
 	int sign = (side == Side::White) ? 1 : -1;
 

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -101,7 +101,15 @@ class LIB_EXPORT WesternBoard : public Board
 		 * of the given \a type that are specified in pawnSteps.
 		 */
 		int pawnAmbiguity(StepType type = FreeStep) const;
-
+		/*!
+		 * Returns true if both counts of kings given by
+		 * \a whiteKings and \a blackKings are correct.
+		 * WesternBoard expects exactly one king per side.
+		 * \sa AntiBoard
+		 * \sa HordeBoard
+		 */
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
 		/*!
 		 * Returns true if the king can capture opposing pieces.
 		 * The default value is true.

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -370,6 +370,20 @@ void tst_Board::results_data() const
 		<< "3k2K1/8/3b4/8/8/8/8/8 w - - 1 1"
 		<< "1/2-1/2";
 
+	variant = "horde";
+
+	QTest::newRow("Horde black win")
+		<< variant
+		<< "8/8/4k3/8/8/8/8/8 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("Horde draw stalemate")
+		<< variant
+		<< "8/8/1k6/5p2/5P2/5P2/8/8 w - - 0 1"
+		<< "1/2-1/2";
+	QTest::newRow("Horde white win")
+		<< variant
+		<< "2k4R/R7/8/3PP3/8/8/8/8 b - - 0 1"
+		<< "1-0";
 }
 
 void tst_Board::results()
@@ -477,6 +491,23 @@ void tst_Board::perft_data() const
 		<< "8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"
 		<< 4  //4 plies: 296242, 5 plies: 9472927
 		<< Q_UINT64_C(296242);
+
+	variant = "horde";
+	QTest::newRow("horde v2 startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"
+		<< 6  //5 plies: 265223, 6 plies: 5396554
+		<< Q_UINT64_C(5396554);
+	QTest::newRow("horde dunsany startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP b kq - 0 1"
+		<< 5  //5 plies: 775839, 6 plies: 59231536
+		<< Q_UINT64_C(775839);
+	QTest::newRow("horde3")
+		<< variant
+		<< "rnbqkbnr/6p1/2p1Pp1P/P1PPPP2/Pp4PP/1p2PPPP/1P2PPPP/PP1nPPPP b kq a3 0 18"
+		<< 5  //4 plies: 197287, 5 plies: 6429490
+		<< Q_UINT64_C(6429490);
 
 }
 


### PR DESCRIPTION
This is a proposal to support the Horde Chess variant(s). Horde chess is a variant that is similar to Dunsany's chess of 1942. A standard chess set of pieces faces a horde of pawns. The pieces must eliminate all pawns to win. The pawns go to checkmate the opponent king. Standard rules apply,

This patch implements the modern variant with 36 white pawns (lichess.org, stockfish). It is quite general and can also be used with switched black/white setup (like older Horde variant). 

The version was tested using stockfish variant fork https://github.com/ddugovic/Stockfish.
I had to adapt the en passant rules to not accept e.p. on rank 2 but to allow double steps from rank 1 (matching perft of stockfish).

A change to WesternBoard makes the assertion of number of kings more flexible (the horde has no king).

I hope this is useful.