### PR TITLE
support Losing Chess (Antichess, Giveaway, Suicide)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -43,6 +43,8 @@ Five-check Chess
 Andernach Chess
 .It antiandernach
 Anti-Andernach Chess
+.It antichess
+Antichess / Losing Chess
 .It atomic
 Atomic Chess
 .It berolina
@@ -61,6 +63,8 @@ Crazyhouse (Drop Chess Variant)
 Extinction Chess
 .It fischerandom
 Fischer Random Chess / Chess 960
+.It giveaway
+Giveaway Chess (Losing Chess)
 .It gothic
 Gothic Chess
 .It horde
@@ -79,6 +83,8 @@ Loop Chess (Drop Chess Variant)
 Loser's Chess
 .It racingkings
 Racing Kings Chess
+.It suicide
+Suicide Chess (Losing Chess Variant)
 .It superandernach
 Super-Andernach Chess
 .It standard

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -14,6 +14,7 @@ Options:
 			'5check': Five-check Chess
 			'andernach': Andernach Chess
 			'antiandernach': Anti-Andernach Chess
+			'antichess': Antichess (Losing Chess)
 			'atomic': Atomic Chess
 			'berolina': Berolina Chess
 			'capablanca': Capablanca Chess
@@ -23,6 +24,7 @@ Options:
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'extinction': Extinction Chess
 			'fischerandom': Fischer Random Chess/Chess 960
+			'giveaway': Giveaway Chess (Losing Chess)
 			'gothic': Gothic Chess
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
@@ -34,6 +36,7 @@ Options:
 			'racingkings': Racing Kings Chess
 			'superandernach': Super-Andernach Chess
 			'standard': Standard Chess (default).
+			'suicide': Suicide Chess (Losing Chess)
   -concurrency N	Set the maximum number of concurrent games to N
   -draw movenumber=NUMBER movecount=COUNT score=SCORE
 			Adjudicate the game as a draw if the score of both

