### PR TITLE
support Grid Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -57,12 +57,18 @@ Checkless Chess
 Chessgi / Drop Chess
 .It crazyhouse
 Crazyhouse (Drop Chess Variant)
+.It displacedgrid
+Displaced Grid Chess
 .It extinction
 Extinction Chess
 .It fischerandom
 Fischer Random Chess / Chess 960
 .It gothic
 Gothic Chess
+.It grid
+Grid Chess
+.It gridolina
+Berolina Grid Chess
 .It horde
 Horde Chess (v2)
 .It janus
@@ -79,6 +85,8 @@ Loop Chess (Drop Chess Variant)
 Loser's Chess
 .It racingkings
 Racing Kings Chess
+.It slippedgrid
+Slipped Grid Chess
 .It superandernach
 Super-Andernach Chess
 .It standard

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -21,9 +21,12 @@ Options:
 			'checkless': Checkless Chess
 			'chessgi': Chessgi (Drop Chess)
 			'crazyhouse': Crazyhouse (Drop Chess)
+			'discplacedgrid': Displaced Grid Chess
 			'extinction': Extinction Chess
 			'fischerandom': Fischer Random Chess/Chess 960
 			'gothic': Gothic Chess
+			'grid': Grid Chess
+			'gridolina': Berolina Grid Chess
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
 			'kinglet': Kinglet Chess
@@ -32,6 +35,7 @@ Options:
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
 			'racingkings': Racing Kings Chess
+			'slippedgrid': Slipped Grid Chess
 			'superandernach': Super-Andernach Chess
 			'standard': Standard Chess (default).
   -concurrency N	Set the maximum number of concurrent games to N

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -7,6 +7,8 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/andernachboard.cpp \
     $$PWD/berolinaboard.cpp \
     $$PWD/racingkingsboard.cpp \
+    $$PWD/restrictedmoveboard.cpp \
+    $$PWD/gridboard.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/extinctionboard.cpp \
     $$PWD/kingofthehillboard.cpp \
@@ -40,6 +42,8 @@ HEADERS += $$PWD/board.h \
     $$PWD/andernachboard.h \
     $$PWD/berolinaboard.h \
     $$PWD/racingkingsboard.h \
+    $$PWD/restrictedmoveboard.h \
+    $$PWD/gridboard.h \
     $$PWD/capablancaboard.h \
     $$PWD/extinctionboard.h \
     $$PWD/kingofthehillboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -25,6 +25,7 @@
 #include "extinctionboard.h"
 #include "frcboard.h"
 #include "gothicboard.h"
+#include "gridboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
 #include "losersboard.h"
@@ -50,10 +51,13 @@ REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
+REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
 REGISTER_BOARD(ExtinctionBoard, "extinction")
 REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GothicBoard, "gothic")
+REGISTER_BOARD(GridBoard, "grid")
+REGISTER_BOARD(BerolinaGridBoard, "gridolina")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
@@ -61,6 +65,7 @@ REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")
 

