### PR TITLE
Cecp position set-up with black to move

### DIFF
--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -120,9 +120,15 @@ void XboardEngine::startGame()
 	if (board()->variant() != "standard")
 		write("variant " + variantToXboard(board()->variant()));
 	
+	setForceMode(true);
+
 	if (board()->isRandomVariant()
 	||  board()->fenString() != board()->defaultFenString())
 	{
+		if (board()->sideToMove() == Chess::Side::Black)
+		{
+			write("b2b3"); // now engine will play the black side
+		}
 		if (m_ftSetboard)
 			write("setboard " + board()->fenString());
 		else
@@ -171,7 +177,6 @@ void XboardEngine::startGame()
 		write("hard");
 	else
 		write("easy");
-	setForceMode(true);
 	
 	// Tell the opponent's type and name to the engine
 	if (m_ftName)


### PR DESCRIPTION
This patch resolves problems setting up positions with black side to move and xboard - engines.

I observed that engines started playing the white side when a black position was given.
A command sequence is used according to the CECP specification https://www.gnu.org/software/xboard/engine-intf.html as described for the edit command. It includes a dummy move to switch the engine from the white to the black side.

Now force mode is set earlier, this also resolves problems I observed with sjaakii (e.g. version 1.4.1). 
