### PR TITLE
close initial game tab if unused

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -73,7 +73,8 @@ MainWindow::TabData::TabData(ChessGame* game, Tournament* tournament)
 MainWindow::MainWindow(ChessGame* game)
 	: m_game(nullptr),
 	  m_closing(false),
-	  m_readyToClose(false)
+	  m_readyToClose(false),
+	  m_firstTabAutoCloseEnabled(true)
 {
 	setAttribute(Qt::WA_DeleteOnClose, true);
 	setDockNestingEnabled(true);
@@ -426,6 +427,18 @@ void MainWindow::addGame(ChessGame* game)
 
 	m_tabs.append(tab);
 	m_tabBar->setCurrentIndex(m_tabBar->addTab(genericTitle(tab)));
+
+	// close initial tab if unused and if enabled by settings
+	if (m_tabs.size() >= 2
+	&&  m_firstTabAutoCloseEnabled)
+	{
+		if (QSettings().value("ui/close_unused_initial_tab", true).toBool()
+		&&  !m_tabs[0].m_game.isNull()
+		&&  m_tabs[0].m_game.data()->moves().isEmpty())
+			closeTab(0);
+
+		m_firstTabAutoCloseEnabled = false;
+	}
 
 	if (m_tabs.size() >= 2)
 		m_tabBar->parentWidget()->show();

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -154,6 +154,8 @@ class MainWindow : public QMainWindow
 		QString m_currentFile;
 		bool m_closing;
 		bool m_readyToClose;
+
+		bool m_firstTabAutoCloseEnabled;
 };
 
 #endif // MAINWINDOW_H

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -37,6 +37,12 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/highlight_legal_moves", checked);
 	});
 
+	connect(ui->m_closeUnusedInitialTabCheck, &QCheckBox::toggled,
+		this, [=](bool checked)
+	{
+		QSettings().setValue("ui/close_unused_initial_tab", checked);
+	});
+
 	connect(ui->m_concurrencySpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
 		this, [=](int value)
 	{
@@ -96,6 +102,8 @@ void SettingsDialog::readSettings()
 	s.beginGroup("ui");
 	ui->m_highlightLegalMovesCheck->setChecked(
 		s.value("highlight_legal_moves", true).toBool());
+	ui->m_closeUnusedInitialTabCheck->setChecked(
+		s.value("close_unused_initial_tab", true).toBool());
 	ui->m_tbPathEdit->setText(s.value("tb_path").toString());
 	s.endGroup();
 

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -44,6 +44,9 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="m_siteEdit"/>
+       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="m_tbPathLabel">
          <property name="text">
@@ -68,8 +71,15 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="1">
-        <widget class="QLineEdit" name="m_siteEdit"/>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="m_closeUnusedInitialTabCheck">
+         <property name="text">
+          <string>Close initial game tab if unused</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
This patch adds a configuration option to `Settings/General` to close the initial tab of cutechess GUI, provided that other game tabs are open and the first tab has not been used for playing.  #114