--- a/projects/lib/src/board/gridboard.cpp
+++ b/projects/lib/src/board/gridboard.cpp
@@ -1,0 +1,130 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gridboard.h"
+
+namespace Chess {
+
+GridBoard::GridBoard() : RestrictedMoveBoard() {}
+
+Board* GridBoard::copy() const
+{
+	return new GridBoard(*this);
+}
+
+QString GridBoard::variant() const
+{
+	return "grid";
+}
+
+QString GridBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool GridBoard::leavesRegion(const Move& move, int fs, int rs) const
+{
+	Square sourceSq = chessSquare(move.sourceSquare());
+	Square targetSq = chessSquare(move.targetSquare());
+
+	return ((sourceSq.file() - fs) / 2 != (targetSq.file() - fs) / 2)
+	||      (sourceSq.rank() - rs) / 2 != (targetSq.rank() - rs) / 2;
+}
+
+bool GridBoard::restriction(const Move& move, bool) const
+{
+	return leavesRegion(move);
+}
+
+
+
+DisplacedGridBoard::DisplacedGridBoard() : GridBoard() {}
+
+Board* DisplacedGridBoard::copy() const
+{
+	return new DisplacedGridBoard(*this);
+}
+
+QString DisplacedGridBoard::variant() const
+{
+	return "displacedgrid";
+}
+
+QString DisplacedGridBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool DisplacedGridBoard::restriction(const Move& move, bool) const
+{
+	return leavesRegion(move, -1, -1);
+}
+
+
+
+SlippedGridBoard::SlippedGridBoard() : GridBoard() {}
+
+Board* SlippedGridBoard::copy() const
+{
+	return new SlippedGridBoard(*this);
+}
+
+QString SlippedGridBoard::variant() const
+{
+	return "slippedgrid";
+}
+
+QString SlippedGridBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool SlippedGridBoard::restriction(const Move& move, bool) const
+{
+	return leavesRegion(move, -1, 0);
+}
+
+
+
+BerolinaGridBoard::BerolinaGridBoard() : GridBoard()
+{
+ /*
+  * Berolina pawns move one square diagonally forward and they capture
+  * one square straight ahead.
+  */
+	m_pawnSteps.clear();
+	m_pawnSteps += {FreeStep, -1};
+	m_pawnSteps += {CaptureStep, 0};
+	m_pawnSteps += {FreeStep, 1};
+}
+
+Board* BerolinaGridBoard::copy() const
+{
+	return new BerolinaGridBoard(*this);
+}
+
+QString BerolinaGridBoard::variant() const
+{
+	return "gridolina";
+}
+
+QString BerolinaGridBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/gridboard.h
+++ b/projects/lib/src/board/gridboard.h
@@ -1,0 +1,150 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GRIDBOARD_H
+#define GRIDBOARD_H
+
+#include "restrictedmoveboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Grid Chess
+ *
+ * Grid Chess is a variant of standard chess with an additional rule.
+ * The board is divided into 16 quadratic regions of 2x2 squares.
+ * Moves within a region are forbidden.
+ *
+ * As a consequence a piece cannot be captured or protected from inside
+ * its own region. A king cannot be checked from inside his own region.
+ *
+ * Introduced by Walter Stead in 1952.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Grid_chess
+ */
+class LIB_EXPORT GridBoard : public RestrictedMoveBoard
+{
+	public:
+		/*! Creates a new GridBoard object. */
+		GridBoard();
+
+		// Inherited from RestrictedMoveBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from RestrictedMoveBoard
+		virtual bool restriction(const Move& move,
+					 bool reverse = false) const;
+
+		/*!
+		 * Returns true if the \a move targets a different region
+		 * else false. Possible displacement of the grid is given by
+		 * file shift \a fs and rank shift \a rs.
+		 */
+		bool leavesRegion(const Move& move,
+				  int fs = 0,
+				  int rs = 0) const;
+};
+
+/*!
+ * \brief A board for Displaced-grid Chess
+ *
+ * Displaced-grid Chess is a variant of Grid Chess. The grid is shifted
+ * by one rank and one file. There are 25 regions of nine central 2x2,
+ * twelve 1x2 (or 2x1) and four 1x1 cells at the corners.
+ *
+ * Introduced by Doug Grant in 1974, the variant is also known as DGChess.
+ *
+ * \sa GridBoard
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Grid_chess
+ */
+class LIB_EXPORT DisplacedGridBoard : public GridBoard
+{
+	public:
+		/*! Creates a new DisplacedGridBoard object. */
+		DisplacedGridBoard();
+
+		// Inherited from GridBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from GridBoard
+		virtual bool restriction(const Move& move,
+					 bool reverse = false) const;
+};
+
+/*!
+ * \brief A board for Slipped-grid Chess
+ *
+ * Slipped-grid Chess is a variant of Grid Chess. The grid is shifted
+ * by one file. There are 20 regions of twelve 2x2, and eight 2x1 cells
+ * at the sides.
+ *
+ * \sa GridBoard
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Grid_chess
+ */
+class LIB_EXPORT SlippedGridBoard : public GridBoard
+{
+	public:
+		/*! Creates a new SlippedGridBoard object. */
+		SlippedGridBoard();
+
+		// Inherited from GridBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from GridBoard
+		virtual bool restriction(const Move& move,
+					 bool reverse = false) const;
+};
+
+/*!
+ * \brief A board for Berolina Grid Chess
+ *
+ * Berolina Grid Chess is a combination of Grid Chess and Berolina Chess.
+ * The Berolina pawns move one step diagonally and capture straight.
+ * In the grid they are more mobile than orthodox pawns.
+ *
+ * Introduced in NOST.
+ *
+ * \sa GridBoard
+ * \sa BerolinaBoard
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Grid_chess
+ */
+class LIB_EXPORT BerolinaGridBoard : public GridBoard
+{
+	public:
+		/*! Creates a new BerolinaGridBoard object. */
+		BerolinaGridBoard();
+
+		// Inherited from GridBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+};
+
+} // namespace Chess
+#endif // GRIDBOARD_H

--- a/projects/lib/src/board/restrictedmoveboard.cpp
+++ b/projects/lib/src/board/restrictedmoveboard.cpp
@@ -1,0 +1,71 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "restrictedmoveboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+RestrictedMoveBoard::RestrictedMoveBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+bool RestrictedMoveBoard::vIsLegalMove(const Move& move)
+{
+	if (!restriction(move))
+		return false;
+
+	return WesternBoard::vIsLegalMove(move);
+}
+
+bool RestrictedMoveBoard::inCheck(Side side, int square) const
+{
+	if (!WesternBoard::inCheck(side, square))
+		return false;
+
+	if (square == 0)
+		square = kingSquare(side);
+
+	QVarLengthArray <Move> moves;
+	if (sideToMove() == side)
+		// needs symmetry of piece movement of both sides
+		for (int type = Pawn; type <= King; type++)
+		{
+			generateMovesForPiece(moves, type, square);
+			for (const auto m: moves)
+			{
+				if (captureType(m) == type
+				&&  restriction(m, true))
+					return true;
+			}
+			moves.clear();
+		}
+	else
+	{
+		generateMoves(moves);
+		for (const auto m: moves)
+		{
+			if (m.targetSquare() == square
+			&&  restriction(m))
+				return true;
+		}
+	}
+	return false;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/restrictedmoveboard.h
+++ b/projects/lib/src/board/restrictedmoveboard.h
@@ -1,0 +1,53 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef RESTRICTEDMOVEBOARD_H
+#define RESTRICTEDMOVEBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A base class for boards.
+ * It is intended for chess variants of standard
+ * chess with additional move restrictions
+ *
+ * \sa GridBoard
+ */
+class LIB_EXPORT RestrictedMoveBoard : public WesternBoard
+{
+	protected:
+		/*! Creates a new RestrictedMoveBoard object. */
+		RestrictedMoveBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const = 0;
+		virtual bool vIsLegalMove(const Move& move);
+		virtual bool inCheck(Side side, int square = 0) const;
+
+		/*!
+		 * Returns true if \a move fulfills the additional game rules.
+		 * Set \a reverse to true if this is a move of the opponent
+		 * side (not the side to move). Default value is false.
+		 */
+		virtual bool restriction(const Move& move,
+					 bool reverse = false) const = 0;
+};
+
+} // namespace Chess
+#endif // RESTRICTEDMOVEBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -453,6 +453,29 @@ void tst_Board::results_data() const
 		<< variant
 		<< "K5kr/5Q2/8/8/8/8/8/8 b - - 0 1"
 		<< "1-0";
+
+	variant = "grid";
+
+	QTest::newRow("grid white win")
+		<< variant
+		<< "r6r/2kRN2p/pp6/2p5/5B2/3P1P2/PP3P1P/6K1 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("grid black win")
+		<< variant
+		<< "8/8/1p3R2/pkp5/2b1P1r1/5N2/Pb3P1P/3R2K1 w - - 2 28"
+		<< "0-1";
+	QTest::newRow("grid black win2")
+		<< variant
+		<< "Q1bk1bnr/8/3p2p1/p3p3/8/4P3/PPPP2PP/RNB1K1qR w KQ - 0 1"
+		<< "0-1";
+	QTest::newRow("grid white win2")
+		<< variant
+		<< "r1bqkbnr/p1p1pppp/1pBp4/8/8/4P3/PPPP1PPP/RNBQK1NR b KQkq - 0 4"
+		<< "1-0";
+	QTest::newRow("grid draw stalemate")
+		<< variant
+		<< "8/8/8/8/pk6/KP6/2r5/8 w - - 0 1"
+		<< "1/2-1/2";
 }
 
 void tst_Board::results()
