### PR TITLE
KnightMate using new symbols, fix for castling notation in KnightMate and Janus

### DIFF
--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -23,6 +23,7 @@
 #include "capablancaboard.h"
 #include "caparandomboard.h"
 #include "checklessboard.h"
+#include "chessgiboard.h"
 #include "crazyhouseboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
@@ -31,15 +32,11 @@
 #include "gridboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
-#include "losersboard.h"
-#include "standardboard.h"
-#include "berolinaboard.h"
-#include "chessgiboard.h"
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
 #include "loopboard.h"
-#include "ncheckboard.h"
 #include "losersboard.h"
+#include "ncheckboard.h"
 #include "racingkingsboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
@@ -74,8 +71,8 @@ REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
-REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
+REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")

--- a/projects/lib/src/board/janusboard.cpp
+++ b/projects/lib/src/board/janusboard.cpp
@@ -62,11 +62,16 @@ int JanusBoard::castlingFile(CastlingSide castlingSide) const
 
 QString JanusBoard::sanMoveString(const Move& move)
 {
-	// uses Kb1/Kb8/Ki1/Ki8 for castling
 	QString san = WesternBoard::sanMoveString(move);
-	if (san == "O-O" || san == "O-O-O")
-		return pieceSymbol(King).toUpper() + lanMoveString(move).mid(2);
-	return san;
+
+	if (!san.startsWith("O-O"))
+		return san;
+
+	// uses Kb1/Kb8/Ki1/Ki8 for castling
+	QString sym = san.right(1);
+	if (sym != "+" && sym != "#")
+		sym.clear();
+	return pieceSymbol(King).toUpper() + lanMoveString(move).mid(2) + sym;
 }
 
 
@@ -76,10 +81,10 @@ Move JanusBoard::moveFromSanString(const QString& str)
 	 * accepts O-O and Kb1/Kb8/Ki1/Ki8 formats for castling
 	 * Xboard uses O-O for B-file and Ki1/Ki8 for I-file castling
 	 */
-	if (str == "O-O")
-		return WesternBoard::moveFromSanString("O-O-O");
-	if (str == "O-O-O")
+	if (str.startsWith("O-O-O"))
 		return WesternBoard::moveFromSanString("O-O");
+	if (str.startsWith("O-O"))
+		return WesternBoard::moveFromSanString("O-O-O");
 
 	if (!str.startsWith(pieceSymbol(King).toUpper()))
 		return WesternBoard::moveFromSanString(str);  //main path

--- a/projects/lib/src/board/knightmateboard.cpp
+++ b/projects/lib/src/board/knightmateboard.cpp
@@ -23,8 +23,8 @@ namespace Chess {
 KnightMateBoard::KnightMateBoard()
 	: WesternBoard(new WesternZobrist())
 {
-	setPieceType(King, tr("king"), "K", 0, "N");
-	setPieceType(Mann, tr("mann"), "M", 0, "K");
+	setPieceType(King, tr("king"), "K", 0, "RN");
+	setPieceType(Mann, tr("mann"), "M", 0);
 }
 
 Board* KnightMateBoard::copy() const
@@ -110,19 +110,31 @@ bool KnightMateBoard::inCheck(Side side, int square) const
 
 Move KnightMateBoard::moveFromSanString(const QString& str)
 {
-	if (!str.startsWith(pieceSymbol(King).toUpper()))
+	QString kingSymbol(pieceSymbol(King).toUpper());
+	if (!str.startsWith(kingSymbol))
 		return WesternBoard::moveFromSanString(str);  //main path
 
 	// besides O-O/O-O-O also accepts Kc1/Kc8/Kg1/Kg8 format for castling
 	Side side = sideToMove();
-	int target = squareIndex(str.mid(1));
+
+	// Identify check/mate/strong move/blunder notation
+	int ksymlen = kingSymbol.length();
+	int len = str.length();
+	const QString notation("+#!?");
+
+	while (notation.contains(str.at(len - 1)))
+		len--;
+
+	// Skip king symbol and omit trailing notation parts
+	int target = squareIndex(str.mid(ksymlen, len - ksymlen));
+	int kingFile = chessSquare(kingSquare(side)).file();
 
 	if (hasCastlingRight(side, QueenSide)
-	&&  target == kingSquare(side) + castlingFile(QueenSide) - 4)
+	&&  target == kingSquare(side) + castlingFile(QueenSide) - kingFile)
 		return moveFromSanString("O-O-O");
 
 	if (hasCastlingRight(side, KingSide)
-	&&  target == kingSquare(side) + castlingFile(KingSide) - 4)
+	&&  target == kingSquare(side) + castlingFile(KingSide) - kingFile)
 		return moveFromSanString("O-O");
 
 	return WesternBoard::moveFromSanString(str); // other king moves

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -266,7 +266,7 @@ void tst_Board::moveStrings_data() const
 		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
 	QTest::newRow("janus castling san2")
 		<< "janus"
-		<< "O-O Be3 Ng6 O-O-O"
+		<< "O-O Be3 Ng6 O-O-O!"
 		<< "r3kqbnjr/pppp1ppppp/2jn1b4/4p5/4P5/3Q1PNJ2/PPPP2PPPP/RJNBK1B2R b KQkq - 0 1"
 		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
 	QTest::newRow("janus castling lan")
@@ -276,7 +276,7 @@ void tst_Board::moveStrings_data() const
 		<< "1kr2qb1jr/pppp1ppppp/2jn1bn3/4p5/4P5/3QBPNJ2/PPPP2PPPP/RJNB3RK1 b - - 0 3";
 	QTest::newRow("knightmate castling san1")
 		<< "knightmate"
-		<< "O-O Be6 Bxe6 Qxe6 Re1 O-O-O"
+		<< "O-O Be6 Bxe6 Qxe6 Re1 O-O-O!"
 		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
 		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
 	QTest::newRow("knightmate castling san2")


### PR DESCRIPTION
This PR is intended for the maintainance of some recent additions

 and comprises of 3 parts: 

1) I suggest to change the graphical representation of KnightMate:
King to use Royal Knight graphical symbol instead of Knight symbol.
Mann to use Mann symbol instead of King symbol.

![km1](https://user-images.githubusercontent.com/6425738/29242509-f9b4a122-7f8e-11e7-85f6-f181ddea8728.png)


2) fix for Janus and Knightmate: I noticed that the SAN notation with trailing symbols, e.g.  O-O-O+ or O-O-O! was not processed correctly. 

3) remove some duplicate includes in boardfactory.cpp, They had slipped into master via my anti-0 branch.

HTH
