### PR TITLE
Horde: correct result string for black win

### DIFF
--- a/projects/lib/src/board/hordeboard.cpp
+++ b/projects/lib/src/board/hordeboard.cpp
@@ -78,7 +78,8 @@ Result HordeBoard::result()
 	Side side = sideToMove();
 	Side opp = side.opposite();
 	if (!hasMaterial(side))
-		return Result(Result::Win, opp, tr("%1 wins").arg(opp));
+		return Result(Result::Win, opp,
+			      tr("%1 wins").arg(opp.toString()));
 
 	return StandardBoard::result();
 }


### PR DESCRIPTION
This corrects the PGN comments for wins of the pieces in Horde Chess. Comment currently is  `{1 wins}`  if the horde starts for the white side. Sorry for the glitch.