@@ -633,6 +656,54 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4897256);
+
+	variant = "grid";
+	QTest::newRow("grid startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  // 4 plies: 173165, 5 plies: 3814913, 6 plies: 83288561
+		<< Q_UINT64_C(3814913);
+	QTest::newRow("grid pos2")
+		<< variant
+		<< "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -"
+		<< 4
+		<< Q_UINT64_C(1853429);
+	QTest::newRow("grid pos3")
+		<< variant
+		<< "8/3K4/2p5/p2b2r1/5k2/8/8/1q6 b - -"
+		<< 2
+		<< Q_UINT64_C(142);
+	QTest::newRow("grid pos4")
+		<< variant
+		<< "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -"
+		<< 6
+		<< Q_UINT64_C(1477948);
+	QTest::newRow("grid pos5")
+		<< variant
+		<< "r1bqkbnr/pppppppp/n7/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq -"
+		<< 5 // 3 plies: 8768, 4 plies: 177309, 5 plies: 4069318
+		<< Q_UINT64_C(4069318);
+
+	variant = "displacedgrid";
+	QTest::newRow("displacedgrid startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  // 4 plies: 31057, 5 plies: 537400, 6 plies: 9222549
+		<< Q_UINT64_C(537400);
+
+	variant = "slippedgrid";
+	QTest::newRow("slippedgrid startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5  // 4 plies: 176529, 5 plies: 3953321, 6 plies: 87774558
+		<< Q_UINT64_C(3953321);
+
+	variant = "gridolina";
+	QTest::newRow("gridolina startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4  // 4 plies: 798011, 5 plies: 24033022
+		<< Q_UINT64_C(798011);
 
 	variant = "janus";
 	QTest::newRow("janus startpos")


### PR DESCRIPTION
This is a suggestion to support Grid Chess, a chess variant with an additional move restriction.

The board is devided into regions of 2x2 square. Moves within the regions are forbidden. So a piece cannot be captured or protected from inside its region. A king can not be checked from inside its region.

The implementation of `GridBoard` uses `RestrictedMoveBoard` as base class. This class can also be re-used for other variants.

_Grid Chess_ is accompanied by some related variants, where either the grid is displaced by file and rank or berolina pawns are used which more easily move between the grid's regions.

GridChessBoard has been tested manually and by engine-engine play with a hacked-up version of _Sloppy_.

The other variants have been tested manually.
I hope this is useful.
