### PR TITLE
Separate UCI and Xboard high and mate scores

### DIFF
--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -40,17 +40,8 @@ QString evalString(const MoveEvaluation& eval)
 			str += "+";
 
 		// Detect mate-in-n scores
-
-		// convert new CECP mate scores to old ones if needed
-		if (absScore > 99900 && absScore < 100100)
-		{
-			absScore = 200000 - 2 * absScore + 30000;
-			if (score >= absScore)
-				absScore++;
-		}
-
-		if (absScore > 9900
-		&&  (absScore = 1000 - (absScore % 1000)) < 100)
+		if (absScore > 98800
+		&&  (absScore = 1000 - (absScore % 1000)) < 200)
 		{
 			if (score < 0)
 				str += "-";

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -417,9 +417,9 @@ void UciEngine::parseInfo(const QVarLengthArray<QStringRef>& tokens,
 				{
 					score = tokens[i].toString().toInt();
 					if (score > 0)
-						score = 30001 - score * 2;
+						score = 99000 + 1 - score * 2;
 					else if (score < 0)
-						score = -30000 - score * 2;
+						score = -99000 - score * 2;
 				}
 				else if (tokens[i - 1] == "lowerbound"
 				     ||  tokens[i - 1] == "upperbound")

--- a/projects/lib/src/xboardengine.h
+++ b/projects/lib/src/xboardengine.h
@@ -66,6 +66,7 @@ class LIB_EXPORT XboardEngine : public ChessEngine
 		void sendTimeLeft();
 		void finishGame();
 		QString moveString(const Chess::Move& move);
+		int adaptScore(int score) const;
 		
 		bool m_forceMode;
 		bool m_drawOnNextMove;


### PR DESCRIPTION
Very high non-mate scores of UCI engines collide with the xboard mate score detection. Most engines are using lower scores, but e.g. _Houdini 5_ issues very high scores. For example, a UCI score of 99.99 gets translated to +M1, a false positive mate score. Reference: #250 

This patch moves most of the mate score preparation for xboard-scores from `ChessGame` into `XboardEngine`. The virtual mate scores now are mapped into the range around 98000 cp. `UciEngine` was adapted accordingly.

Remarks:
- While there I made a correction to the code for new Xboard scores.
- The choice 99000 for the virtual mate score was deliberate. It could be lower or higher. I also tried to use 200000 but then the output does not quite fit into the "Score" field on screen, but one could of course widen it.
- The vast majority of UCI and Xboard engines give scores which are correctly interpreted.
I have seen peculiar behaviour of some engines:

```
----------------------------
Matescores: 

1 sjeng 1 ply off: +M2 in M1 position.
1 nemorino  +M1 in +M3 position, 0.00 in win +M1: UCI win one move off, losing scores OK
H pulsar2009-9b-64 -M2 and -M1 in -M4 and -M2 positions: counts moves
2 baislicka -M12 -M8 -M4 in -M6, -M4, and -M2 positions
2 zetadva0301 -M4, -M8 in -M2, -M4 positions
2 gnucheese jumps +M18, +M14, +M10, +M6, +M2
2 olithink -M12, -M8, -M4
3 crafty -327.65 in -M2 position, 327.66 in +M1 position
3 crafty-25.2 -327.65 in -M2 position 327.66 in +M1 position
3 Gull3 -327.56 in -M2 position
3 Gull3 327.59 for +M1
8 fairymax 4.8Q -79.99 in -M2, -79.98 in -M4
8 shamax -79.99 in -M2 position
8 kingslayer -79.98 and -79.99 in -M4 and -M2 positions
* sjaakii -159.98 in -M2 position, 159.99 on UCI interface, problem created
* tunguska 299.99 for +M1 on UCI, problem created
0 amoeba-2.5.l64p omitted last losing score in -M2 position
0 hoichess-0.19.0 omits score in -M2 position
0 hoichess sometimes omits scores, sequence ok
5 heracles -100.07 in -M2 position
5 heracles UCI no mate score -100.09 is -M2
5 heracles UCI no mate score -100.15 is -M2
7  pulsar2009-9b-64 -74.98 in -M2 (antichess)
- wyldchess1.2_fast_tc_popcnt -298.69 in losing position -M4
- wyldchess1.2 (xboard) -298.71 in losing position -M2
- galjoen-0.34 (xboard) -10.46 and -0.01 in -M4 and -M2 positions (!!)
- galjoen-0.34 (xboard) -0.01/2 amd 0.00/1 in -M4 and -M2 (!!)
  galjoen-0.34 UCI OK
- hedwig -99.35 for -M2.
- hedwig -98.80 for -M2.

Classification:  
0 omits score ocasionally
1 ply or move off
2 doubled distance (taken ply for move?)
H half distance (taken move for ply?)
3 mate score around 32767   
5 special score around 10000
7 mate score of 7500
8 mate score of 8000
* using UCI but not using the mate token
- peculiar scores

```

This PR maintains the score as `int `and does not introduce additional qualifiers into `MoveEvaluation`.
HTH. 