### PR TITLE
support Janus Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -61,6 +61,8 @@ Fischer Random Chess / Chess 960
 Gothic Chess
 .It horde
 Horde Chess (v2)
+.It janus
+Janus Chess
 .It kinglet
 Kinglet Chess
 .It kingofthehill

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -23,6 +23,7 @@ Options:
 			'fischerandom': Fischer Random Chess/Chess 960
 			'gothic': Gothic Chess
 			'horde': Horde Chess (v2)
+			'janus': Janus Chess
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess
 			'loop': Loop Chess (Drop Chess)

--- a/projects/gui/src/boardview/boardscene.cpp
+++ b/projects/gui/src/boardview/boardscene.cpp
@@ -415,7 +415,7 @@ GraphicsPiece* BoardScene::createPiece(const Chess::Piece& piece)
 
 	return new GraphicsPiece(piece,
 				 s_squareSize,
-				 m_board->pieceSymbol(piece),
+				 m_board->representation(piece),
 				 m_renderer);
 }
 

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -131,12 +131,16 @@ int Board::maxPieceSymbolLength() const
 void Board::setPieceType(int type,
 			 const QString& name,
 			 const QString& symbol,
-			 unsigned movement)
+			 unsigned movement,
+			 const QString& gsymbol)
 {
 	if (type >= m_pieceData.size())
 		m_pieceData.resize(type + 1);
 
-	PieceData data = { name, symbol.toUpper(), movement };
+	const QString& graphicalSymbol = gsymbol.isEmpty() ? symbol : gsymbol;
+
+	PieceData data =
+		{ name, symbol.toUpper(), movement, graphicalSymbol.toUpper() };
 	m_pieceData[type] = data;
 }
 
@@ -181,6 +185,17 @@ QString Board::pieceString(int pieceType) const
 	if (pieceType <= 0 || pieceType >= m_pieceData.size())
 		return QString();
 	return m_pieceData[pieceType].name;
+}
+
+QString Board::representation(Piece piece) const
+{
+	int type = piece.type();
+	if (type <= 0 || type >= m_pieceData.size())
+		return QString();
+
+	if (piece.side() == upperCaseSide())
+		return m_pieceData[type].representation;
+	return m_pieceData[type].representation.toLower();
 }
 
 int Board::reserveType(int pieceType) const

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -220,6 +220,8 @@ class LIB_EXPORT Board
 		Piece pieceFromSymbol(const QString& pieceSymbol) const;
 		/*! Returns the internationalized name of \a pieceType. */
 		QString pieceString(int pieceType) const;
+		/*! Returns symbol for graphical representation of \a piece. */
+		QString representation(Piece piece) const;
 
 		/*!
 		 * Makes a chess move on the board.
@@ -309,11 +311,14 @@ class LIB_EXPORT Board
 		 * \param symbol Short piece name or piece symbol
 		 * \param movement A bit mask for the kinds of moves the
 		 *        piece can make.
+		 * \param gsymbol Select the piece's graphical representation.
+		 *	  If not set the \a symbol will be used (default).
 		 */
 		void setPieceType(int type,
 				  const QString& name,
 				  const QString& symbol,
-				  unsigned movement = 0);
+				  unsigned movement = 0,
+				  const QString & gsymbol = QString());
 		/*! Returns true if \pieceType can move like \a movement. */
 		bool pieceHasMovement(int pieceType, unsigned movement) const;
 
@@ -506,6 +511,7 @@ class LIB_EXPORT Board
 			QString name;
 			QString symbol;
 			unsigned movement;
