### PR TITLE
support Andernach chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -39,6 +39,10 @@ is one of:
 Three-check Chess
 .It 5check
 Five-check Chess
+.It andernach
+Andernach Chess
+.It antiandernach
+Anti-Andernach Chess
 .It atomic
 Atomic Chess
 .It berolina
@@ -73,6 +77,8 @@ Loop Chess (Drop Chess Variant)
 Loser's Chess
 .It racingkings
 Racing Kings Chess
+.It superandernach
+Super-Andernach Chess
 .It standard
 Standard Chess (default)
 .El

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -12,6 +12,8 @@ Options:
   -variant VARIANT	Set the chess variant to VARIANT, which can be one of:
 			'3check': Three-check Chess
 			'5check': Five-check Chess
+			'andernach': Andernach Chess
+			'antiandernach': Anti-Andernach Chess
 			'atomic': Atomic Chess
 			'berolina': Berolina Chess
 			'capablanca': Capablanca Chess
@@ -29,6 +31,7 @@ Options:
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
 			'racingkings': Racing Kings Chess
+			'superandernach': Super-Andernach Chess
 			'standard': Standard Chess (default).
   -concurrency N	Set the maximum number of concurrent games to N
   -draw movenumber=NUMBER movecount=COUNT score=SCORE

--- a/projects/lib/src/board/andernachboard.cpp
+++ b/projects/lib/src/board/andernachboard.cpp
@@ -1,0 +1,142 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "andernachboard.h"
+
+namespace Chess {
+
+AndernachBoard::AndernachBoard()
+	: StandardBoard()
+{
+}
+
+Board* AndernachBoard::copy() const
+{
+	return new AndernachBoard(*this);
+}
+
+QString AndernachBoard::variant() const
+{
+	return "andernach";
+}
+
+Move AndernachBoard::moveFromSanString(const QString& str)
+{
+	// import: ignore redundant move information in brackets: Nxd5(=bN)
+	const QString istr = str.left(str.indexOf("("));
+	return WesternBoard::moveFromSanString(istr);
+}
+
+/*
+ * Cutechess follows convention and writes redundant information about side
+ * changes to SAN: e.g. Nxd5(=bN) instead of Nxd5. Imports both formats.
+ */
+QString AndernachBoard::sanMoveString(const Move& move)
+{
+	Piece pc = pieceAt(move.sourceSquare());
+	if (!switchesSides(move))
+		return WesternBoard::sanMoveString(move);
+
+	//append new piece color and type in brackets
+	int promotion = move.promotion();
+	int type = (promotion == Piece::NoPiece) ? pc.type() : promotion;
+	Piece piece(pc.side(), type);
+	QString color = (piece.side() == Side::White) ? "b" : "w";
+	QString a = "(=" + color + pieceSymbol(piece).toUpper() + ")";
+
+	return WesternBoard::sanMoveString(move) + a;
+}
+
+void AndernachBoard::vMakeMove(const Move& move,
+			       BoardTransition* transition)
+{
+	bool moveSwitchesSides = switchesSides(move);
+	StandardBoard::vMakeMove(move, transition);
+
+	// switch side if the move is a capture (not by king)
+	Piece piece = pieceAt(move.targetSquare());
+	if (piece.isValid()
+	&&  moveSwitchesSides)
+		piece.setSide(piece.side().opposite());
+
+	setSquare(move.targetSquare(), piece);
+}
+
+void AndernachBoard::vUndoMove(const Move& move)
+{
+	// switch side on target square if occupied by opposite side
+	Piece piece = pieceAt(move.targetSquare());
+	if (piece.side() == sideToMove().opposite())
+		piece.setSide(piece.side().opposite());
+
+	setSquare(move.targetSquare(), piece);
+
+	StandardBoard::vUndoMove(move);
+}
+
+bool AndernachBoard::switchesSides(const Move& move) const
+{
+	return captureType(move) != Piece::NoPiece
+	&&     pieceAt(move.sourceSquare()).type() != King;
+}
+
+
+
+AntiAndernachBoard::AntiAndernachBoard()
+	: AndernachBoard()
+{
+}
+
+Board* AntiAndernachBoard::copy() const
+{
+	return new AntiAndernachBoard(*this);
+}
+
+QString AntiAndernachBoard::variant() const
+{
+	return "antiandernach";
+}
+
+bool AntiAndernachBoard::switchesSides(const Move& move) const
+{
+	return captureType(move) == Piece::NoPiece
+	&&     pieceAt(move.sourceSquare()).type() != King;
+}
+
+
+
+SuperAndernachBoard::SuperAndernachBoard()
+	: AndernachBoard()
+{
+}
+
+Board* SuperAndernachBoard::copy() const
+{
+	return new SuperAndernachBoard(*this);
+}
+
+QString SuperAndernachBoard::variant() const
+{
+	return "superandernach";
+}
+
+bool SuperAndernachBoard::switchesSides(const Move& move) const
+{
+	return pieceAt(move.sourceSquare()).type() != King;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/andernachboard.h
+++ b/projects/lib/src/board/andernachboard.h
@@ -1,0 +1,122 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ANDERNACHBOARD_H
+#define ANDERNACHBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Andernach Chess
+ *
+ * Andernach chess is a variant of standard chess with modified captures.
+ * Capturing pieces - except for kings - change sides. A pawn capturing on
+ * the final rank is promoted first and then changes sides.
+ *
+ * The game was introduced in 1993 during a tournament in Andernach, Germany.
+ * It was suggested by H. P. Rehm and evolved from Double Tibetian Chess.
+ * It is a popular variant in problem chess.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Andernach_chess
+ *
+ * AndernachBoard uses Polyglot-compatible zobrist position keys,
+ * so appropriate books in Polyglot format can be used.
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ * \sa PolyglotBook
+ * \sa AntiAndernachBoard
+ */
+class LIB_EXPORT AndernachBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new AndernachBoard object. */
+		AndernachBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		/*!
+		 * Returns true if \a move switches sides of moved piece.
+		 * True for a capture move not by king.
+		 */
+		virtual bool switchesSides(const Move& move) const;
+
+		// Inherited from StandardBoard
+		virtual Move moveFromSanString(const QString& str);
+		virtual QString sanMoveString(const Move& move);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move &move);
+};
+
+
+/*!
+ * \brief A board for Anti-Andernach Chess
+ *
+ * Anti-Andernach chess is standard chess but non-capturing moves imply a
+ * change of color (except for Kings). Used in problem chess.
+ * \sa AndernachBoard
+ */
+class LIB_EXPORT AntiAndernachBoard : public AndernachBoard
+{
+	public:
+		/*! Creates a new AntiAndernachBoard object. */
+		AntiAndernachBoard();
+
+		// Inherited from AndernachBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		/*!
+		 * Returns true if \a move switches sides of moved piece.
+		 * True for a non-capture move not by king.
+		 */
+		virtual bool switchesSides(const Move& move) const;
+};
+
+/*!
+ * \brief A board for Super-Andernach Chess
+ *
+ * All moves except for King moves imply a change of color in
+ * Super-Andernach chess. This variant is used in problem chess.
+ * \sa AndernachBoard
+ */
+class LIB_EXPORT SuperAndernachBoard : public AndernachBoard
+{
+	public:
+		/*! Creates a new SuperAndernachBoard object. */
+		SuperAndernachBoard();
+
+		// Inherited from AndernachBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		/*!
+		 * Returns true if \a move switches sides of moved piece.
+		 * True for any move not by king.
+		 */
+		virtual bool switchesSides(const Move& move) const;
+};
+
+} // namespace Chess
+#endif // ANDERNACHBOARD_H

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -4,6 +4,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/square.cpp \
     $$PWD/standardboard.cpp \
     $$PWD/ncheckboard.cpp \
