### PR TITLE
fathom tbprobe.c: include x86intrin.h only for x386-compatible builds

### DIFF
--- a/projects/lib/3rdparty/fathom/src/tbprobe.c
+++ b/projects/lib/3rdparty/fathom/src/tbprobe.c
@@ -30,7 +30,9 @@
 #include "tbprobe.h"
 
 #ifdef __GNUC__
-#include <x86intrin.h>
+#  if defined(__i386) || defined(__x86_64__)
+#  include <x86intrin.h>
+#  endif
 #endif
 
 #define WHITE_KING              (TB_WPAWN + 5)


### PR DESCRIPTION
This patch avoids problem #204. 