### PR TITLE
EPD (or rather FEN) output of end position into a file (lib and cli)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -236,6 +236,10 @@ Save the games to
 in PGN format. Use the
 .Cm min
 argument to save in a minimal PGN format.
+.It Fl epdout Ar file
+Save the games to
+.Ar file
+in FEN format.
 .It Fl recover
 Restart crashed engines instead of stopping the game.
 .It Fl repeat

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -101,6 +101,7 @@ Options:
 			'disk': The book is accessed directly on disk.
   -pgnout FILE [min]	Save the games to FILE in PGN format. Use the 'min'
 			argument to save in a minimal/compact PGN format.
+  -epdout FILE		Save the end position of the games to FILE in FEN format.
   -recover		Restart crashed engines instead of stopping the match
   -repeat		Play each opening twice so that both players get
 			to play it on both sides

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -256,6 +256,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-openings", QVariant::StringList);
 	parser.addOption("-bookmode", QVariant::String);
 	parser.addOption("-pgnout", QVariant::StringList, 1, 2);
+	parser.addOption("-epdout", QVariant::String, 1, 1);
 	parser.addOption("-repeat", QVariant::Bool, 0, 0);
 	parser.addOption("-recover", QVariant::Bool, 0, 0);
 	parser.addOption("-site", QVariant::String, 1, 1);
@@ -490,6 +491,12 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 			}
 			if (ok)
 				tournament->setPgnOutput(list.at(0), mode);
+		}
+		// FEN/EPD output file to save positions
+		else if (name == "-epdout")
+		{
+			QString fileName = value.toString();
+			tournament->setEpdOutput(fileName);
 		}
 		// Play every opening twice, just switch the players' sides
 		else if (name == "-repeat")

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -188,6 +188,14 @@ class LIB_EXPORT Tournament : public QObject
 		void setPgnCleanupEnabled(bool enabled);
 
 		/*!
+		 * Sets the EPD output file for the end positions to \a fileName.
+		 *
+		 * If no EPD output file is set (default) then the positions
+		 * will not be saved.
+		 */
+		void setEpdOutput(const QString& fileName);
+
+		/*!
 		 * Sets the opening repetition mode to \a repeat.
 		 *
 		 * If \a repeat is true, each opening is repeated for two
@@ -374,6 +382,7 @@ class LIB_EXPORT Tournament : public QObject
 	private slots:
 		void startNextGame();
 		bool writePgn(PgnGame* pgn, int gameNumber);
+		bool writeEpd(ChessGame* game);
 		void onGameStarted(ChessGame* game);
 		void onGameFinished(ChessGame* game);
 		void onGameDestroyed(ChessGame* game);
@@ -423,6 +432,8 @@ class LIB_EXPORT Tournament : public QObject
 		Sprt* m_sprt;
 		QFile m_pgnFile;
 		QTextStream m_pgnOut;
+		QFile m_epdFile;
+		QTextStream m_epdOut;
 		QString m_startFen;
 		PgnGame::PgnMode m_pgnOutMode;
 		TournamentPair* m_pair;


### PR DESCRIPTION
This patch helps to save the end positions of games into a specified file.  The notation is done in EPD (more exactly: FEN) format, one line per position.

This is part of #251 

