### PR TITLE
enable FEN parser to work with multi-character piece symbols

### DIFF
--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -366,6 +366,8 @@ class LIB_EXPORT Board
 		virtual Move moveFromLanString(const QString& str);
 		/*! Converts a string in SAN format into a Move object. */
 		virtual Move moveFromSanString(const QString& str) = 0;
+		/*! Returns the maximal length of a piece symbol */
+		virtual int maxPieceSymbolLength() const;
 
 		/*!
 		 * Returns the latter part of the current position's FEN string.
@@ -514,6 +516,7 @@ class LIB_EXPORT Board
 		Side m_side;
 		Side m_startingSide;
 		QString m_startingFen;
+		int m_maxPieceSymbolLength;
 		quint64 m_key;
 		Zobrist* m_zobrist;
 		QSharedPointer<Zobrist> m_sharedZobrist;

--- a/projects/lib/src/board/crazyhouseboard.cpp
+++ b/projects/lib/src/board/crazyhouseboard.cpp
@@ -87,7 +87,7 @@ int CrazyhouseBoard::normalPieceType(int type)
 	}
 }
 
-int CrazyhouseBoard::promotedPieceType(int type)
+int CrazyhouseBoard::promotedPieceType(int type) const
 {
 	switch (type)
 	{

--- a/projects/lib/src/board/crazyhouseboard.h
+++ b/projects/lib/src/board/crazyhouseboard.h
@@ -62,11 +62,12 @@ class LIB_EXPORT CrazyhouseBoard : public WesternBoard
 		/*!
 		 * Returns promoted piece type corresponding to normal \a type.
 		 */
-		virtual int promotedPieceType(int type);
+		virtual int promotedPieceType(int type) const;
 		/*!
 		 * Asserts side to move may drop pawns on given \a rank.
 		 */
 		virtual bool pawnDropOkOnRank(int rank) const;
+
 		// Inherited from WesternBoard
 		virtual int reserveType(int pieceType) const;
 		virtual QString sanMoveString(const Move& move);

--- a/projects/lib/src/board/loopboard.cpp
+++ b/projects/lib/src/board/loopboard.cpp
@@ -44,4 +44,10 @@ int LoopBoard::promotedPieceType(int type) const
 	return type;
 }
 
+int LoopBoard::maxPieceSymbolLength() const
+{
+	// prevent reading of Crazyhouse's promoted piece types
+	return 1;
+}
+
 } // namespace Chess

--- a/projects/lib/src/board/loopboard.h
+++ b/projects/lib/src/board/loopboard.h
@@ -50,6 +50,7 @@ class LIB_EXPORT LoopBoard : public CrazyhouseBoard
 	protected:
 		// Inherited from CrazyhouseBoard
 		virtual int promotedPieceType(int type) const;
+		virtual int maxPieceSymbolLength() const;
 };
 
 } // namespace Chess

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -508,6 +508,11 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4888832);
+	QTest::newRow("crazyhouse promo1")
+		<< variant
+		<< "3q1bkr/2p1pBp1/q1n3p1/1N2p3/1Pp5/P4Q~2/BBPp1PPP/R2K2NR[RPPn] b - - 0 28"
+		<< 3
+		<< Q_UINT64_C(6386);
 
 	variant = "loop";
 	QTest::newRow("loop startpos")


### PR DESCRIPTION
This patch extends the FEN parser in `Board::setFenString`. It supports multi-character piece symbols up to a length `maxsymlen` which depends on the predefined piece types. The longest match prevails, e.g.  the variant `Crazyhouse` uses `maxsymlen = 2` and so `Q~` (Pawn promoted to Queen) can be set instead of `Q` (Queen). This resolves issue #198.

Currently, apart from `Crazyhouse` and subvariants `maxsymlen`  equals one. Thus the reader will not be significantly slower.

Note: This extension only refers to pieces on the board, not to pieces in the reserve (in hand).
I hope this is useful. 

(updated patch and comment)