+			QString representation;
 		};
 		struct MoveData
 		{

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -10,6 +10,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/extinctionboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
+    $$PWD/janusboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
     $$PWD/frcboard.cpp \
@@ -40,6 +41,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/extinctionboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \
+    $$PWD/janusboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \
     $$PWD/frcboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -25,6 +25,7 @@
 #include "frcboard.h"
 #include "gothicboard.h"
 #include "hordeboard.h"
+#include "janusboard.h"
 #include "losersboard.h"
 #include "standardboard.h"
 #include "berolinaboard.h"
@@ -50,6 +51,7 @@ REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(HordeBoard, "horde")
+REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")

--- a/projects/lib/src/board/janusboard.cpp
+++ b/projects/lib/src/board/janusboard.cpp
@@ -1,0 +1,103 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "janusboard.h"
+
+namespace Chess {
+
+JanusBoard::JanusBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	// Janus uses notation "J" and the graphical image of Archbishop "A"
+	setPieceType(Janus, tr("janus"), "J", KnightMovement | BishopMovement, "A");
+}
+
+Board* JanusBoard::copy() const
+{
+	return new JanusBoard(*this);
+}
+
+QString JanusBoard::variant() const
+{
+	return "janus";
+}
+
+int JanusBoard::width() const
+{
+	return 10;
+}
+
+QString JanusBoard::defaultFenString() const
+{
+	return "rjnbkqbnjr/pppppppppp/10/10/10/10/PPPPPPPPPP/RJNBKQBNJR w KQkq - 0 1";
+}
+
+void JanusBoard::addPromotions(int sourceSquare,
+				int targetSquare,
+				QVarLengthArray<Move>& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+	moves.append(Move(sourceSquare, targetSquare, Janus));
+}
+
+int JanusBoard::castlingFile(CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	return castlingSide == QueenSide ? 1 : width() - 2; // B-File and I-File
+}
+
+QString JanusBoard::sanMoveString(const Move& move)
+{
+	// uses Kb1/Kb8/Ki1/Ki8 for castling
+	QString san = WesternBoard::sanMoveString(move);
+	if (san == "O-O" || san == "O-O-O")
+		return pieceSymbol(King).toUpper() + lanMoveString(move).mid(2);
+	return san;
+}
+
+
+Move JanusBoard::moveFromSanString(const QString& str)
+{
+	/*
+	 * accepts O-O and Kb1/Kb8/Ki1/Ki8 formats for castling
+	 * Xboard uses O-O for B-file and Ki1/Ki8 for I-file castling
+	 */
+	if (str == "O-O")
+		return WesternBoard::moveFromSanString("O-O-O");
+	if (str == "O-O-O")
+		return WesternBoard::moveFromSanString("O-O");
+
+	if (!str.startsWith(pieceSymbol(King).toUpper()))
+		return WesternBoard::moveFromSanString(str);  //main path
+
+	if (hasCastlingRight(sideToMove(), KingSide))
+	{
+		Move castlingMove = WesternBoard::moveFromSanString("O-O");
+		if (str == sanMoveString(castlingMove))
+			return castlingMove;
+	}
+	if (hasCastlingRight(sideToMove(), QueenSide))
+	{
+		Move castlingMove = WesternBoard::moveFromSanString("O-O-O");
+		if (str == sanMoveString(castlingMove))
+			return castlingMove;
+	}
+
+	return WesternBoard::moveFromSanString(str); // normal king moves
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/janusboard.h
+++ b/projects/lib/src/board/janusboard.h
@@ -1,0 +1,72 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef JANUSBOARD_H
+#define JANUSBOARD_H
+
+#include "westernboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Janus Chess
+ *
+ * Janus Chess is a variant of standard chess which adds the Janus
+ * piece type (Bishop + Knight). Like Capablanca Chess it is played
+ * on a 10x8 board.
+ *
+ * Initially the Jani are positioned between Rooks and Knights. The
+ * King castles from E-file to either B- or I-file, the corresponding
+ * rook to C- or H-file.
+ *
+ * Introduced by Werner Schöndorf, Germany, 1978.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Janus_chess
+ *
+ * \sa CapablancaBoard
+ */
+class LIB_EXPORT JanusBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new JanusBoard object. */
+		JanusBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Special piece types for Capablanca variants. */
+		enum JanusPieceType
+		{
+			Janus = 7,	//!< Janus = Princess (knight + bishop)
+		};
+
+		// Inherited from WesternBoard
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+		virtual int castlingFile(CastlingSide castlingSide) const;
+		virtual QString sanMoveString(const Move& move);
+		virtual Move moveFromSanString(const QString& str);
+};
+
+} // namespace Chess
+#endif // JANUSBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -79,10 +79,10 @@ void WesternBoard::vInitialize()
 	m_kingSquare[Side::White] = 0;
 	m_kingSquare[Side::Black] = 0;
 
