### PR TITLE
Support new mate score format of xboard engines in addition to old one

### DIFF
--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -40,6 +40,15 @@ QString evalString(const MoveEvaluation& eval)
 			str += "+";
 
 		// Detect mate-in-n scores
+
+		// convert new CECP mate scores to old ones if needed
+		if (absScore > 99900 && absScore < 100100)
+		{
+			absScore = 200000 - 2 * absScore + 30000;
+			if (score >= absScore)
+				absScore++;
+		}
+
 		if (absScore > 9900
 		&&  (absScore = 1000 - (absScore % 1000)) < 100)
 		{


### PR DESCRIPTION
The xboard (CECP) specification now maps (absolute) mate scores just above 100000 with mate distance in moves instead of plys.

> Mate scores should be indicated as 100000 + N for "mate in N moves", and -100000 - N for "mated in N moves".

https://www.gnu.org/software/xboard/engine-intf.html

I found that Fairy-Max 5.0b implements this new specification.
This patch adds support for the new mate scores. So it shows  +M9 instead of 1000.05 and -M10 instead of -1000.05. The scores out of (absolute) range 99900 to 100100 are unchanged. So far I have not seen any new problems with older mate score formats.
 