### PR TITLE
Support variant Two Kings Each (Wild9)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -89,12 +89,16 @@ Loop Chess (Drop Chess Variant)
 Loser's Chess
 .It racingkings
 Racing Kings Chess
-.It suicide
-Suicide Chess (Losing Chess Variant)
 .It slippedgrid
 Slipped Grid Chess
+.it sortland9
+Symmetrized Wild 9
+.It suicide
+Suicide Chess (Losing Chess Variant)
 .It superandernach
 Super-Andernach Chess
+.It twokings
+Two Kings Each Chess (Wild 9)
 .It standard
 Standard Chess (default)
 .El

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -38,9 +38,11 @@ Options:
 			'losers': Loser's Chess
 			'racingkings': Racing Kings Chess
 			'slippedgrid': Slipped Grid Chess
-			'superandernach': Super-Andernach Chess
-			'standard': Standard Chess (default).
+			'sortland9': Symmetrical Two Kings Each Chess
 			'suicide': Suicide Chess (Losing Chess)
+			'superandernach': Super-Andernach Chess
+			'twokings': Two Kings Each Chess (Wild 9)
+			'standard': Standard Chess (default).
   -concurrency N	Set the maximum number of concurrent games to N
   -draw movenumber=NUMBER movecount=COUNT score=SCORE
 			Adjudicate the game as a draw if the score of both

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -15,6 +15,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/hordeboard.cpp \
     $$PWD/janusboard.cpp \
     $$PWD/knightmateboard.cpp \
+    $$PWD/twokingseachboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
     $$PWD/frcboard.cpp \
@@ -53,6 +54,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/hordeboard.h \
     $$PWD/janusboard.h \
     $$PWD/knightmateboard.h \
+    $$PWD/twokingseachboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \
     $$PWD/frcboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -43,6 +43,7 @@
 #include "racingkingsboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
