### PR TITLE
support KnightMate

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -67,6 +67,8 @@ Janus Chess
 Kinglet Chess
 .It kingofthehill
 King of the Hill Chess
+.It knightmate
+Knightmate
 .It loop
 Loop Chess (Drop Chess Variant)
 .It losers

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -26,6 +26,7 @@ Options:
 			'janus': Janus Chess
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess
+			'knightmate': Knightmate
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
 			'racingkings': Racing Kings Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -11,6 +11,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
     $$PWD/janusboard.cpp \
+    $$PWD/knightmateboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
     $$PWD/frcboard.cpp \
@@ -42,6 +43,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \
     $$PWD/janusboard.h \
+    $$PWD/knightmateboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \
     $$PWD/frcboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -31,6 +31,7 @@
 #include "berolinaboard.h"
 #include "chessgiboard.h"
 #include "kingofthehillboard.h"
+#include "knightmateboard.h"
 #include "loopboard.h"
 #include "ncheckboard.h"
 #include "racingkingsboard.h"
@@ -53,6 +54,7 @@ REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
+REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")

--- a/projects/lib/src/board/knightmateboard.cpp
+++ b/projects/lib/src/board/knightmateboard.cpp
@@ -1,0 +1,131 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "knightmateboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+KnightMateBoard::KnightMateBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(King, tr("king"), "K", 0, "N");
+	setPieceType(Mann, tr("mann"), "M", 0, "K");
+}
+
+Board* KnightMateBoard::copy() const
+{
+	return new KnightMateBoard(*this);
+}
+
+QString KnightMateBoard::variant() const
+{
+	return "knightmate";
+}
+
+QString KnightMateBoard::defaultFenString() const
+{
+	return "rmbqkbmr/pppppppp/8/8/8/8/PPPPPPPP/RMBQKBMR w KQkq - 0 1";
+}
+
+void KnightMateBoard::addPromotions(int sourceSquare,
+				    int targetSquare,
+				    QVarLengthArray< Move >& moves) const
+{
+	moves.append(Move(sourceSquare, targetSquare, Mann));
+	moves.append(Move(sourceSquare, targetSquare, Bishop));
+	moves.append(Move(sourceSquare, targetSquare, Rook));
+	moves.append(Move(sourceSquare, targetSquare, Queen));
+}
+
+void KnightMateBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
+					    int pieceType,
+					    int square) const
+{
+	if (pieceType == King || pieceType == Mann)
+	{
+		QVarLengthArray <Move> testmoves;
+		WesternBoard::generateMovesForPiece(testmoves, King, square);
+		for (const auto m: testmoves)
+		{
+			Square src = chessSquare(m.sourceSquare());
+			Square dest = chessSquare(m.targetSquare());
+			bool castling = abs(src.file() - dest.file()) > 1;
+
+			if ((pieceType == King && castling)
+			||  (pieceType == Mann && !castling))
+				moves.append(m);
+		}
+		if (pieceType == Mann)
+			return;
+		// king's leaps
+		return WesternBoard::generateMovesForPiece(moves, Knight, square);
+	}
+	return WesternBoard::generateMovesForPiece(moves, pieceType, square);
+}
+
+bool KnightMateBoard::inCheck(Side side, int square) const
+{
+	if (square == 0)
+		square = kingSquare(side);
+
+	QVarLengthArray <Move> moves;
+	if (sideToMove() == side)
+		// needs symmetry of piece movement of both sides
+		for (int type = Pawn; type <= Mann; type++)
+		{
+			generateMovesForPiece(moves, type, square);
+			for (const auto m: moves)
+			{
+				if (captureType(m) == type)
+					return true;
+			}
+			moves.clear();
+		}
+	else
+	{
+		generateMoves(moves);
+		for (const auto m: moves)
+		{
+			if (m.targetSquare() == square)
+				return true;
+		}
+	}
+	return false;
+}
+
+Move KnightMateBoard::moveFromSanString(const QString& str)
+{
+	if (!str.startsWith(pieceSymbol(King).toUpper()))
+		return WesternBoard::moveFromSanString(str);  //main path
+
+	// besides O-O/O-O-O also accepts Kc1/Kc8/Kg1/Kg8 format for castling
+	Side side = sideToMove();
+	int target = squareIndex(str.mid(1));
+
+	if (hasCastlingRight(side, QueenSide)
+	&&  target == kingSquare(side) + castlingFile(QueenSide) - 4)
+		return moveFromSanString("O-O-O");
+
+	if (hasCastlingRight(side, KingSide)
+	&&  target == kingSquare(side) + castlingFile(KingSide) - 4)
+		return moveFromSanString("O-O");
+
+	return WesternBoard::moveFromSanString(str); // other king moves
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/knightmateboard.h
+++ b/projects/lib/src/board/knightmateboard.h
@@ -1,0 +1,63 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KNIGHTMATEBOARD_H
+#define KNIGHTMATEBOARD_H
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Knight Mate Chess
+ *
+ * Knight Mate chess is a variant of standard chess but with king and knight
+ * movements interchanged. Introduced by Bruce Zymov, 1972.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Chess_variant
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ */
+class LIB_EXPORT KnightMateBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new KnightMateBoard object. */
+		KnightMateBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Special piece types for Knightmate */
+		enum KnightMatePieceType
+		{
+			Mann = King + 1	//!< Mann (Commoner, moves like a chess king)
+		};
+		// Inherited from WesternBoard
+		void virtual generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+		virtual Move moveFromSanString(const QString& str);
+};
+
+} // namespace Chess
+#endif // KNIGHTMATEBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -274,6 +274,16 @@ void tst_Board::moveStrings_data() const
 		<< "e8b8 g1e3 h8g6 e1i1"
 		<< "r3kqbnjr/pppp1ppppp/2jn1b4/4p5/4P5/3Q1PNJ2/PPPP2PPPP/RJNBK1B2R b KQkq - 0 1"
 		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
+	QTest::newRow("knightmate castling san1")
+		<< "knightmate"
+		<< "O-O Be6 Bxe6 Qxe6 Re1 O-O-O"
+		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
+		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
+	QTest::newRow("knightmate castling san2")
+		<< "knightmate"
+		<< "Kg1 Be6 Bxe6 Qxe6 Re1 O-O-O"
+		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
+		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
 }
 
 void tst_Board::moveStrings()
@@ -618,6 +628,13 @@ void tst_Board::perft_data() const
 		<< "rjnbkqbnjr/pppppppppp/10/10/10/10/PPPPPPPPPP/RJNBKQBNJR w KQkq - 0 1"
 		<< 4 //4 plies: 772074, 5 plies: 26869186
 		<< Q_UINT64_C(772074);
+
+	variant = "knightmate";
+	QTest::newRow("knightmate startpos")
+		<< variant
+		<< "rmbqkbmr/pppppppp/8/8/8/8/PPPPPPPP/RMBQKBMR w KQkq - 0 1"
+		<< 5 //4 plies: 139774, 5 plies: 3249033, 6 plies: 74568983
+		<< Q_UINT64_C(3249033);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a patch to support **Knightmate**. Here kings move like standard knights and vice versa. Castling moves are unchanged /wrt standard chess. 

I tested this implementation with some versions of _Fairy Max_ and _Sjaak II_. On the board the `King` is represented graphically by a `Knight` piece and the standard Knights are replaced by `Mann` or `Commoner` pieces that look like standard Kings.