+    $$PWD/andernachboard.cpp \
     $$PWD/berolinaboard.cpp \
     $$PWD/racingkingsboard.cpp \
     $$PWD/capablancaboard.cpp \
@@ -35,6 +36,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/square.h \
     $$PWD/standardboard.h \
     $$PWD/ncheckboard.h \
+    $$PWD/andernachboard.h \
     $$PWD/berolinaboard.h \
     $$PWD/racingkingsboard.h \
     $$PWD/capablancaboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "boardfactory.h"
+#include "andernachboard.h"
 #include "atomicboard.h"
 #include "capablancaboard.h"
 #include "caparandomboard.h"
@@ -39,6 +40,8 @@ namespace Chess {
 
 REGISTER_BOARD(ThreeCheckBoard, "3check")
 REGISTER_BOARD(FiveCheckBoard, "5check")
+REGISTER_BOARD(AndernachBoard, "andernach")
+REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
 REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
@@ -57,6 +60,7 @@ REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(StandardBoard, "standard")
+REGISTER_BOARD(SuperAndernachBoard, "superandernach")
 
 
 ClassRegistry<Board>* BoardFactory::registry()

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -485,7 +485,7 @@ void tst_Board::perft_data() const
 		<< "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -"
 		<< 6
 		<< Q_UINT64_C(11030083);
-	
+
 	variant = "capablanca";
 	QTest::newRow("gothic startpos")
 		<< variant
@@ -597,6 +597,18 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/6p1/2p1Pp1P/P1PPPP2/Pp4PP/1p2PPPP/1P2PPPP/PP1nPPPP b kq a3 0 18"
 		<< 5  //4 plies: 197287, 5 plies: 6429490
 		<< Q_UINT64_C(6429490);
+
+	variant = "andernach";
+	QTest::newRow("andernach startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  //4 plies: 197410, 5 plies: 4870137
+		<< Q_UINT64_C(4870137);
+	QTest::newRow("andernach pos1")
+		<< variant
+		<< "rnbqkbnr/ppp1p1pp/8/3pPp2/8/8/PPPP1PPP/RNBQKBNR w KQkq f6 0 3"
+		<< 4  //4 plies: 523348, 5 plies: 16330793
+		<< Q_UINT64_C(523348);
 
 	variant = "checkless";
 	QTest::newRow("checkless startpos")


### PR DESCRIPTION
This is a suggestion to support **Andernach Chess**. Except for the kings a piece switches sides after it made a capture. A pawn capturing on the eighth rank first promotes and then switches sides. Apart from this standard chess rules apply. This variant originated from problem chess but can also be played in competition. A computer implementation has advantages against over the board play. The latter needs two sets of chess pieces and more interaction to exchange capturing pieces.

There seem to be no engines for this variant yet. Other than by playing myself in order to test the implementation I made some crude changes to the _sloppy_ engine.

While there I implemented boards for **Anti-Andernach Chess** (switch sides after non-captures) and  **Super-Andernach Chess** (always sitch sides after a move). These variants are more of interest for  problem chess than for competition.

I hope this is useful.