+#include "twokingseachboard.h"
 
 namespace Chess {
 
@@ -73,10 +74,12 @@ REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")
+REGISTER_BOARD(TwoKingsEachBoard, "twokings")
 
 
 ClassRegistry<Board>* BoardFactory::registry()

--- a/projects/lib/src/board/twokingseachboard.cpp
+++ b/projects/lib/src/board/twokingseachboard.cpp
@@ -1,0 +1,206 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "twokingseachboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+TwoKingsEachBoard::TwoKingsEachBoard()
+	: WesternBoard(new WesternZobrist()),
+	  m_symmetrical(false),
+	  m_castlingSourceFile(4)
+{
+}
+
+Board* TwoKingsEachBoard::copy() const
+{
+	return new TwoKingsEachBoard(*this);
+}
+
+QString TwoKingsEachBoard::variant() const
+{
+	return "twokings";
+}
+
+QString TwoKingsEachBoard::defaultFenString() const
+{
+	return "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1";
+}
+
+void TwoKingsEachBoard::vInitialize()
+{
+	m_symmetrical = isSymmetrical();
+	WesternBoard::vInitialize();
+}
+
+bool TwoKingsEachBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings > 0 && blackKings > 0;
+}
+
+bool TwoKingsEachBoard::isSymmetrical() const
+{
+	return false;
+}
+
+int TwoKingsEachBoard::royalKingSquare(Side side) const
+{
+	Q_ASSERT(!side.isNull());
+	bool reverseOrder = m_symmetrical && side == Side::Black;
+	int boardWidth = width();
+	int boardHeight = height();
+
+	for (int file = 0; file < boardWidth; file++)
+		for (int rank = 0; rank < boardHeight; rank++)
+		{
+			int relativeRank = reverseOrder ?
+				boardHeight - 1 - rank: rank;
+			Square sq = Square(file, relativeRank);
+			Piece piece = pieceAt(sq);
+
+			if (piece.type() == King
+			&&  piece.side() == side)
+				return squareIndex(sq);
+		}
+	return 0;
+}
+
+bool TwoKingsEachBoard::inCheck(Side side, int square) const
+{
+	if (square == 0)
+		square = royalKingSquare(side);
+
+	return WesternBoard::inCheck(side, square);
+}
+
+void TwoKingsEachBoard::generateMovesForPiece(QVarLengthArray< Move >& moves, int pieceType, int square) const
+{
+	if (pieceType != King)
+		return WesternBoard::generateMovesForPiece(moves,
+							   pieceType,
+							   square);
+
+	QVarLengthArray< Move > testmoves;
+	WesternBoard::generateMovesForPiece(testmoves, King, square);
+
+	for (const auto& move : testmoves)
+	{
+		int src = move.sourceSquare();
+		int tgt = move.targetSquare();
+		Square srcSq = chessSquare(src);
+		Square tgtSq = chessSquare(tgt);
+		// only use non-castling moves
+		if (abs(srcSq.file() - tgtSq.file()) <= 1)
+			moves.append(move);
+	}
+	// castling
+	Side side = sideToMove();
+	Square sq = chessSquare(square);
+	int rrank = (side == Side::White) ? sq.rank()
+					  : height() - 1 - sq.rank();
+	int rookSqQ = square - m_castlingSourceFile;
+	int rookSqK = rookSqQ + width() - 1;
+
+	if (sq.file() == m_castlingSourceFile && rrank == 0)
+	{
+		bool freeK = true;
+		bool freeQ = true;
+		for (int index = square + 1; index < rookSqK; index++)
+			if (!pieceAt(index).isEmpty())
+				freeK = false;
+		for (int index = rookSqQ + 1; index < square; index++)
+			if (!pieceAt(index).isEmpty())
+				freeQ = false;
+
+		if (hasCastlingRight(side, KingSide) && freeK)
+			moves.append(Move(square, rookSqK));
+
+		if (hasCastlingRight(side, QueenSide) && freeQ)
+			moves.append(Move(square, rookSqQ));
+	}
+}
+
+Move TwoKingsEachBoard::moveFromLanString(const QString& str)
+{
+	Move move(Board::moveFromLanString(str));
+
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	Piece piece = pieceAt(source);
+	int srcFile = chessSquare(source).file();
+	int tgtFile = chessSquare(target).file();
+
+	if (piece.type() == King
+	&&  qAbs(srcFile - tgtFile) > 1)
+	{
+		// find out which target square is needed by WesternBoard
+		Side side = sideToMove();
+		Move move1 = Move(kingSquare(side), target);
+		QString str2(lanMoveString(move1));
+		Move move2 = WesternBoard::moveFromLanString(str2);
+		Move move3 = Move(source, move2.targetSquare());
+		return move3;
+	}
+
+	return move;
+}
+
+Move TwoKingsEachBoard::moveFromSanString(const QString& str)
+{
+	if (!str.startsWith("O-O"))
+		return WesternBoard::moveFromSanString(str);
+
+	Side side = sideToMove();
+	int srcFile = m_castlingSourceFile;
+	int rank = (side == Side::White) ? 0 : height() - 1;
+	int tgtFile = (str.startsWith("O-O-O")) ? 0 : width() - 1;
+	Square srcSq = Square(srcFile, rank);
+	Square tgtSq = Square(tgtFile, rank);
+
+	Move move(squareIndex(srcSq), squareIndex(tgtSq));
+	return move;
+}
+
+
+
+TwoKingsSymmetricalBoard::TwoKingsSymmetricalBoard()
+	: TwoKingsEachBoard()
+{
+}
+
+Board* TwoKingsSymmetricalBoard::copy() const
+{
+	return new TwoKingsSymmetricalBoard(*this);
+}
+
+QString TwoKingsSymmetricalBoard::variant() const
+{
+	return "sortland9";
+}
+
+bool TwoKingsSymmetricalBoard::isSymmetrical() const
+{
+	return true;
+}
+
+QString TwoKingsSymmetricalBoard::defaultFenString() const
+{
+	return "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1";
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/twokingseachboard.h
+++ b/projects/lib/src/board/twokingseachboard.h
@@ -1,0 +1,106 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TWOKINGSEACHBOARD_H
+#define TWOKINGSEACHBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Two Kings Each Chess (or Wild 9)
+ *
+ * Two Kings Each is a variant of standard chess with two kings on both
+ * sides. The kings' roles depend on the position. Only the king that is
+ * closer to the a-file is royal and it is exposed to check and mate.
+ * If the kings are on the same file the king closer to (White's) first
+ * rank is royal. The other king is a normal piece and can be captured.
+ * Giving mate to the royal king wins.
+ *
+ * Introduced on the ICC as wild/9.
+ * \note Rules: https://www.chessclub.com/user/help/wild9
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ */
+class LIB_EXPORT TwoKingsEachBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new TwoKingsEachBoard object. */
+		TwoKingsEachBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+	protected:
+		virtual void vInitialize();
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+		virtual Move moveFromLanString(const QString& str);
+		virtual Move moveFromSanString(const QString& str);
+
+		/*!
+		 * This defines the symmetry of the game:
+		 * The returned value is false per default: Black kings
+		 * refer to white's base rank (square a1).
+		 * If configured to return true then both sides refer to
+		 * their own base rank (squares a1/a8).
+		 */
+		virtual bool isSymmetrical() const;
+		/*!
+		 * Returns the square index of the royal king of given \a side.
+		 */
+		virtual int royalKingSquare(Side side) const;
+	private:
+		bool m_symmetrical;
+		const int m_castlingSourceFile;
+};
+
+
+
+/*!
+ * \brief A board for Two Kings Each Chess, symmetrical version
+ *
+ * This version of Two Kings Each Chess is more balanced for the sides.
+ * When a side's kings are on the same file the king closer to its own
+ * base rank is royal.
+ *
+ * Symmetry suggested by Jon Åsvang, Norway 2017.
+ *
+ * \sa TwoKingsEachBoard
+ */
+class LIB_EXPORT TwoKingsSymmetricalBoard : public TwoKingsEachBoard
+{
+	public:
+		/*! Creates a new TwoKingsSymmetricalBoard object. */
+		TwoKingsSymmetricalBoard();
+
+		// Inherited from TwoKingsEachBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual bool isSymmetrical() const;
+};
+
+} // namespace Chess
+
+#endif // TWOKINGSEACHBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -486,6 +486,17 @@ void tst_Board::results_data() const
 		<< variant
 		<< "8/8/8/8/pk6/KP6/2r5/8 w - - 0 1"
 		<< "1/2-1/2";
