### PR TITLE
configurable default PGN files for single games and for tournament games

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -725,6 +725,20 @@ void MainWindow::onGameFinished(ChessGame* game)
 			m_game = nullptr;
 		updateWindowTitle();
 	}
+
+	// save game notation of non-tournament games to default PGN file
+	if (!tab.m_tournament
+	&&  !game->pgn()->isNull()
+	&&  	(  !game->pgn()->moves().isEmpty()   // ignore empty games
+		|| !game->pgn()->result().isNone())) // without adjudication
+	{
+		QString fileName = QSettings().value("games/default_pgn_output_file", QString())
+					      .toString();
+
+		if (!fileName.isEmpty())
+			game->pgn()->write(fileName);
+			//TODO: reaction on error
+	}
 }
 
 void MainWindow::newTournament()

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -271,4 +271,12 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 void NewTournamentDialog::readSettings()
 {
 	ui->m_siteEdit->setText(QSettings().value("pgn/site").toString());
+
+	QString pgnName = ui->m_pgnoutEdit->text();
+	if (pgnName.isEmpty())
+	{
+		pgnName = QSettings().value("tournament/default_pgn_output_file",
+					    QString()).toString();
+		ui->m_pgnoutEdit->setText(pgnName);
+	}
 }

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -56,8 +56,24 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("pgn/site", site);
 	});
 
+	connect(ui->m_defaultPgnOutFileEdit, &QLineEdit::textChanged,
+		[=](const QString& defaultPgnFile)
+	{
+		QSettings().setValue("games/default_pgn_output_file", defaultPgnFile);
+	});
+
+	connect(ui->m_tournamentDefaultPgnOutFileEdit, &QLineEdit::textChanged,
+		[=](const QString& tourFile)
+	{
+		QSettings().setValue("tournament/default_pgn_output_file", tourFile);
+	});
+
 	connect(ui->m_browseTbPathBtn, &QPushButton::clicked,
 		this, &SettingsDialog::browseTbPath);
+	connect(ui->m_defaultPgnOutFileBtn, &QPushButton::clicked,
+		this, &SettingsDialog::browseDefaultPgnOutFile);
+	connect(ui->m_tournamentDefaultPgnOutFileBtn, &QPushButton::clicked,
+		this, &SettingsDialog::browseTournamentDefaultPgnOutFile);
 
 	ui->m_gameSettings->onHumanCountChanged(0);
 	ui->m_gameSettings->enableSettingsUpdates();
@@ -95,6 +111,36 @@ void SettingsDialog::browseTbPath()
 	dlg->open();
 }
 
+void SettingsDialog::browseDefaultPgnOutFile()
+{
+	auto dlg = new QFileDialog(
+		this, tr("Select PGN output file"),
+		QString(),
+		tr("Portable Game Notation (*.pgn)"));
+	dlg->setAttribute(Qt::WA_DeleteOnClose);
+	dlg->setAcceptMode(QFileDialog::AcceptSave);
+	connect(dlg,
+		&QFileDialog::fileSelected,
+		ui->m_defaultPgnOutFileEdit,
+		&QLineEdit::setText);
+	dlg->open();
+}
+
+void SettingsDialog::browseTournamentDefaultPgnOutFile()
+{
+	auto dlg = new QFileDialog(
+		this, tr("Select PGN output file"),
+		QString(),
+		tr("Portable Game Notation (*.pgn)"));
+	dlg->setAttribute(Qt::WA_DeleteOnClose);
+	dlg->setAcceptMode(QFileDialog::AcceptSave);
+	connect(dlg,
+		&QFileDialog::fileSelected,
+		ui->m_tournamentDefaultPgnOutFileEdit,
+		&QLineEdit::setText);
+	dlg->open();
+}
+
 void SettingsDialog::readSettings()
 {
 	QSettings s;
@@ -111,7 +157,14 @@ void SettingsDialog::readSettings()
 	ui->m_siteEdit->setText(s.value("site").toString());
 	s.endGroup();
 
+	s.beginGroup("games");
+	ui->m_defaultPgnOutFileEdit
+		->setText(s.value("default_pgn_output_file").toString());
+	s.endGroup();
+
 	s.beginGroup("tournament");
+	ui->m_tournamentDefaultPgnOutFileEdit
+		->setText(s.value("default_pgn_output_file").toString());
 	ui->m_concurrencySpin->setValue(s.value("concurrency", 1).toInt());
 	s.endGroup();
 }

