### PR TITLE
Do not start tournament with duplicate configuration names

### DIFF
--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -169,6 +169,9 @@ void NewTournamentDialog::configureEngine(const QModelIndex& index)
 
 	if (dlg.exec() == QDialog::Accepted)
 		m_addedEnginesManager->updateEngineAt(row, dlg.engineConfiguration());
+
+	QPushButton* button = ui->buttonBox->button(QDialogButtonBox::Ok);
+	button->setEnabled(canStart());
 }
 
 void NewTournamentDialog::moveEngine(int offset)
@@ -191,6 +194,17 @@ bool NewTournamentDialog::canStart() const
 
 	if (m_addedEnginesManager->engineCount() < 2)
 		return false;
+
+	QPushButton* button = ui->buttonBox->button(QDialogButtonBox::Ok);
+
+	// check for duplicate configuration names
+	if (m_addedEnginesManager->engineNames().count()
+	!=  m_addedEnginesManager->engineCount())
+	{
+		button->setText(tr("Resolve Duplicates!"));
+		return false;
+	}
+	button->setText("&OK");
 
 	QString variant = ui->m_gameSettings->chessVariant();
 	return m_addedEnginesManager->supportsVariant(variant);


### PR DESCRIPTION
This patch prevents the user from starting a tournament with non-unique configuration names. If there are ambiguities in the engine list the `NewTournamentDialog::canStart()` method returns false and the start button gets disabled. Furthermore the button shows a "Resolve Duplicates!" text as long as there are duplicates in the list.
Resolution can be accomplished by removing or renaming entries of engine configurations.

Reference: Request #213 