### PR TITLE
support Checkless Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -47,6 +47,8 @@ Berolina Chess
 Capablanca Chess
 .It caparandom
 Capablanca Random Chess
+.It checkless
+Checkless Chess
 .It chessgi
 Chessgi / Drop Chess
 .It crazyhouse

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -16,6 +16,7 @@ Options:
 			'berolina': Berolina Chess
 			'capablanca': Capablanca Chess
 			'caparandom': Capablanca Random Chess
+			'checkless': Checkless Chess
 			'chessgi': Chessgi (Drop Chess)
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'extinction': Extinction Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -19,6 +19,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/genericmove.cpp \
     $$PWD/atomicboard.cpp \
     $$PWD/losersboard.cpp \
+    $$PWD/checklessboard.cpp \
     $$PWD/gothicboard.cpp \
     $$PWD/crazyhouseboard.cpp \
     $$PWD/loopboard.cpp \
@@ -48,6 +49,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/genericmove.h \
     $$PWD/atomicboard.h \
     $$PWD/losersboard.h \
+    $$PWD/checklessboard.h \
     $$PWD/gothicboard.h \
     $$PWD/crazyhouseboard.h \
     $$PWD/loopboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -19,6 +19,7 @@
 #include "atomicboard.h"
 #include "capablancaboard.h"
 #include "caparandomboard.h"
+#include "checklessboard.h"
 #include "crazyhouseboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
@@ -41,6 +42,7 @@ REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
+REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(ExtinctionBoard, "extinction")

--- a/projects/lib/src/board/checklessboard.cpp
+++ b/projects/lib/src/board/checklessboard.cpp
@@ -1,0 +1,56 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "checklessboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+ChecklessBoard::ChecklessBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+Board* ChecklessBoard::copy() const
+{
+	return new ChecklessBoard(*this);
+}
+
+QString ChecklessBoard::variant() const
+{
+	return "checkless";
+}
+
+QString ChecklessBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool ChecklessBoard::isLegalPosition()
+{
+	if (!WesternBoard::isLegalPosition())
+		return false;
+
+	Side side = sideToMove();
+
+	if (inCheck(side))
+		return (!canMove());
+
+	return true;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/checklessboard.h
+++ b/projects/lib/src/board/checklessboard.h
@@ -1,0 +1,53 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHECKLESSBOARD_H
+#define CHECKLESSBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Checkless Chess
+ *
+ * Checkless Chess is a variant of standard chess that already
+ * has been played in the early 19th century. It is also
+ * known as Prohibition Chess.
+ *
+ * The kings must not be checked unless for mate.
+ * Entering check is forbidden.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Checkless_chess
+ * */
+class LIB_EXPORT ChecklessBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new ChecklessBoard object. */
+		ChecklessBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual bool isLegalPosition();
+};
+
+} // namespace Chess
+#endif // CHECKLESSBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -420,6 +420,13 @@ void tst_Board::results_data() const
 		<< variant
 		<< "8/8/6p1/8/8/4P3/8/8 w - - 0 1"
 		<< "*";
+
+	variant = "checkless";
+
+	QTest::newRow("checkless white win")
+		<< variant
+		<< "K5kr/5Q2/8/8/8/8/8/8 b - - 0 1"
+		<< "1-0";
 }
 
 void tst_Board::results()
@@ -574,6 +581,13 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/6p1/2p1Pp1P/P1PPPP2/Pp4PP/1p2PPPP/1P2PPPP/PP1nPPPP b kq a3 0 18"
 		<< 5  //4 plies: 197287, 5 plies: 6429490
 		<< Q_UINT64_C(6429490);
+
+	variant = "checkless";
+	QTest::newRow("checkless startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5
+		<< Q_UINT64_C(4835050);
 
 	variant = "extinction";
 	QTest::newRow("extinction startpos")


### PR DESCRIPTION
This is a proposal to support _checkless chess_. This is an old variant of standard chess. No checks are allowed except for giving mate. Tested by manual play, as there seems to be a lack of available chess engines. This is a lightweight implementation. 

Test position `K5kr/5Q2/8/8/8/8/8/8 b - - 0 1`  is correctly solved as a white win.

I hope this is useful.