### PR TITLE
support for Three-Check Chess

### DIFF
--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -3,6 +3,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/westernboard.cpp \
     $$PWD/square.cpp \
     $$PWD/standardboard.cpp \
+    $$PWD/ncheckboard.cpp \
     $$PWD/berolinaboard.cpp \
     $$PWD/racingkingsboard.cpp \
     $$PWD/capablancaboard.cpp \
@@ -28,6 +29,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/westernboard.h \
     $$PWD/square.h \
     $$PWD/standardboard.h \
+    $$PWD/ncheckboard.h \
     $$PWD/berolinaboard.h \
     $$PWD/racingkingsboard.h \
     $$PWD/capablancaboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -27,10 +27,13 @@
 #include "standardboard.h"
 #include "berolinaboard.h"
 #include "kingofthehillboard.h"
+#include "ncheckboard.h"
 #include "racingkingsboard.h"
 
 namespace Chess {
 
+REGISTER_BOARD(ThreeCheckBoard, "3check")
+REGISTER_BOARD(FiveCheckBoard, "5check")
 REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")

--- a/projects/lib/src/board/ncheckboard.cpp
+++ b/projects/lib/src/board/ncheckboard.cpp
@@ -1,0 +1,193 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ncheckboard.h"
+
+
+namespace Chess {
+
+/*! Maximum feasible value \a maxNCheck for nth-check limit. */
+static const int maxNCheck = 99;
+
+NCheckBoard::NCheckBoard(int n)
+	: StandardBoard(),
+	  m_checkLimit(qBound(1, n, maxNCheck))
+{
+}
+
+Board* NCheckBoard::copy() const
+{
+	return new NCheckBoard(*this);
+}
+
+QString NCheckBoard::variant() const
+{
+	return QString("%1check").arg(checkLimit());
+}
+
+QString NCheckBoard::defaultFenString() const
+{
+	return QString("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - %1+%1 0 1")
+	.arg(checkLimit());
+}
+
+void NCheckBoard::vInitialize()
+{
+	m_checksToWin[Side::White] = m_checksToWin[Side::Black] = checkLimit();
+	StandardBoard::vInitialize();
+}
+
+void NCheckBoard::updateCheckCounters(Side side, int d = -1)
+{
+	Q_ASSERT(m_checksToWin[Side::White] >=0);
+	Q_ASSERT(m_checksToWin[Side::Black] >=0);
+	Q_ASSERT(side != Side::NoSide);
+
+	if (inCheck(side.opposite()))
+		m_checksToWin[side] += d;
+}
+
+void NCheckBoard::vMakeMove(const Move& move,
+			    BoardTransition* transition)
+{
+	StandardBoard::vMakeMove(move, transition);
+	// If opponent in check then decrease counter of this side
+	updateCheckCounters(sideToMove(), -1);
+}
+
+void NCheckBoard::vUndoMove(const Move& move)
+{
+	// If undoing checking move then increase counter of this side
+	updateCheckCounters(sideToMove(), +1);
+	StandardBoard::vUndoMove(move);
+}
+
+Result NCheckBoard::result()
+{
+	// Side wins if counter is zero
+	Side opp = sideToMove().opposite();
+	if (m_checksToWin[opp] == 0)
+		return Result(Result::Win, opp,
+			      tr("%1 checks %2 times")
+			      .arg(opp.toString()).arg(checkLimit()));
+
+	return StandardBoard::result();
+}
+
+inline int NCheckBoard::checkLimit() const
+{
+	return m_checkLimit;
+}
+
+void NCheckBoard::setChecksToWin(int whiteCount, int blackCount)
+{
+	m_checksToWin[Side::White] = qBound(0, whiteCount, checkLimit());
+	m_checksToWin[Side::Black] = qBound(0, blackCount, checkLimit());
+}
+
+int NCheckBoard::checksToWin(Side side) const
+{
+	if (side == Side::White)
+		return m_checksToWin[Side::White];
+	if (side == Side::Black)
+		return m_checksToWin[Side::Black];
+	return -1;
+}
+
+/*!
+ * A format to extend FEN for N-Check was suggested by H. G. Muller:
+ * The numbers of checks to win the game are given for both sides in succession
+ * of the the en passant field. They are separated by a single plus sign "+"
+ * (check symbol) without any other character in between (like 3+3).
+ * In contrast Lichess uses two plus signs and *forward counters* (like +0+0)
+ * appended to the normal FEN.
+ */
+QString NCheckBoard::vFenIncludeString(Board::FenNotation notation) const
+{
+	Q_UNUSED(notation);
+
+	QString fen = QString(" %1+%2")
+	.arg(m_checksToWin[Side::White])
+	.arg(m_checksToWin[Side::Black]);
+
+	return fen;
+}
+
+ /*!
+  * This method extracts check counters from extended FEN (like Xboard /
+  * Stockfish and Lichess formats) and is tolerant to standard FEN.
+  * If no counters can be extracted (e.g. from a standard FEN) the number of
+  * checks to win will be set to checkLimit.
+  * Calls StandardBoard method for FEN handling.
+  */
+bool NCheckBoard::vSetFenString(const QStringList& fen)
+{
+	if (fen.count() < 2)
+		return false;
+
+	// Make a copy to modify and to forward to parent's method
+	QStringList sfen(fen);
+
+	// Reset counters, do not rely on getting check counters from PGN
+	setChecksToWin(checkLimit(), checkLimit());
+	// Try to extract and remove the check count field
+	for (const QString& field: fen)
+	{
+		if (field.contains('+'))
+		{
+			int marker = field.lastIndexOf('+');
+			int counterW = field.left(marker).toInt();
+			int counterB = field.mid(marker+1).toInt();
+
+			if (counterW < 0 || counterW > maxNCheck
+			||  counterB < 0 || counterB > maxNCheck)
+				continue;
+
+			if (field.count('+') == 1)
+				// reverse counter style (like 3+3)
+				setChecksToWin(counterW, counterB);
+			else
+				// lichess style forward counter +0+0
+				setChecksToWin(checkLimit() - counterW,
+					       checkLimit() - counterB);
+			sfen.removeOne(field);
+			break;
+		}
+	}
+	// correction for FENs w/o check counters if king is in check
+	if (sfen == fen)
+		updateCheckCounters(sideToMove().opposite(), -1);
+
+	// Let StandardBoard do the rest
+	return StandardBoard::vSetFenString(sfen);
+}
+
+ThreeCheckBoard::ThreeCheckBoard() : NCheckBoard(3) {}
+
+Board * ThreeCheckBoard::copy() const
+{
+	return new ThreeCheckBoard(*this);
+}
+
+FiveCheckBoard::FiveCheckBoard() : NCheckBoard(5) {}
+
+Board * FiveCheckBoard::copy() const
+{
+	return new FiveCheckBoard(*this);
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/ncheckboard.h
+++ b/projects/lib/src/board/ncheckboard.h
@@ -1,0 +1,106 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NCHECKBOARD_H
+#define NCHECKBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for N-Check Chess
+ *
+ * N-Check chess is a variant of standard chess with an additional rule.
+ * A player also wins when he gives check n times in a game.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Three-check_chess
+ *
+ * NCheckBoard uses Polyglot-compatible zobrist position keys,
+ * so N-Check opening books in Polyglot format could be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT NCheckBoard : public StandardBoard
+{
+	protected:
+		/*!
+		 * Creates a new NCheckBoard object.
+		 * Giving the \a n -th check wins.
+		 * Defaults to Three-Check (variant: 3Check)
+		 */
+		NCheckBoard(int n = 3);
+	public:
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+		/*! Returns number of checks yet needed for \a side to win */
+		int checksToWin(Side side) const;
+
+	protected:
+		// Inherited from StandardBoard
+		virtual void vInitialize();
+		virtual QString vFenIncludeString(FenNotation notation) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+
+		/*! Returns total number of checks necessary to win */
+		int checkLimit() const;
+
+	private:
+		int m_checkLimit;
+		int m_checksToWin[2];
+		void setChecksToWin(int whiteCount, int blackCount);
+		void updateCheckCounters(Side side, int d);
+};
+
+/*!
+ * \brief A board for Three-Check Chess (Wild 25)
+ *
+ * Three-Check chess is a variant of standard chess with an additional rule.
+ * A player also wins when he gives check three times in a game.
+ * This is a trivial subclass of NCheckboard (variant: 3Check)
+ */
+class LIB_EXPORT ThreeCheckBoard : public NCheckBoard
+{
+	public:
+		ThreeCheckBoard();
+		virtual Board* copy() const;
+};
+
+/*!
+ * \brief A board for Five-Check Chess
+ *
+ * Five-Check chess is a variant of standard chess with an additional rule.
+ * A player also wins when he gives check five times in a game.
+ * This is a trivial subclass of NCheckboard (variant: 5Check)
+ */
+class LIB_EXPORT FiveCheckBoard : public NCheckBoard
+{
+	public:
+		FiveCheckBoard();
+		virtual Board* copy() const;
+};
+
+} // namespace Chess
+#endif // NCHECKBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -531,6 +531,12 @@ int WesternBoard::pawnAmbiguity(StepType t) const
 	return count;
 }
 
+QString WesternBoard::vFenIncludeString(FenNotation notation) const
+{
+	Q_UNUSED(notation);
+	return "";
+}
+
 QString WesternBoard::vFenString(FenNotation notation) const
 {
 	// Castling rights
@@ -542,6 +548,8 @@ QString WesternBoard::vFenString(FenNotation notation) const
 		//TODO:  HOW to achieve Berolina disambiguation?
 	else
 		fen += '-';
+
+	fen +=vFenIncludeString(notation);
 
 	// Reversible halfmove count
 	fen += ' ';

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -153,6 +153,15 @@ class LIB_EXPORT WesternBoard : public Board
 		 */
 		virtual bool inCheck(Side side, int square = 0) const;
 
+		/*!
+		 * Returns FEN extensions. The default is an empty string.
+		 *
+		 * This function is called by fenString() via vFenString().
+		 * Returns additional parts of the current position's (extended)
+		 * FEN string which succeed the en passant field.
+		 */
+		virtual QString vFenIncludeString(FenNotation notation) const;
+
 		// Inherited from Board
 		virtual void vInitialize();
 		virtual QString vFenString(FenNotation notation) const;

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -248,6 +248,16 @@ void tst_Board::moveStrings_data() const
 		<< "Qd4"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
 		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+	QTest::newRow("3check san1")
+		<< "3check"
+		<< "e4 e5 Nf3 Nc6 d4 exd4"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
+		<< "r1bqkbnr/pppp1ppp/2n5/8/3pP3/5N2/PPP2PPP/RNBQKB1R w KQkq - 3+3 0 4";
+	QTest::newRow("3check san2")
+		<< "3check"
+		<< "e4 e5 Nf3 d6 Bb5+ c6 Bxc6+"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
+		<< "rnbqkbnr/pp3ppp/2Bp4/4p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1+3 0 4";
 }
 
 void tst_Board::moveStrings()


### PR DESCRIPTION
This patch adds support for Three-Check (actually N-Check) Chess.
Giving Check n times is an additional way to win a chess game.

Variant `3check` was tested manually and also using PyChess, Sjaak II and the Stockfish fork (https://github.com/ddugovic/Stockfish). For my tests I patched stockfish for that variant string, it normally uses `threecheck`).

This version can read various FEN formats, including standard chess FEN and extended FENs from lichess.org with check counters appended to the FEN (like <fen> +0+0) as well as a format suggested by H. G. Muller and implemented into Stockfish. The latter uses backward counters like <fen up to e. p. field> 3+3 <rest of fen string> and only one plus sign.  The writing format yet has to be determined. Currently reverse counters are appended to the fen: <fen> 3+3.

I hope this is useful.