### PR TITLE
Game adjuducation by user

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -159,6 +159,10 @@ void MainWindow::createActions()
 
 	m_flipBoardAct = new QAction(tr("&Flip Board"), this);
 
+	m_adjudicateDrawAct = new QAction(tr("Ad&judicate Draw"), this);
+	m_adjudicateWhiteWinAct = new QAction(tr("Adjudicate Win for White"), this);
+	m_adjudicateBlackWinAct = new QAction(tr("Adjudicate Win for Black"), this);
+
 	m_quitGameAct = new QAction(tr("&Quit"), this);
 	m_quitGameAct->setMenuRole(QAction::QuitRole);
 	#ifdef Q_OS_WIN32
@@ -223,6 +227,11 @@ void MainWindow::createActions()
 
 	connect(m_saveGameAct, SIGNAL(triggered()), this, SLOT(save()));
 	connect(m_saveGameAsAct, SIGNAL(triggered()), this, SLOT(saveAs()));
+
+	connect(m_adjudicateDrawAct, SIGNAL(triggered()), this, SLOT(adjudicateDraw()));
+	connect(m_adjudicateWhiteWinAct, SIGNAL(triggered()), this, SLOT(adjudicateWhiteWin()));
+	connect(m_adjudicateBlackWinAct, SIGNAL(triggered()), this, SLOT(adjudicateBlackWin()));
+
 	connect(m_quitGameAct, &QAction::triggered,
 		app, &CuteChessApplication::onQuitAction);
 
@@ -261,6 +270,10 @@ void MainWindow::createMenus()
 	m_gameMenu->addAction(m_saveGameAct);
 	m_gameMenu->addAction(m_saveGameAsAct);
 	m_gameMenu->addAction(m_copyFenAct);
+	m_gameMenu->addSeparator();
+	m_gameMenu->addAction(m_adjudicateDrawAct);
+	m_gameMenu->addAction(m_adjudicateWhiteWinAct);
+	m_gameMenu->addAction(m_adjudicateBlackWinAct);
 	m_gameMenu->addSeparator();
 	m_gameMenu->addAction(m_quitGameAct);
 
@@ -917,7 +930,7 @@ void MainWindow::showAboutDialog()
 	html += "<h3>" + QString("Cute Chess %1")
 		.arg(CuteChessApplication::applicationVersion()) + "</h3>";
 	html += "<p>" + tr("Using Qt version %1").arg(qVersion()) + "</p>";
-	html += "<p>" + tr("Copyright 2008-2016 "
+	html += "<p>" + tr("Copyright 2008-2017 "
 			   "Ilari Pihlajisto and Arto Jonsson") + "</p>";
 	html += "<p>" + tr("This is free software; see the source for copying "
 			   "conditions. There is NO warranty; not even for "
@@ -1032,6 +1045,43 @@ bool MainWindow::askToSave()
 			return false;
 	}
 	return true;
+}
+
+void MainWindow::adjudicateDraw()
+{
+	adjudicateGame(Draw);
+}
+
+void MainWindow::adjudicateWhiteWin()
+{
+	adjudicateGame(WhiteWin);
+}
+
+void MainWindow::adjudicateBlackWin()
+{
+	adjudicateGame(BlackWin);
+}
+
+void MainWindow::adjudicateGame(UserAdjudication value)
+{
+	using Chess::Result;
+	ChessGame *game = m_tabs.at(m_tabBar->currentIndex()).m_game;
+
+	if (game == nullptr)
+		return;
+
+	Chess::Side winner = Chess::Side::NoSide;
+
+	if (value == WhiteWin)
+		winner = Chess::Side::White;
+	else if (value == BlackWin)
+		winner = Chess::Side::Black;
+
+	Result result = Result(Result::Adjudication, winner, tr("user decision"));
+
+	lockCurrentGame();
+	game->onAdjudication(result);
+	unlockCurrentGame();
 }
 
 void MainWindow::addDefaultWindowMenu()

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -80,6 +80,9 @@ class MainWindow : public QMainWindow
 		void copyFen();
 		void showAboutDialog();
 		void closeAllGames();
+		void adjudicateDraw();
+		void adjudicateWhiteWin();
+		void adjudicateBlackWin();
 
 	private:
 		struct TabData
@@ -92,6 +95,14 @@ class MainWindow : public QMainWindow
 			PgnGame* m_pgn;
 			Tournament* m_tournament;
 			bool m_finished;
+		};
+
+		/*! Outcomes of adjudication by user */
+		enum UserAdjudication
+		{
+			WhiteWin,
+			BlackWin,
+			Draw
 		};
 
 		void createActions();
@@ -110,6 +121,7 @@ class MainWindow : public QMainWindow
 		int tabIndex(ChessGame* game) const;
 		int tabIndex(Tournament* tournament, bool freeTab = false) const;
 		void addDefaultWindowMenu();
+		void adjudicateGame(UserAdjudication value);
 
 		QMenu* m_gameMenu;
 		QMenu* m_tournamentMenu;
@@ -126,6 +138,9 @@ class MainWindow : public QMainWindow
 
 		QAction* m_quitGameAct;
 		QAction* m_newGameAct;
+		QAction* m_adjudicateBlackWinAct;
+		QAction* m_adjudicateWhiteWinAct;
+		QAction* m_adjudicateDrawAct;
 		QAction* m_closeGameAct;
 		QAction* m_saveGameAct;
 		QAction* m_saveGameAsAct;

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -310,6 +310,16 @@ void ChessGame::startTurn()
 	}
 }
 
+void ChessGame::onAdjudication(const Chess::Result& result)
+{
+	if (result.type() != Chess::Result::Adjudication || m_finished)
+		return;
+
+	m_result = result;
+
+	stop();
+}
+
 void ChessGame::onResultClaim(const Chess::Result& result)
 {
 	if (m_finished)

--- a/projects/lib/src/chessgame.h
+++ b/projects/lib/src/chessgame.h
@@ -85,6 +85,7 @@ class LIB_EXPORT ChessGame : public QObject
 		void kill();
 		void emitStartFailed();
 		void onMoveMade(const Chess::Move& move);
+		void onAdjudication(const Chess::Result& result);
 
 	signals:
 		void humanEnabled(bool);


### PR DESCRIPTION
This patch adds three menu items to the "Game" menu. The user can adjudicate an _ongoing_ game as Draw, White Win, and Black Win: a call to a new slot on the `ChessGame` class stops and adjudicates the game displayed in the current game tab (single game or tournament game).

Refer to #211 (for ongoing games)
