### PR TITLE
flip board for gauntlet player 0 with black pieces

### DIFF
--- a/projects/gui/src/gamewall.cpp
+++ b/projects/gui/src/gamewall.cpp
@@ -122,6 +122,17 @@ void GameWallWidget::setGame(ChessGame* game)
 	m_scene->setBoard(game->pgn()->createBoard());
 	m_scene->populate();
 
+	// flip scene if human plays black and engine plays white
+	// also flip scene if player 0 of a gauntlet plays black
+	const Tournament *t = game->tournament();
+	bool gPlayer0Black = t
+			  && t->type() == "gauntlet"
+			  && t->playerIndex(game, Chess::Side::Black) == 0;
+
+	if ((m_players[Chess::Side::Black]->isHuman() || gPlayer0Black)
+	&&  !m_players[Chess::Side::White]->isHuman())
+		m_scene->flip();
+
 	foreach (const Chess::Move& move, game->moves())
 		m_scene->makeMove(move);
 

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -565,7 +565,14 @@ void MainWindow::setCurrentGame(const TabData& gameData)
 	}
 
 	// if a human plays the black side against an engine then flip the board
-	if (m_players[Chess::Side::Black]->isHuman() && !m_players[Chess::Side::White]->isHuman())
+	// also flip the board if gauntlet player 0 has black pieces
+	const Tournament* t = m_game->tournament();
+	bool gPlayer0Black = t
+			  && t->type() == "gauntlet"
+			  && t->playerIndex(m_game, Chess::Side::Black) == 0;
+
+	if (!m_players[Chess::Side::White]->isHuman()
+	&& ( m_players[Chess::Side::Black]->isHuman() || gPlayer0Black ))
 		m_gameViewer->boardScene()->flip();
 
 	updateWindowTitle();

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -71,7 +71,10 @@ QString evalString(const MoveEvaluation& eval)
 
 } // anonymous namespace
 
-ChessGame::ChessGame(Chess::Board* board, PgnGame* pgn, QObject* parent)
+ChessGame::ChessGame(Chess::Board* board,
+		     PgnGame* pgn,
+		     QObject* parent,
+		     const Tournament* tournament)
 	: QObject(parent),
 	  m_board(board),
 	  m_startDelay(0),
@@ -80,10 +83,10 @@ ChessGame::ChessGame(Chess::Board* board, PgnGame* pgn, QObject* parent)
 	  m_paused(false),
 	  m_pgnInitialized(false),
 	  m_bookOwnership(false),
-	  m_pgn(pgn)
+	  m_pgn(pgn),
+	  m_tournament(tournament)
 {
 	Q_ASSERT(pgn != nullptr);
-
 	for (int i = 0; i < 2; i++)
 	{
 		m_player[i] = nullptr;
@@ -148,6 +151,11 @@ const QMap<int,int>& ChessGame::scores() const
 Chess::Result ChessGame::result() const
 {
 	return m_result;
+}
+
+const Tournament* ChessGame::tournament() const
+{
+	return m_tournament;
 }
 
 ChessPlayer* ChessGame::playerToMove() const

--- a/projects/lib/src/chessgame.h
+++ b/projects/lib/src/chessgame.h
@@ -28,6 +28,7 @@
 #include "board/move.h"
 #include "timecontrol.h"
 #include "gameadjudicator.h"
+#include "tournament.h"
 
 namespace Chess { class Board; }
 class ChessPlayer;
@@ -40,7 +41,10 @@ class LIB_EXPORT ChessGame : public QObject
 	Q_OBJECT
 
 	public:
-		ChessGame(Chess::Board* board, PgnGame* pgn, QObject* parent = nullptr);
+		ChessGame(Chess::Board* board,
+			  PgnGame* pgn,
+			  QObject* parent = nullptr,
+			  const Tournament* tournament = nullptr);
 		virtual ~ChessGame();
 		
 		QString errorString() const;
@@ -74,6 +78,7 @@ class LIB_EXPORT ChessGame : public QObject
 
 		void lockThread();
 		void unlockThread();
+		const Tournament* tournament() const;
 
 	public slots:
 		void start();
@@ -137,6 +142,7 @@ class LIB_EXPORT ChessGame : public QObject
 		QSemaphore m_pauseSem;
 		QSemaphore m_resumeSem;
 		GameAdjudicator m_adjudicator;
+		const Tournament* m_tournament;
 };
 
 #endif // CHESSGAME_H

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -147,6 +147,15 @@ int Tournament::playerCount() const
 	return m_players.size();
 }
 
+int Tournament::playerIndex(ChessGame* game, Chess::Side side) const
+{
+	if (side.isNull() || !m_gameData.contains(game))
+		return -1;
+
+	const GameData* gd = m_gameData[game];
+	return side == Chess::Side::White ? gd->whiteIndex : gd->blackIndex;
+}
+
 int Tournament::seedCount() const
 {
 	return m_seedCount;
@@ -318,7 +327,7 @@ void Tournament::startGame(TournamentPair* pair)
 
 	Chess::Board* board = Chess::BoardFactory::create(m_variant);
 	Q_ASSERT(board != nullptr);
-	ChessGame* game = new ChessGame(board, new PgnGame());
+	ChessGame* game = new ChessGame(board, new PgnGame(), nullptr, this);
 
 	connect(game, SIGNAL(started(ChessGame*)),
 		this, SLOT(onGameStarted(ChessGame*)));

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -106,6 +106,11 @@ class LIB_EXPORT Tournament : public QObject
 		/*! Returns the number of participants in the tournament. */
 		int playerCount() const;
 		/*!
+		 * Returns the index of the player in \a game with given
+		 * \a side. Returns -1 if invalid.
+		 */
+		int playerIndex(ChessGame* game, Chess::Side side) const;
+		/*!
 		 * Returns the maximum number of players that can be seeded
 		 * in the tournament.
 		 */


### PR DESCRIPTION
Following a gauntlet is easier if seen from the gauntlet player's side (here engine with index 0).
As requested in #148 .