### PR TITLE
support Co-regal Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -57,6 +57,8 @@ Capablanca Random Chess
 Checkless Chess
 .It chessgi
 Chessgi / Drop Chess
+.It coregal
+Co-regal Chess
 .It crazyhouse
 Crazyhouse (Drop Chess Variant)
 .It displacedgrid

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -21,6 +21,7 @@ Options:
 			'caparandom': Capablanca Random Chess
 			'checkless': Checkless Chess
 			'chessgi': Chessgi (Drop Chess)
+			'coregal': Co-regal Chess
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'discplacedgrid': Displaced Grid Chess
 			'extinction': Extinction Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -10,6 +10,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/restrictedmoveboard.cpp \
     $$PWD/gridboard.cpp \
     $$PWD/capablancaboard.cpp \
+    $$PWD/coregalboard.cpp \
     $$PWD/extinctionboard.cpp \
     $$PWD/threekingsboard.cpp \
     $$PWD/kingofthehillboard.cpp \
@@ -50,6 +51,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/restrictedmoveboard.h \
     $$PWD/gridboard.h \
     $$PWD/capablancaboard.h \
+    $$PWD/coregalboard.h \
     $$PWD/extinctionboard.h \
     $$PWD/threekingsboard.h \
     $$PWD/kingofthehillboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -24,6 +24,7 @@
 #include "caparandomboard.h"
 #include "checklessboard.h"
 #include "chessgiboard.h"
+#include "coregalboard.h"
 #include "crazyhouseboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
@@ -56,6 +57,7 @@ REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
+REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
 REGISTER_BOARD(ExtinctionBoard, "extinction")

--- a/projects/lib/src/board/coregalboard.cpp
+++ b/projects/lib/src/board/coregalboard.cpp
@@ -1,0 +1,62 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "coregalboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+CoRegalBoard::CoRegalBoard(const QSet< int >& setOfRoyalTypes)
+	: WesternBoard(new WesternZobrist()),
+	  m_royalPieceTypes(setOfRoyalTypes)
+{
+}
+
+Board* CoRegalBoard::copy() const
+{
+	return new CoRegalBoard(*this);
+}
+
+QString CoRegalBoard::variant() const
+{
+	return "coregal";
+}
+
+QString CoRegalBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+bool CoRegalBoard::inCheck(Side side, int square) const
+{
+	if (square != 0)
+		return WesternBoard::inCheck(side, square);
+
+	Piece piece;
+
+	for (int i = 0; i < arraySize(); i++)
+	{
+		piece = pieceAt(i);
+		if (piece.side() == side
+		&&  m_royalPieceTypes.contains(piece.type())
+		&&  WesternBoard::inCheck(side, i))
+			return true;
+	}
+	return false;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/coregalboard.h
+++ b/projects/lib/src/board/coregalboard.h
@@ -1,0 +1,60 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COREGALBOARD_H
+#define COREGALBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Co-regal Chess
+ *
+ * Co-regal Chess follows the rules of standard chess, but
+ * the Queen like the King is subject to check and mate.
+ *
+ * Introduced by Vernon R. Parton, UK, 1970.
+ *
+ * \note This implements the original variant without Queen castling.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/V._R._Parton#Co-Regal_Chess
+ */
+
+
+class LIB_EXPORT CoRegalBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new CoregalBoard object. */
+		CoRegalBoard(const QSet<int>& setOfRoyalTypes
+			     = QSet<int>{King, Queen});
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual bool inCheck(Side side, int square = 0) const;
+
+	private:
+		const QSet<int> m_royalPieceTypes;
+
+};
+
+} // namespace Chess
+#endif // COREGALBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -464,6 +464,17 @@ void tst_Board::results_data() const
 		<< "K5kr/5Q2/8/8/8/8/8/8 b - - 0 1"
 		<< "1-0";
 
+	variant = "coregal";
+
+	QTest::newRow("coregal white win #1")
+		<< variant
+		<< "4Rqk1/p2p2pp/1pp2p2/8/8/3P4/PP3PPP/4Q1K1 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("coregal white win #2")
+		<< variant
+		<< "q3r1k1/R1Q2ppp/8/4n3/4PN2/3P3P/5PP1/6K1 b - - 0 27"
+		<< "1-0";
+
 	variant = "grid";
 
 	QTest::newRow("grid white win")
@@ -670,6 +681,13 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4835050);
+
+	variant = "coregal";
+	QTest::newRow("coregal startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5
+		<< Q_UINT64_C(4756867);
 
 	variant = "extinction";
 	QTest::newRow("extinction startpos")


### PR DESCRIPTION
This patch supports _Co-regal Chess_, where the Queens are subject to check and mate just as the Kings. This implementation follows the original rules by Vernon R. Parton, i. e. there is no castling of Queens. It is quite compact and based on `WesternBoard`.