--- a/projects/gui/src/settingsdlg.h
+++ b/projects/gui/src/settingsdlg.h
@@ -43,6 +43,8 @@ class SettingsDialog : public QDialog
 
 	private slots:
 		void browseTbPath();
+		void browseDefaultPgnOutFile();
+		void browseTournamentDefaultPgnOutFile();
 
 	private:
 		void readSettings();

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -24,6 +24,9 @@
        <string>General</string>
       </attribute>
       <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+       </property>
        <item row="0" column="0">
         <widget class="QCheckBox" name="m_highlightLegalMovesCheck">
          <property name="text">
@@ -35,6 +38,16 @@
         </widget>
        </item>
        <item row="1" column="0">
+        <widget class="QCheckBox" name="m_closeUnusedInitialTabCheck">
+         <property name="text">
+          <string>Close initial game tab if unused</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
         <widget class="QLabel" name="m_siteLabel">
          <property name="text">
           <string>PGN Site:</string>
@@ -44,10 +57,10 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="m_siteEdit"/>
        </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QLabel" name="m_tbPathLabel">
          <property name="text">
           <string>Syzygy tablebases path:</string>
@@ -57,7 +70,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLineEdit" name="m_tbPathEdit"/>
@@ -71,15 +84,33 @@
          </item>
         </layout>
        </item>
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="m_closeUnusedInitialTabCheck">
+       <item row="6" column="0">
+        <widget class="QLabel" name="m_defaultPgnOutFileLabel">
          <property name="text">
-          <string>Close initial game tab if unused</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
+          <string>Append game notation to file:</string>
          </property>
         </widget>
+       </item>
+       <item row="6" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLineEdit" name="m_defaultPgnOutFileEdit">
+           <property name="text">
+            <string>games.pgn</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="m_defaultPgnOutFileBtn">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+           <property name="shortcut">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -139,34 +170,92 @@
         <widget class="TournamentSettingsWidget" name="m_tournamentSettings" native="true"/>
        </item>
        <item>
-        <layout class="QFormLayout" name="formLayout_2">
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="m_concurrencySpin">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>90</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Games</string>
+         </property>
+         <widget class="QWidget" name="layoutWidget">
+          <property name="geometry">
+           <rect>
+            <x>10</x>
+            <y>20</y>
+            <width>341</width>
+            <height>93</height>
+           </rect>
+          </property>
+          <layout class="QFormLayout" name="formLayout_2">
+           <property name="fieldGrowthPolicy">
+            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
            </property>
-           <property name="minimum">
-            <number>1</number>
+           <property name="leftMargin">
+            <number>0</number>
            </property>
-           <property name="maximum">
-            <number>128</number>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="m_concurrencyLabel">
-           <property name="text">
-            <string>Maximum number of concurrent games:</string>
-           </property>
-           <property name="buddy">
-            <cstring>m_concurrencySpin</cstring>
-           </property>
-          </widget>
-         </item>
-        </layout>
+           <item row="0" column="0">
+            <widget class="QLabel" name="m_concurrencyLabel">
+             <property name="text">
+              <string>Maximum number of concurrent games:</string>
+             </property>
+             <property name="buddy">
+              <cstring>m_concurrencySpin</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="m_concurrencySpin">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>128</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="m_tournamentDefaultPgnOutFileLabel">
+             <property name="text">
+              <string>Default file for  game notation:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="2">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLineEdit" name="m_tournamentDefaultPgnOutFileEdit">
+               <property name="text">
+                <string>tournaments.pgn</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="m_tournamentDefaultPgnOutFileBtn">
+               <property name="text">
+                <string>Browse...</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
        </item>
        <item>
         <spacer name="verticalSpacer">

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>240</height>
+    <height>286</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
This patch introduces settings into the configuration of cutechess GUI that specify a default PGN file name for non-tournament games (preset games.pgn) and a default tournament PGN file name (preset tournaments.pgn). They can be found in the General and the Tournament settings tabs.

The change helps to avoid loss of game information, especially of tournament games, if a user forgets to specify a tournament output file or to save a game directly.

References: issues #147 (#208), and  #210 
