### PR TITLE
support Pocket Knight Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -87,6 +87,8 @@ Knightmate
 Loop Chess (Drop Chess Variant)
 .It losers
 Loser's Chess
+.It pocketknight
+Pocket Knight Chess
 .It racingkings
 Racing Kings Chess
 .It slippedgrid

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -36,6 +36,7 @@ Options:
 			'knightmate': Knightmate
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
+			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
 			'slippedgrid': Slipped Grid Chess
 			'sortland9': Symmetrical Two Kings Each Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -34,6 +34,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/crazyhouseboard.cpp \
     $$PWD/loopboard.cpp \
     $$PWD/chessgiboard.cpp \
+    $$PWD/pocketknightboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -74,6 +75,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/crazyhouseboard.h \
     $$PWD/loopboard.h \
     $$PWD/chessgiboard.h \
+    $$PWD/pocketknightboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -37,6 +37,7 @@
 #include "loopboard.h"
 #include "losersboard.h"
 #include "ncheckboard.h"
+#include "pocketknightboard.h"
 #include "racingkingsboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
@@ -71,6 +72,7 @@ REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
+REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")

--- a/projects/lib/src/board/pocketknightboard.cpp
+++ b/projects/lib/src/board/pocketknightboard.cpp
@@ -1,0 +1,118 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pocketknightboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+PocketKnightBoard::PocketKnightBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+Board* PocketKnightBoard::copy() const
+{
+	return new PocketKnightBoard(*this);
+}
+
+QList< Piece > PocketKnightBoard::reservePieceTypes() const
+{
+	QList<Piece> list;
+
+	list << Piece(Side::White, Knight);
+	list << Piece(Side::Black, Knight);
+
+	return list;
+}
+
+QString PocketKnightBoard::variant() const
+{
+	return "pocketknight";
+}
+
+/*!
+ * Most common set-up positions for Pocket Knight Chess:
+ * Pocket Knight Chess with full standard pieces and extra knight in pocket
+ * rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Nn] w KQkq - 0 1
+ * Pocket Knight Chess with Queen's Knight in pocket
+ * r1bqkbnr/pppppppp/8/8/8/8/PPPPPPPP/R1BQKBNR[Nn] w KQkq - 0 1
+ * Pocket Knight Chess with full standard set and two extra knights in pocket
+ * rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[NNnn] w KQkq - 0 1
+ */
+QString PocketKnightBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Nn] w KQkq - 0 1";
+}
+
+bool PocketKnightBoard::variantHasDrops() const
+{
+	return true;
+}
+
+int PocketKnightBoard::reserveType(int) const
+{
+	return Piece::NoPiece;
+}
+
+void PocketKnightBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	int source = move.sourceSquare();
+	int prom = move.promotion();
+	int ctype = captureType(move);
+
+	if (ctype == Piece::NoPiece
+	&&  source == 0)
+		removeFromReserve(Piece(sideToMove(), prom));
+
+	return WesternBoard::vMakeMove(move, transition);
+}
+
+void PocketKnightBoard::vUndoMove(const Move& move)
+{
+	int source = move.sourceSquare();
+	int prom = move.promotion();
+
+	WesternBoard::vUndoMove(move);
+
+	int ctype = captureType(move);
+	if (ctype == Piece::NoPiece
+	&&  source == 0)
+		addToReserve(Piece(sideToMove(), prom));
+}
+
+void PocketKnightBoard::generateMovesForPiece(QVarLengthArray< Move >& moves, int pieceType, int square) const
+{
+	// Generate drops
+	if (square == 0)
+	{
+		const int size = arraySize();
+		for (int i = 0; i < size; i++)
+		{
+			Piece tmp = pieceAt(i);
+			if (!tmp.isEmpty())
+				continue;
+			moves.append(Move(0, i, pieceType));
+		}
+	}
+	else
+		WesternBoard::generateMovesForPiece(moves, pieceType, square);
+}
+
+
+
+} // namespace Chess

--- a/projects/lib/src/board/pocketknightboard.h
+++ b/projects/lib/src/board/pocketknightboard.h
@@ -1,0 +1,64 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef POCKETKNIGHTBOARD_H
+#define POCKETKNIGHTBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Pocket Knight Chess
+ *
+ * Pocket Knight Chess is a variant of standard chess.
+ * Each side has an additional Knight in their reserve that can be
+ * dropped onto an empty square during the game instead of making a
+ * normal move.
+ *
+ * This variant originates from the early 20th century and is also known
+ * under the name Tombola Chess.
+ *
+ * \note Rules: http://www.chessvariants.com/other.dir/pocket.html
+ *
+ */
+class LIB_EXPORT PocketKnightBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new PocketKnightBoard object. */
+		PocketKnightBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QList< Piece > reservePieceTypes() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual bool variantHasDrops() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual int reserveType(int pieceType) const;
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+};
+
+} // namespace Chess
+#endif // POCKETKNIGHTBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -740,6 +740,13 @@ void tst_Board::perft_data() const
 		<< 5 //4 plies: 139774, 5 plies: 3249033, 6 plies: 74568983
 		<< Q_UINT64_C(3249033);
 
+	variant = "pocketknight";
+	QTest::newRow("pocketknight startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Nn] w KQkq - 0 1"
+		<< 4  // 3 plies: 88617, 4 plies: 3071267, 5 plies: 99614985
+		<< Q_UINT64_C(3071267);
+
 	variant = "losers";
 	QTest::newRow("losers startpos")
 		<< variant


### PR DESCRIPTION
This is a suggestion to support _Pocket Knight Chess_, a chess variant where each side has an extra knight in his pocket (reserve) which can be dropped onto an empty square instead of a normal move. So this is a very conservative type of drop chess which might appeal to people that are not familiar with drop chess. Pocket Knight Chess has been popular in The Netherlands and in Germany already at the beginning of the 20th century.

There are sub-variants of Pocket Knight with different set-up. There are remarks /wrt this in the code.
This implementation (main variant with the simplest rules) has been tested with _Sjaak II_, versions 1.3.1a and 1.4.1.

