### PR TITLE
use edit command for xboard engines without setboard feature

### DIFF
--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -401,6 +401,24 @@ GenericMove Board::genericMove(const Move& move) const
 			   move.promotion());
 }
 
+QStringList Board::pieceList(Side side) const
+{
+	QStringList list;
+	for (int file = 0; file < height(); file++)
+		for (int rank = 0; rank < width(); rank++)
+		{
+			Square sq = Chess::Square(file, rank);
+			const Piece piece = pieceAt(sq);
+			if (piece.side() != side)
+				continue;
+
+			QString s = pieceSymbol(piece).toUpper();
+			s.append(squareString(sq));
+			list.append(s);
+		}
+	return list;
+}
+
 QString Board::fenString(FenNotation notation) const
 {
 	QString fen;

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -155,6 +155,10 @@ class LIB_EXPORT Board
 		bool isValidSquare(const Square& square) const;
 
 		/*!
+		 * Returns list of the pieces of \a side in current position.
+		 */
+		QStringList pieceList(Side side) const;
+		/*!
 		 * Returns the FEN string of the current board position in
 		 * X-Fen or Shredder FEN notation
 		 */

--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -126,7 +126,17 @@ void XboardEngine::startGame()
 		if (m_ftSetboard)
 			write("setboard " + board()->fenString());
 		else
-			qDebug("%s doesn't support the setboard command", qPrintable(name()));
+		{
+			qDebug("%s does not support the setboard command, using the edit command now", qPrintable(name()));
+			write("edit");
+			write("#"); // clear board on engine
+			for (const auto& s: board()->pieceList(Chess::Side::White))
+				write(s); // set a piece
+			write("c");
+			for (const auto& s: board()->pieceList(Chess::Side::Black))
+				write(s); // set a piece
+			write("."); // finished
+		}
 	}
 	
 	// Send the time controls


### PR DESCRIPTION
This is a proposal to support board setup for xboard engines that do not have the `setboard` feature. Instead of `setboard` the `edit` command is used to place the pieces.

The `edit` command is part of the CECP specification.

> The edit command is the old way to set up positions. For compatibility with old engines, it is still used by default, but new engines may prefer to use the feature command (see below) to cause xboard to use setboard instead.

http://www.open-aurec.com/wbforum/WinBoard/engine-intf.html
https://www.gnu.org/software/xboard/engine-intf.html

_Chessbase/Fritz_ extensions for en passant and castling `ep` and `castle` (see remarks at the end of CECP specification) are not supported yet.

I hope this is useful nevertheless.


