### PR TITLE
new optional parameter n for -repeat, new option -noswap to not swap …

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -242,9 +242,15 @@ Save the games to
 in FEN format.
 .It Fl recover
 Restart crashed engines instead of stopping the game.
-.It Fl repeat
-Play each opening twice so that both players get to play it on both
-sides.
+.It Fl repeat Bq Cm Ar n
+Play each opening twice (or
+.Ar n
+times). Unless the -noswap option is used, the players swap
+sides after each game. So they get to play the
+opening on both sides. Please note that a new round will use
+a new opening.
+.It Fl noswap
+Do not swap sides of paired engines
 .It Fl seeds Ar n
 Set the first
 .Ar n

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -103,8 +103,11 @@ Options:
 			argument to save in a minimal/compact PGN format.
   -epdout FILE		Save the end position of the games to FILE in FEN format.
   -recover		Restart crashed engines instead of stopping the match
-  -repeat		Play each opening twice so that both players get
-			to play it on both sides
+  -repeat [N]		Play each opening twice (or N times). Unless the -noswap
+			option is used, the players swap sides after each game.
+			So they get to play the opening on both sides. Please
+			note that a new round will use a new opening.
+  -noswap		Do not swap sides of paired engines
   -seeds N		Set the first N engines as seeds in the tournament
   -site SITE		Set the site/location to SITE
   -srand N		Set the seed for the random number generator to N

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -252,7 +252,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	auto book = ui->m_gameSettings->openingBook();
 	int bookDepth = ui->m_gameSettings->bookDepth();
 
-	t->setOpeningRepetition(ts->openingRepetition());
+	t->setOpeningRepetitions(ts->openingRepetition()? 2: 1);
 	t->setRecoveryMode(ts->engineRecovery());
 
 	const auto engines = m_addedEnginesManager->engines();

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -196,12 +196,19 @@ class LIB_EXPORT Tournament : public QObject
 		void setEpdOutput(const QString& fileName);
 
 		/*!
-		 * Sets the opening repetition mode to \a repeat.
+		 * Sets the number of opening repetitions to \a count.
 		 *
-		 * If \a repeat is true, each opening is repeated for two
-		 * rounds; otherwise each game gets its own opening.
+		 * Each opening is played \a count times before
+		 * going to the next opening. The default is 1.
 		 */
-		void setOpeningRepetition(bool repeat);
+		void setOpeningRepetitions(int count);
+		/*!
+		 * Sets the side swap flag to \a enabled.
+		 *
+		 * If \a enabled is true then paired engines will
+		 * swap sides for the following game.
+		 */
+		void setSwapSides(bool enabled);
 		/*!
 		 * Sets opening book ownerhip to \a enabled.
 		 *
@@ -422,7 +429,7 @@ class LIB_EXPORT Tournament : public QObject
 		int m_openingDepth;
 		int m_seedCount;
 		bool m_stopping;
-		bool m_repeatOpening;
+		int m_openingRepetitions;
 		bool m_recover;
 		bool m_pgnCleanup;
 		bool m_finished;
@@ -435,6 +442,8 @@ class LIB_EXPORT Tournament : public QObject
 		QFile m_epdFile;
 		QTextStream m_epdOut;
 		QString m_startFen;
+		int m_repetitionCounter;
+		int m_swapSides;
 		PgnGame::PgnMode m_pgnOutMode;
 		TournamentPair* m_pair;
 		QMap< QPair<int, int>, TournamentPair* > m_pairs;


### PR DESCRIPTION
…sides of paired engines.
 
This PR introduces a new optional parameter n to the `-repeat` option of cutechess-cli.

When set to a positive integer n, an opening will be played n times during an encounter between two engines. If the parameter is omitted, as before the opening will be played twice (default). The program issues a warning if the number of games per encounter and the number of opening repetitions do not match well, e.g. `-games 4 -repeat 3` playing with 3 repetitions when 4 games are played per encounter.
The repetitions cannot extend over several rounds. A new round will start with a new opening.
Requested in #188.

The PR also introduces a new option `-noswap`.

The engines usually swap sides when having an encounter of more than one game. When the option `-noswap` is used, the engines will further play the sides on which they started the round and not switch.
Feature suggested in #95.

The PR only adds functionality to the CLI, whereas the formal change to the GUI is non-functional.

I hope this helps.