### PR TITLE
support Loop Chess and Chessgi

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -47,8 +47,10 @@ Berolina Chess
 Capablanca Chess
 .It caparandom
 Capablanca Random Chess
+.It chessgi
+Chessgi / Drop Chess
 .It crazyhouse
-Crazyhouse / Drop Chess
+Crazyhouse (Drop Chess Variant)
 .It fischerandom
 Fischer Random Chess / Chess 960
 .It gothic
@@ -57,6 +59,8 @@ Gothic Chess
 Horde Chess (v2)
 .It kingofthehill
 King of the Hill Chess
+.It loop
+Loop Chess (Drop Chess Variant)
 .It losers
 Loser's Chess
 .It racingkings

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -16,11 +16,13 @@ Options:
 			'berolina': Berolina Chess
 			'capablanca': Capablanca Chess
 			'caparandom': Capablanca Random Chess
-			'crazyhouse': Crazyhouse/Drop Chess
+			'chessgi': Chessgi (Drop Chess)
+			'crazyhouse': Crazyhouse (Drop Chess)
 			'fischerandom': Fischer Random Chess/Chess 960
 			'gothic': Gothic Chess
 			'horde': Horde Chess (v2)
 			'kingofthehill': King of the Hill Chess
+			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
 			'racingkings': Racing Kings Chess
 			'standard': Standard Chess (default).

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -20,6 +20,8 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/losersboard.cpp \
     $$PWD/gothicboard.cpp \
     $$PWD/crazyhouseboard.cpp \
+    $$PWD/loopboard.cpp \
+    $$PWD/chessgiboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -46,6 +48,8 @@ HEADERS += $$PWD/board.h \
     $$PWD/losersboard.h \
     $$PWD/gothicboard.h \
     $$PWD/crazyhouseboard.h \
+    $$PWD/loopboard.h \
+    $$PWD/chessgiboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -26,7 +26,9 @@
 #include "losersboard.h"
 #include "standardboard.h"
 #include "berolinaboard.h"
+#include "chessgiboard.h"
 #include "kingofthehillboard.h"
+#include "loopboard.h"
 #include "ncheckboard.h"
 #include "racingkingsboard.h"
 
@@ -38,11 +40,13 @@ REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
+REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
+REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(StandardBoard, "standard")

--- a/projects/lib/src/board/chessgiboard.cpp
+++ b/projects/lib/src/board/chessgiboard.cpp
@@ -1,0 +1,44 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chessgiboard.h"
+
+namespace Chess {
+
+ChessgiBoard::ChessgiBoard()
+	: LoopBoard()
+{
+}
+
+Board* ChessgiBoard::copy() const
+{
+	return new ChessgiBoard(*this);
+}
+
+QString ChessgiBoard::variant() const
+{
+	return "chessgi";
+}
+
+bool ChessgiBoard::pawnDropOkOnRank(int rank) const
+{
+	if (sideToMove() == Side::Black)
+		rank--;
+	return rank >= 0 && rank < height() - 1;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/chessgiboard.h
+++ b/projects/lib/src/board/chessgiboard.h
@@ -1,0 +1,56 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHESSGIBOARD_H
+#define CHESSGIBOARD_H
+
+#include "loopboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Chessgi
+ *
+ * Chessgi differs from Loop Chess only in one rule: a side may
+ * also drop pawns onto their first rank. The name Chessgi was
+ * introduced by Ralph Betza in order to stress its similarities
+ * to both Chess and Shogi. Alias names are Drop Chess, Mad Mate,
+ * Neo-Chess, among others.
+ *
+ * \sa LoopBoard
+ * \sa CrazyhouseBoard
+ *
+ * \note Rules: http://www.chessvariants.com/other.dir/chessgi.html
+ *
+ */
+class LIB_EXPORT ChessgiBoard : public LoopBoard
+{
+	public:
+		/*! Creates a new ChessgiBoard object. */
+		ChessgiBoard();
+
+		// Inherited from LoopBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		// Inherited from LoopBoard (override)
+		virtual bool pawnDropOkOnRank(int rank) const;
+};
+
+} // namespace Chess
+#endif // CHESSGIBOARD_H

--- a/projects/lib/src/board/crazyhouseboard.cpp
+++ b/projects/lib/src/board/crazyhouseboard.cpp
@@ -211,6 +211,11 @@ void CrazyhouseBoard::vUndoMove(const Move& move)
 		addToReserve(Piece(sideToMove(), prom));
 }
 
+bool CrazyhouseBoard::pawnDropOkOnRank(int rank) const
+{
+	return rank > 0 && rank < height() - 1;
+}
+
 void CrazyhouseBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
 					    int pieceType,
 					    int square) const
@@ -219,7 +224,6 @@ void CrazyhouseBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
 	if (square == 0)
 	{
 		const int size = arraySize();
-		const int maxRank = height() - 2;
 		for (int i = 0; i < size; i++)
 		{
 			Piece tmp = pieceAt(i);
@@ -228,10 +232,9 @@ void CrazyhouseBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
 			if (pieceType == Pawn)
 			{
 				Square sq(chessSquare(i));
-				if (sq.rank() < 1 || sq.rank() > maxRank)
+				if (!pawnDropOkOnRank(sq.rank()))
 					continue;
 			}
-
 			moves.append(Move(0, i, pieceType));
 		}
 	}