+
+	variant = "twokings";
+
+	QTest::newRow("twokings black win1")
+		<< variant
+		<< "8/2k5/4b1Pp/2p3K1/8/2P1p3/2k2q1K/B7 w - - 0 59"
+		<< "0-1";
+	QTest::newRow("twokings black win2")
+		<< variant
+		<< "8/8/8/8/2k5/4kK2/5K2/2q5 w - - 0 1"
+		<< "0-1";
 }
 
 void tst_Board::results()
@@ -773,6 +784,30 @@ void tst_Board::perft_data() const
 		<< "8/k1KP4/8/8/8/8/8/6n1 b - - 0 1"
 		<< 7  //7 plies: 2891980
 		<< Q_UINT64_C(2891980);
+
+	variant = "twokings";
+	QTest::newRow("twokings startpos")
+		<< variant
+		<< "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1"
+		//asymmetrical variant 4 plies: 192312, 5 plies: 4629168, 6 plies: 110762251
+		// symmetrical variant 4 plies: 192332, 5 plies: 4629764, 6 plies: 110829475
+		<< 5
+		<< Q_UINT64_C(4629168);
+	QTest::newRow("twokings endgame1")
+		<< variant
+		<< "8/8/p1k5/1p1r1K1p/1P5P/P1K5/8/8 b - - 0 121"
+		// 3 plies:3076, 4 plies: 36828
+		<< 4
+		<< Q_UINT64_C(36828);
+
+	variant = "sortland9";
+	QTest::newRow("twokings symmetrical variant, startpos")
+		<< variant
+		<< "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1"
+		//asymmetrical variant 4 plies: 192312, 5 plies: 4629168, 6 plies: 110762251
+		// symmetrical variant 4 plies: 192332, 5 plies: 4629764, 6 plies: 110829475
+		<< 4
+		<< Q_UINT64_C(192332);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This is a suggestion to support the chess variant _Two Kings Each_, also known as _wild9_, as per user request (discussion among other topics in #242). It is played on chess server ICC. 

Wild 9 is a variant with two Kings on each side. Only the King of either side that is currently closer to the a-file is royal and subject to check and mate. The other King is a normal piece and can be captured. Only the king starting on the e-file is able to castle. The castling rights are lost when any of the two kings of a side moves.

When two kings of a side are on the same file, the king closer to the first white rank is royal (i.e both sides refer to square a1), so the game has an asymmetry.

The `twokings` implementation `TwokingsEachBoard` has been tested with the existing engine pulsar2009-9b-64 and with the new engine by H. G. Muller, TK-max, a fairymax derivative. 

A symmetric subvariant has been proposed by @Nordlandia to reduce the white advantage, with black referring to the square a8 instead of a1. This subvariant is supported in `TwoKingsSymmetricalBoard` with ad-hoc variant name `sortland9`.

This variant has also been tested (albeit in a patched state to match the variant strings) with the help of TK-max and the white advantage seems to be less.


