### PR TITLE
only protect a tournament game tab if the corresponding game is active

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -610,7 +610,9 @@ void MainWindow::onTabChanged(int index)
 
 void MainWindow::onTabCloseRequested(int index)
 {
-	if (m_tabs.at(index).tournament)
+	const TabData& tab = m_tabs.at(index);
+
+	if (tab.tournament && tab.game)
 	{
 		auto btn = QMessageBox::question(this, tr("End tournament game"),
 			   tr("Do you really want to end the active tournament game?"));


### PR DESCRIPTION
At the end of a tournament tab message box and results window have a tendency to get into each other's way.

So I suggest to only protect a tourney game tab if the corresponding game is active. I made some malicious tests already (for running games, close while waiting between games, before and after tournament finished, also with different delays of confirmation). #157