### PR TITLE
SAN disambiguation for kings

### DIFF
--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -206,10 +206,8 @@ QString WesternBoard::sanMoveString(const Move& move)
 				str += checkOrMate;
 			return str;
 		}
-		else
-			str += pieceSymbol(piece).toUpper();
 	}
-	else	// not king or pawn
+	if (piece.type() != Pawn)	// not pawn
 	{
 		str += pieceSymbol(piece).toUpper();
 		QVarLengthArray<Move> moves;


### PR DESCRIPTION
This patch extends SAN move disambiguation to kings. This resolves errors in variants with possibly more than one king per side, e.g. _Antichess_ and _Suicide Chess_ , among others.

With two kings of the same colour on e4 and g4, a move to f4 will then have a notation `Kef4` or `Kgf4` (instead of `Kf4`).
