### PR TITLE
Berolina FEN ep extension

### DIFF
--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -242,7 +242,7 @@ void tst_Board::moveStrings_data() const
 		<< "berolina"
 		<< "e2c4 b8c6 c4d5 e7c5"
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-		<< "r1bqkbnr/pppp1ppp/2n5/2pP4/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3";
+		<< "r1bqkbnr/pppp1ppp/2n5/2pP4/8/8/PPPP1PPP/RNBQKBNR w KQkq d6c5 0 3";
 	QTest::newRow("berolina san2")
 		<< "berolina"
 		<< "Qd4"


### PR DESCRIPTION
This patch adds a FEN extension for variants with ambiguous en-passant cases.
The en-passant field comprises of ep square (destination square of capture move) and ep target (square of capture victim) like `d6e5`. 
This format was introduced by H. G. Muller and implemented into xboard (development version > 4.9.1).
