### PR TITLE
support Three Kings Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -97,6 +97,8 @@ Symmetrized Wild 9
 Suicide Chess (Losing Chess Variant)
 .It superandernach
 Super-Andernach Chess
+.It threekings
+Three Kings Chess
 .It twokings
 Two Kings Each Chess (Wild 9)
 .It standard

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -41,6 +41,7 @@ Options:
 			'sortland9': Symmetrical Two Kings Each Chess
 			'suicide': Suicide Chess (Losing Chess)
 			'superandernach': Super-Andernach Chess
+			'threekings': Three Kings Chess
 			'twokings': Two Kings Each Chess (Wild 9)
 			'standard': Standard Chess (default).
   -concurrency N	Set the maximum number of concurrent games to N

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -11,6 +11,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/gridboard.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/extinctionboard.cpp \
+    $$PWD/threekingsboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
     $$PWD/janusboard.cpp \
@@ -50,6 +51,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/gridboard.h \
     $$PWD/capablancaboard.h \
     $$PWD/extinctionboard.h \
+    $$PWD/threekingsboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \
     $$PWD/janusboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -23,6 +23,7 @@
 #include "capablancaboard.h"
 #include "caparandomboard.h"
 #include "checklessboard.h"
+#include "chessgiboard.h"
 #include "crazyhouseboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
@@ -31,18 +32,15 @@
 #include "gridboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
-#include "losersboard.h"
-#include "standardboard.h"
-#include "berolinaboard.h"
-#include "chessgiboard.h"
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
 #include "loopboard.h"
-#include "ncheckboard.h"
 #include "losersboard.h"
+#include "ncheckboard.h"
 #include "racingkingsboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
+#include "threekingsboard.h"
 #include "twokingseachboard.h"
 
 namespace Chess {
@@ -74,11 +72,12 @@ REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
-REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
+REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")
+REGISTER_BOARD(ThreeKingsBoard, "threekings")
 REGISTER_BOARD(TwoKingsEachBoard, "twokings")
 
 

--- a/projects/lib/src/board/threekingsboard.cpp
+++ b/projects/lib/src/board/threekingsboard.cpp
@@ -1,0 +1,78 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "threekingsboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+ThreeKingsBoard::ThreeKingsBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+Board* ThreeKingsBoard::copy() const
+{
+	return new ThreeKingsBoard(*this);
+}
+
+QString ThreeKingsBoard::variant() const
+{
+	return "threekings";
+}
+
+QString ThreeKingsBoard::defaultFenString() const
+{
+	return "knbqkbnk/pppppppp/8/8/8/8/PPPPPPPP/KNBQKBNK w - - 0 1";
+}
+
+bool ThreeKingsBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings == 3 && blackKings == 3;
+}
+
+bool ThreeKingsBoard::inCheck(Side, int) const
+{
+	return false;
+}
+
+Result ThreeKingsBoard::result()
+{
+	if (kingCount(Side::White) > kingCount(Side::Black))
+		return Result(Result::Win, Side::White,
+			      tr("White wins"));
+	if (kingCount(Side::Black) > kingCount(Side::White))
+		return Result(Result::Win, Side::Black,
+			      tr("Black wins"));
+	return WesternBoard::result();
+}
+
+/*! Returns number of kings of \a side */
+int ThreeKingsBoard::kingCount(Side side) const
+{
+	// Find the kings
+	int kingCount = 0;
+	for (int sq = 0; sq < arraySize(); sq++)
+	{
+		Piece tmp = pieceAt(sq);
+		if (tmp.type() == King && tmp.side() == side)
+			kingCount++;
+	}
+	return kingCount;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/threekingsboard.h
+++ b/projects/lib/src/board/threekingsboard.h
@@ -1,0 +1,56 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef THREEKINGSBOARD_H
+#define THREEKINGSBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Three Kings Chess
+ *
+ * Three Kings Chess is a variant of standard chess with three kings
+ * on both sides. There is no check. Capturing any king wins.
+ *
+ * Introduced by Adam Sobey at the Haslemere Chess Club, UK, December 1988.
+ * \note Rules: http://en.wikipedia.org/wiki/Chess_variant
+ *
+ * \note Standard Chess Rules: http://www.fide.com/component/handbook/?id=124&view=article
+ */
+class LIB_EXPORT ThreeKingsBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new ThreeKingsBoard object. */
+		ThreeKingsBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+	protected:
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool inCheck(Side side, int square = 0) const;
+	private:
+		int kingCount(Side side) const;
+};
+
+} // namespace Chess
+#endif // THREEKINGSBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -785,6 +785,13 @@ void tst_Board::perft_data() const
 		<< 7  //7 plies: 2891980
 		<< Q_UINT64_C(2891980);
 
+	variant = "threekings";
+	QTest::newRow("threekings startpos")
+		<< variant
+		<< "knbqkbnk/pppppppp/8/8/8/8/PPPPPPPP/KNBQKBNK w - - 0 1"
+		<< 5 //4 plies: 199514, 5 plies: 4971357, 6 plies: 123493813
+		<< Q_UINT64_C(4971357);
+
 	variant = "twokings";
 	QTest::newRow("twokings startpos")
 		<< variant


### PR DESCRIPTION
This is a proposal to support _Three Kings Chess_. This is a variant quite different from _Two kings Each (Wild9)_.

In this variant, both sides have three kings and all of these are normal pieces. There is no check. The side that catches one of the opponent's kings wins. The starting position has a king in the middle of the back rank, and there are no rooks but kings at the corners. So the defense has to be balanced.

This variant has been tested by manual play.