-	m_castleTarget[Side::White][QueenSide] = (height() + 1) * m_arwidth + 3;
-	m_castleTarget[Side::White][KingSide] = (height() + 1) * m_arwidth + width() - 1;
-	m_castleTarget[Side::Black][QueenSide] = 2 * m_arwidth + 3;
-	m_castleTarget[Side::Black][KingSide] = 2 * m_arwidth + width() - 1;
+	m_castleTarget[Side::White][QueenSide] = (height() + 1) * m_arwidth + 1 + castlingFile(QueenSide);
+	m_castleTarget[Side::White][KingSide] = (height() + 1) * m_arwidth + 1 + castlingFile(KingSide);
+	m_castleTarget[Side::Black][QueenSide] = 2 * m_arwidth + 1 + castlingFile(QueenSide);
+	m_castleTarget[Side::Black][KingSide] = 2 * m_arwidth + 1 + castlingFile(KingSide);
 
 	m_knightOffsets.resize(8);
 	m_knightOffsets[0] = -2 * m_arwidth - 1;
@@ -781,6 +781,12 @@ void WesternBoard::removeCastlingRights(int square)
 		setCastlingSquare(side, QueenSide, 0);
 	else if (square == cr[KingSide])
 		setCastlingSquare(side, KingSide, 0);
+}
+
+int WesternBoard::castlingFile(CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	return castlingSide == QueenSide ? 2 : width() - 2; // usually C and G
 }
 
 void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -148,6 +148,11 @@ class LIB_EXPORT WesternBoard : public Board
 		 */
 		void removeCastlingRights(int square);
 		/*!
+		 * Defines the file a king may castle to on \a castlingSide.
+		 * Defaults: 2 (c-file) and width() - 2 (normally g-file)
+		 */
+		virtual int castlingFile(CastlingSide castlingSide) const;
+		/*!
 		 * Returns true if \a side is under attack at \a square.
 		 * If \a square is 0, then the king square is used.
 		 */

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -258,6 +258,21 @@ void tst_Board::moveStrings_data() const
 		<< "e4 e5 Nf3 d6 Bb5+ c6 Bxc6+"
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
 		<< "rnbqkbnr/pp3ppp/2Bp4/4p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1+3 0 4";
+	QTest::newRow("janus castling san1")
+		<< "janus"
+		<< "Kb8 Be3 Ng6 Ki1"
+		<< "r3kqbnjr/pppp1ppppp/2jn1b4/4p5/4P5/3Q1PNJ2/PPPP2PPPP/RJNBK1B2R b KQkq - 0 1"
+		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
+	QTest::newRow("janus castling san2")
+		<< "janus"
+		<< "O-O Be3 Ng6 O-O-O"
+		<< "r3kqbnjr/pppp1ppppp/2jn1b4/4p5/4P5/3Q1PNJ2/PPPP2PPPP/RJNBK1B2R b KQkq - 0 1"
+		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
+	QTest::newRow("janus castling lan")
+		<< "janus"
+		<< "e8b8 g1e3 h8g6 e1i1"
+		<< "r3kqbnjr/pppp1ppppp/2jn1b4/4p5/4P5/3Q1PNJ2/PPPP2PPPP/RJNBK1B2R b KQkq - 0 1"
+		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
 }
 
 void tst_Board::moveStrings()
@@ -595,6 +610,13 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4897256);
+
+	variant = "janus";
+	QTest::newRow("janus startpos")
+		<< variant
+		<< "rjnbkqbnjr/pppppppppp/10/10/10/10/PPPPPPPPPP/RJNBKQBNJR w KQkq - 0 1"
+		<< 4 //4 plies: 772074, 5 plies: 26869186
+		<< Q_UINT64_C(772074);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a proposal to support _Janus Chess_. This variant uses a 10x8 board and introduces the _Janus_, a piece with Knight and Bishop movement. This piece is  also known as _Princess, Archbishop, Hawk_ etc. in the context of other variants. As this piece is able to give mate on its own, the draw rate tends to be lower than in standard chess. It is similar to Capablanca Chess, but has different castling rules, different board setup, and one more Bishop+Knight piece per side instead of the _Chancellor_ (Rook+Knight).

Tests were done manually and with the engine Fairy-Max 5.0b .

I tried to abstract the notation symbol of the Janus "J" from the representation symbol on the graphical board scene. `JanusBoard` uses the "A" (Archbishop) graphical representation. In order to achieve this I made an extension to the `Board` class and changed one line in `BoardScene`.

Furthermore the castling rules of _Janus Chess_ were not compatible with the `WesternBoard` base class. I introduced a virtual method to override the castling files for the Kings in _Janus Chess_.

I hope this is acceptable nevertheless.