### PR TITLE
Map variant tag values chess and normal to standard variant for PGN i…

### DIFF
--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -157,6 +157,8 @@ bool PgnGame::parseMove(PgnStream& in)
 	if (m_moves.isEmpty())
 	{
 		QString tmp(m_tags.value("Variant").toLower());
+		if (tmp == "chess" || tmp == "normal")
+			tmp = QString("standard");
 
 		if (!tmp.isEmpty() && !in.setVariant(tmp))
 		{
@@ -383,7 +385,11 @@ Chess::Result PgnGame::result() const
 QString PgnGame::variant() const
 {
 	if (m_tags.contains("Variant"))
-		return m_tags.value("Variant");
+	{
+		QString variant(m_tags.value("Variant"));
+		if ("chess" != variant && "normal" != variant)
+			return variant;
+	}
 	return "standard";
 }
 


### PR DESCRIPTION
This is a suggestion to improve PGN import compatiblity with some collections of game data by mapping the tags `[Variant "chess"] `and` [Variant "normal"]` to standard chess. This is related to issue #226

My observation is that neither the CLI nor the GUI crash, but issue a warning and ignore a game with `[Variant "normal"]`. Cutechess can import PGN files containing multiple (mixed) variants. 

Usually, for standard chess, the `Variant` tag should be omitted.
If a `Variant` tag is present, cutechess will only accept `standard` for standard chess.

I think it helps to map `normal` and `chess` to standard chess for better import compatibility. However, it does not help to accept any unknown `Variant` tags as standard chess. There are many variants that cutechess does not know (yet). We should not hide errors and compatibility problems but address them.

 