--- a/projects/lib/src/board/crazyhouseboard.h
+++ b/projects/lib/src/board/crazyhouseboard.h
@@ -59,6 +59,14 @@ class LIB_EXPORT CrazyhouseBoard : public WesternBoard
 			PromotedQueen,		//!< Promoted Queen
 		};
 
+		/*!
+		 * Returns promoted piece type corresponding to normal \a type.
+		 */
+		virtual int promotedPieceType(int type);
+		/*!
+		 * Asserts side to move may drop pawns on given \a rank.
+		 */
+		virtual bool pawnDropOkOnRank(int rank) const;
 		// Inherited from WesternBoard
 		virtual int reserveType(int pieceType) const;
 		virtual QString sanMoveString(const Move& move);
@@ -72,7 +80,6 @@ class LIB_EXPORT CrazyhouseBoard : public WesternBoard
 
 	private:
 		static int normalPieceType(int type);
-		static int promotedPieceType(int type);
 		void normalizePieces(Piece piece, QVarLengthArray<int>& squares);
 		void restorePieces(Piece piece, const QVarLengthArray<int>& squares);
 };

--- a/projects/lib/src/board/loopboard.cpp
+++ b/projects/lib/src/board/loopboard.cpp
@@ -1,0 +1,47 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "loopboard.h"
+
+namespace Chess {
+
+LoopBoard::LoopBoard()
+	: CrazyhouseBoard()
+{
+}
+
+Board* LoopBoard::copy() const
+{
+	return new LoopBoard(*this);
+}
+
+QString LoopBoard::variant() const
+{
+	return "loop";
+}
+
+QString LoopBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[-] w KQkq - 0 1";
+}
+
+int LoopBoard::promotedPieceType(int type) const
+{
+	return type;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/loopboard.h
+++ b/projects/lib/src/board/loopboard.h
@@ -1,0 +1,56 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LOOPBOARD_H
+#define LOOPBOARD_H
+
+#include "crazyhouseboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Loop Chess
+ *
+ * Loop Chess is a variant of standard chess where captured
+ * pieces can be brought back ("dropped") into the game by
+ * the capturing side, similar to Shogi and Crazyhouse.
+ * Promoted pieces keep their ranks when captured. Pawns must
+ * not be dropped on the first and the eighth rank.
+ *
+ * \sa CrazyhouseBoard
+ * \sa ChessgiBoard
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Crazyhouse#Variations
+ */
+class LIB_EXPORT LoopBoard : public CrazyhouseBoard
+{
+	public:
+		/*! Creates a new LoopBoard object. */
+		LoopBoard();
+
+		// Inherited from CrazyhouseBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from CrazyhouseBoard
+		virtual int promotedPieceType(int type) const;
+};
+
+} // namespace Chess
+#endif // LOOPBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -483,6 +483,31 @@ void tst_Board::perft_data() const
 		<< 5
 		<< Q_UINT64_C(4888832);
 
+	variant = "loop";
+	QTest::newRow("loop startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[-] w KQkq - 0 1"
+		<< 5  //4 plies: 197281, 5 plies: 4888832
+		<< Q_UINT64_C(4888832);
+	QTest::newRow("loop2")
+		<< variant
+		<< "5R2/2p1Nb2/2B4k/6p1/8/P3PP2/1PPqR3/3R1BKn[QBNPPPPrrrnppp] b - - 1 1"
+		<< 3 // 1 ply:157, 2 plies: 31983, 3 plies: 4144334
+		<< Q_UINT64_C(4144334);
+
+	variant = "chessgi";
+	QTest::newRow("chessgi startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[-] w KQkq - 0 1"
+		<< 5  //4 plies: 197281, 5 plies: 4889167
+		<< Q_UINT64_C(4889167);
+	QTest::newRow("chessgi2")
+		<< variant
+		<< "5Rp1/2p1Nb2/2B4k/6p1/8/P3PP2/1PPqR3/3R1BKn[QBNPPPPrrrnpp] b - - 1 48"
+		<< 3 // 1 ply:162, 2 plies: 33032, 3 plies: 4493963
+		<< Q_UINT64_C(4493963);
+		// TBD sjaakii (/wo dbl steps from first rank) 1 ply:161, 2 plies: 32816, 3 plies: 4434101
+
 	variant = "berolina";
 	QTest::newRow("berolina startpos")
 		<< variant
@@ -518,7 +543,6 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/6p1/2p1Pp1P/P1PPPP2/Pp4PP/1p2PPPP/1P2PPPP/PP1nPPPP b kq a3 0 18"
 		<< 5  //4 plies: 197287, 5 plies: 6429490
 		<< Q_UINT64_C(6429490);
-
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a proposal to support the _Loop Chess_ and _Chessgi_ variants. Loop Chess is a variant that is similar to _Crazyhouse_. Captured pieces change sides and can be dropped onto empty squares later. In contrast to Crazyhouse, promoted pawns keep their piece rank when captured in Loop Chess. 

The implementation uses `CrazyhouseBoard`, which is modified to allow overriding promoted piece types. I tested with recent Stockfish multivariant versions and with TJchess 1.3.

Chessgi differs from Loop Chess only in drop rule for pawns: Chessgi allows to drop pawns on a side's own first rank.

The implementation of `ChessgiBoard` relies on `LoopBoard`. Tests were done with Sjaak II versions 1.3.1a and 1.4.1. Currently cutechess allows double steps from first rank and second rank, Sjaak II only from second rank (perhaps this can be made selectable in WesternBoard in the future).

I hope this is useful.