--- a/projects/lib/src/board/antiboard.cpp
+++ b/projects/lib/src/board/antiboard.cpp
@@ -1,0 +1,140 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "antiboard.h"
+
+namespace Chess {
+
+AntiBoard::AntiBoard()
+	: StandardBoard(),
+	m_testKey(0),
+	m_canCapture(false)
+{
+}
+
+Board* AntiBoard::copy() const
+{
+	return new AntiBoard(*this);
+}
+
+QString AntiBoard::variant() const
+{
+	return "antichess";
+}
+
+QString AntiBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+}
+
+bool AntiBoard::hasCastling() const
+{
+	return false;
+}
+
+bool AntiBoard::kingsCountAssertion( int whiteKings,
+				     int blackKings) const
+{
+	/*
+	 * Kings can be captured and pawns can promote to kings.
+	 */
+	return whiteKings + blackKings >= 0;
+}
+
+void AntiBoard::addPromotions(int sourceSquare,
+				int targetSquare,
+				QVarLengthArray<Move>& moves) const
+{
+	StandardBoard::addPromotions(sourceSquare, targetSquare, moves);
+	moves.append(Move(sourceSquare, targetSquare, King));
+}
+
+bool AntiBoard::vSetFenString(const QStringList& fen)
+{
+	m_canCapture = false;
+	m_testKey = 0;
+	return StandardBoard::vSetFenString(fen);
+}
+
+bool AntiBoard::inCheck(Side, int) const
+{
+	return false;
+}
+
+bool AntiBoard::vIsLegalMove(const Move& move)
+{
+	if (!StandardBoard::vIsLegalMove(move))
+		return false;
+
+	if (captureType(move) != Piece::NoPiece)
+		return true;
+
+	//try to use old results to gain higher efficiency
+	if (key() != m_testKey)
+	{
+		m_testKey = key();
+		m_canCapture = false;
+		QVarLengthArray<Move> moves;
+		generateMoves(moves);
+
+		// search for any legal capture move
+		for (int i = 0; i < moves.size(); i++)
+		{
+			if (captureType(moves[i]) != Piece::NoPiece
+			&&  StandardBoard::vIsLegalMove(moves[i]))
+			{
+				m_canCapture = true;
+				break;
+			}
+		}
+	}
+	// move is illegal if a capture move exists else legal
+	return !m_canCapture;
+}
+
+Result AntiBoard::vResultOfStalemate() const
+{
+	Side winner = sideToMove();
+	QString str { tr("%1 wins").arg(winner.toString()) };
+	return Result(Result::Win, winner, str);
+}
+
+Result AntiBoard::result()
+{
+	QString str;
+	// stalemate or no pieces left
+	if (!canMove())
+		return vResultOfStalemate();
+
+	// 50 move rule
+	if (reversibleMoveCount() >= 100)
+	{
+		str = tr("Draw by fifty moves rule");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+	{
+		str = tr("Draw by 3-fold repetition");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/antiboard.h
+++ b/projects/lib/src/board/antiboard.h
@@ -1,0 +1,84 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ANTIBOARD_H
+#define ANTIBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Losing Chess, LC1 (main variant, international rules)
+ * a.k.a Antichess
+ *
+ * Losing Chess is a variant of standard chess but has a different aim.
+ *
+ * The side that has no legal moves wins, either by losing all pieces or
+ * by being stalemated.
+ *
+ * The king has no royal powers, so there is no check and the king can be
+ * captured. Pawns can also promote to king. Castling is not allowed.
+ * If a side can capture then they must make a capture move.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Losing_chess#Rules_.28main_variant.29
+ *
+ * Losing Chess is believed to be several centuries old.
+ * Giveaway Chess and Suicide Chess are variants of Losing Chess.
+ * \sa GiveawayBoard
+ * \sa SuicideBoard
+ *
+ * AntiBoard uses Polyglot-compatible zobrist position keys,
+ * so adequate opening books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT AntiBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new AntiBoard object. */
+		AntiBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		// Inherited from StandardBoard
+		virtual bool hasCastling() const;
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual bool vIsLegalMove(const Move& move);
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+
+		/*! Rules stalemate outcome. */
+		virtual Result vResultOfStalemate() const;
+
+	private:
+		quint64 m_testKey;
+		bool m_canCapture;
+}; // namespace Chess
+
+}
+#endif // ANTIBOARD_H

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -23,6 +23,9 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/atomicboard.cpp \
     $$PWD/losersboard.cpp \
     $$PWD/checklessboard.cpp \
+    $$PWD/antiboard.cpp \
+    $$PWD/giveawayboard.cpp \
+    $$PWD/suicideboard.cpp \
     $$PWD/gothicboard.cpp \
     $$PWD/crazyhouseboard.cpp \
     $$PWD/loopboard.cpp \
@@ -56,6 +59,9 @@ HEADERS += $$PWD/board.h \
     $$PWD/atomicboard.h \
     $$PWD/losersboard.h \
     $$PWD/checklessboard.h \
+    $$PWD/antiboard.h \
+    $$PWD/giveawayboard.h \
+    $$PWD/suicideboard.h \
     $$PWD/gothicboard.h \
     $$PWD/crazyhouseboard.h \
     $$PWD/loopboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -17,13 +17,16 @@
 
 #include "boardfactory.h"
 #include "andernachboard.h"
+#include "antiboard.h"
 #include "atomicboard.h"
+#include "berolinaboard.h"
 #include "capablancaboard.h"
 #include "caparandomboard.h"
 #include "checklessboard.h"
 #include "crazyhouseboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
+#include "giveawayboard.h"
 #include "gothicboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
@@ -35,7 +38,10 @@
 #include "knightmateboard.h"
 #include "loopboard.h"
 #include "ncheckboard.h"
+#include "losersboard.h"
 #include "racingkingsboard.h"
+#include "standardboard.h"
+#include "suicideboard.h"
 
 namespace Chess {
 
@@ -43,6 +49,7 @@ REGISTER_BOARD(ThreeCheckBoard, "3check")
 REGISTER_BOARD(FiveCheckBoard, "5check")
 REGISTER_BOARD(AndernachBoard, "andernach")
 REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
+REGISTER_BOARD(AntiBoard, "antichess")
 REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
@@ -53,6 +60,7 @@ REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(ExtinctionBoard, "extinction")
 REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")
+REGISTER_BOARD(GiveawayBoard, "giveaway")
 REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
@@ -62,6 +70,7 @@ REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(StandardBoard, "standard")
+REGISTER_BOARD(SuicideBoard, "suicide")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")
 
 

--- a/projects/lib/src/board/giveawayboard.cpp
+++ b/projects/lib/src/board/giveawayboard.cpp
@@ -1,0 +1,47 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "giveawayboard.h"
+
+namespace Chess {
+
+GiveawayBoard::GiveawayBoard()
+	: AntiBoard()
+{
+}
+
+Board* GiveawayBoard::copy() const
+{
+	return new GiveawayBoard(*this);
+}
+
+QString GiveawayBoard::variant() const
+{
+	return "giveaway";
+}
+
+QString GiveawayBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool GiveawayBoard::hasCastling() const
+{
+	return true;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/giveawayboard.h
+++ b/projects/lib/src/board/giveawayboard.h
@@ -1,0 +1,64 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GIVEAWAYBOARD_H
+#define GIVEAWAYBOARD_H
+
+#include "antiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Giveaway Chess, a Losing Chess variant (ICC wild 26)
+ *
+ * The side that has no legal moves wins, either by losing all pieces or
+ * by being stalemated.
+ *
+ * The king has no royal powers, so there is no check and the king can be
+ * captured. Pawns can also promote to king. Castling is allowed.
+ * If a side can capture then they must make a capture move.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Losing_chess
+ *
+ * \sa AntiBoard
+ * \sa SuicideBoard
+ *
+ * GiveawayBoard uses Polyglot-compatible zobrist position keys,
+ * so adequate opening books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT GiveawayBoard : public AntiBoard
+{
+	public:
+		/*! Creates a new GiveawayBoard object. */
+		GiveawayBoard();
+
+		// Inherited from AntiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from AntiBoard
+		virtual bool hasCastling() const;
+
+}; // namespace Chess
+
+}
+#endif // GIVEAWAYBOARD_H

--- a/projects/lib/src/board/suicideboard.cpp
+++ b/projects/lib/src/board/suicideboard.cpp
@@ -1,0 +1,63 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "suicideboard.h"
+
+namespace Chess {
+
+SuicideBoard::SuicideBoard()
+	: AntiBoard()
+{
+}
+
+Board* SuicideBoard::copy() const
+{
+	return new SuicideBoard(*this);
+}
+
+QString SuicideBoard::variant() const
+{
+	return "suicide";
+}
+
+Result SuicideBoard::vResultOfStalemate() const
+{
+	int pcwhite = pieceCount(Side::White);
+	int pcblack = pieceCount(Side::Black);
+
+	if (pcwhite == pcblack)
+		return Result(Result::Draw, Side::NoSide, tr("Draw"));
+
+	Side winner = pcwhite < pcblack ? Side::White : Side::Black;
+	QString str { tr("%1 wins").arg(winner.toString()) };
+
+	return Result(Result::Win, winner, str);
+}
+
+int SuicideBoard::pieceCount(Side side, int ptype) const
+{
+	int count = 0;
+	for (int i = 0; i < arraySize(); i++)
+	{
+		if ((ptype == Piece::NoPiece || ptype == pieceAt(i).type())
+	        &&  (side == Side::NoSide || side == pieceAt(i).side()))
+			++count;
+	}
+	return count;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/suicideboard.h
+++ b/projects/lib/src/board/suicideboard.h
@@ -1,0 +1,69 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SUICIDEBOARD_H
+#define SUICIDEBOARD_H
+
+#include "antiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Suicide Chess, a Losing Chess variant
+ *
+ * Suicide Chess is a variant of Losing Chess (FICS Suicide).
+ *
+ * The king has no royal powers, so there is no check and the king can be
+ * captured. Pawns can also promote to king. Castling is not allowed.
+ * If a side can capture then they must make a capture move.
+ *
+ * The side that has lost all pieces wins. If a side cannot move (stalemate)
+ * then the side with less pieces wins and else the game is drawn.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Losing_chess
+ *
+ * \sa AntiBoard
+ * \sa GiveawayBoard
+ *
+ * SuicideBoard uses Polyglot-compatible zobrist position keys,
+ * so adequate opening books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ */
+class LIB_EXPORT SuicideBoard : public AntiBoard
+{
+	public:
+		/*! Creates a new SuicideBoard object. */
+		SuicideBoard();
+
+		// Inherited from AntiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		// Inherited from AntiBoard
+		virtual Result vResultOfStalemate() const;
+
+	private:
+		int pieceCount(Side side,
+			       int ptype = Piece::NoPiece) const;
+
+}; // namespace Chess
+
+}
+#endif // SUICIDEBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -771,16 +771,29 @@ void WesternBoard::setCastlingSquare(Side side,
 void WesternBoard::removeCastlingRights(int square)
 {
 	Piece piece = pieceAt(square);
-	if (piece.type() != Rook)
+	int type = piece.type();
+
+	if (type != Rook && type != King)
 		return;
 
 	Side side(piece.side());
 	const int* cr = m_castlingRights.rookSquare[side];
 
-	if (square == cr[QueenSide])
-		setCastlingSquare(side, QueenSide, 0);
-	else if (square == cr[KingSide])
-		setCastlingSquare(side, KingSide, 0);
+	if (type == Rook)
+	{
+		if (square == cr[QueenSide])
+			setCastlingSquare(side, QueenSide, 0);
+		else if (square == cr[KingSide])
+			setCastlingSquare(side, KingSide, 0);
+	}
+	// variants: remove castling rights if King is captured on base rank
+	else if (type == King)
+	{
+		if (square - cr[QueenSide] < width())
+			setCastlingSquare(side, QueenSide, 0);
+		if (cr[KingSide] - square < width())
+			setCastlingSquare(side, KingSide, 0);
+	}
 }
 
 int WesternBoard::castlingFile(CastlingSide castlingSide) const

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -125,6 +125,7 @@ void UciEngine::sendPosition()
 void UciEngine::startGame()
 {
 	Q_ASSERT(supportsVariant(board()->variant()));
+	const QList<QString> directPvList = {"giveaway", "suicide", "antichess"};
 
 	m_ignoreThinking = false;
 	m_rePing = false;
@@ -135,6 +136,7 @@ void UciEngine::startGame()
 	m_ponderHits = 0;
 	m_bmBuffer.clear();
 	m_moveStrings.clear();
+	m_useDirectPv = directPvList.contains(board()->variant());
 
 	if (board()->isRandomVariant())
 		m_startFen = board()->fenString(Chess::Board::ShredderFen);
@@ -397,7 +399,7 @@ void UciEngine::parseInfo(const QVarLengthArray<QStringRef>& tokens,
 		eval->setPvNumber(tokens[0].toString().toInt());
 		break;
 	case InfoPv:
-		eval->setPv(sanPv(tokens));
+		eval->setPv(m_useDirectPv ?  directPv(tokens) : sanPv(tokens));
 		break;
 	case InfoScore:
 		{
@@ -789,6 +791,17 @@ void UciEngine::setPonderMove(const QString& moveString)
 		if (!m_ponderMove.isNull())
 			m_ponderMoveSan = board->moveString(m_ponderMove, Chess::Board::StandardAlgebraic);
 	}
+}
+
+QString UciEngine::directPv(const QVarLengthArray<QStringRef>& tokens)
+{
+	QString pv;
+	for( auto token : tokens)
+	{
+		pv += " ";
+		pv += token.toString();
+	}
+	return pv;
 }
 
 QString UciEngine::sanPv(const QVarLengthArray<QStringRef>& tokens)

--- a/projects/lib/src/uciengine.h
+++ b/projects/lib/src/uciengine.h
@@ -78,11 +78,13 @@ class LIB_EXPORT UciEngine : public ChessEngine
 		QString positionString();
 		void sendPosition();
 		void setPonderMove(const QString& moveString);
+		QString directPv(const QVarLengthArray<QStringRef>& tokens);
 		QString sanPv(const QVarLengthArray<QStringRef>& tokens);
 		
 		QString m_variantOption;
 		QString m_startFen;
 		QString m_moveStrings;
+		bool m_useDirectPv;
 		// Write buffer for messages that will be flushed to the engine
 		// after it sends a "bestmove"
 		QStringList m_bmBuffer;

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -284,6 +284,16 @@ void tst_Board::moveStrings_data() const
 		<< "Kg1 Be6 Bxe6 Qxe6 Re1 O-O-O"
 		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
 		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
+	QTest::newRow("giveaway san1")
+		<< "giveaway"
+		<< "e3"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b KQkq - 0 1";
+	QTest::newRow("suicide san1")
+		<< "suicide"
+		<< "e3"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+		<< "rnbqkbnr/pppppppp/8/8/8/4P3/PPPP1PPP/RNBQKBNR b - - 0 1";
 }
 
 void tst_Board::moveStrings()
@@ -647,6 +657,51 @@ void tst_Board::perft_data() const
 		<< "rmbqkbmr/pppppppp/8/8/8/8/PPPPPPPP/RMBQKBMR w KQkq - 0 1"
 		<< 5 //4 plies: 139774, 5 plies: 3249033, 6 plies: 74568983
 		<< Q_UINT64_C(3249033);
+
+	variant = "losers";
+	QTest::newRow("losers startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  //4 plies: 152955, 5 plies: 2723795, 6 plies: 46038682, 7 plies: 757349642 
+		<< Q_UINT64_C(2723795);
+
+	variant = "antichess";
+	QTest::newRow("antichess startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+		<< 5  //4 plies: 153299, 5 plies: 2732672, 6 plies: 46264162, 7 plies: 762010688
+		<< Q_UINT64_C(2732672);
+
+	variant = "giveaway";
+
+	QTest::newRow("giveaway startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  //4 plies: 153299, 5 plies: 2732672, 6 plies: 46264162, 7 plies: 762096669
+		<< Q_UINT64_C(2732672);
+
+	variant = "suicide";
+
+	QTest::newRow("suicide startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+		<< 5  //4 plies: 153299, 5 plies: 2732672
+		<< Q_UINT64_C(2732672);
+	QTest::newRow("suicide endgame1")
+		<< variant
+		<< "8/2b5/8/3B4/8/8/2P5/8 b - - 0 1"
+		<< 5  //5 plies: 116051, 6 plies: 1218696
+		<< Q_UINT64_C(116051);
+	QTest::newRow("suicide endgame2")
+		<< variant
+		<< "8/1kKP4/8/8/8/8/8/6n1 b - - 0 1"
+		<< 3  //3 plies: 5, 4 plies: 0
+		<< Q_UINT64_C(5);
+	QTest::newRow("suicide endgame3")
+		<< variant
+		<< "8/k1KP4/8/8/8/8/8/6n1 b - - 0 1"
+		<< 7  //7 plies: 2891980
+		<< Q_UINT64_C(2891980);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a proposal to support  _Losing Chess_  variants _Antichess_, _Giveaway_, _Suicide_. (Currently there are some problems.)

In _Losing Chess_ a side that lost all pieces or cannot move wins. The King is a normal piece, there is no check and Pawns can also promote to King. If a side can capture a piece, the must do so.

The variant labelled _Antichess_ is the oldest and has no castling moves. _Giveaway_ is identical, but castling is allowed. _Suicide Chess_ is like _Antichess_ but in stalemate the side with less pieces wins.

`GiveawayBoard` and `SuicideBoard` were implemented as subclasses of `AntiBoard`.

I tested _Giveaway_ and _Suicide Chess_ with recent multivariant Stockfish and Sjeng 11,2. The latter was also tested using Sjaak II 1.3.1a and PyChess. _Antichess_ was test manually and by imports from Lichess.org.

In contrast to other variants I observed stability problems with the UCI interface when Stockfish engines went to depth rapidly with very low effective branching. I noticed move data corruption during moveFromString execution (Issue #201) under heavy load from `info pv` line processing. This includes conversion to SAN and testing legality of PV moves.

For now, I made a workaround to skip SAN conversion and legality testing of PVs. This reduces failure rate drastically. This helped me to find some other, less frequent problems. My attempts to use a mutex on some execution paths the have not been successful so far.

I hope this is useful nevertheless.
