### PR TITLE
mark duplicates in engine configuration list

### DIFF
--- a/projects/gui/src/engineconfigurationmodel.cpp
+++ b/projects/gui/src/engineconfigurationmodel.cpp
@@ -102,6 +102,13 @@ QVariant EngineConfigurationModel::data(const QModelIndex& index, int role) cons
 		if (!engine.supportsVariant(m_chessVariant))
 			return QBrush(Qt::red);
 
+		int count = 0;
+		const auto& engines = m_engineManager->engines();
+		for (const EngineConfiguration& engine2: engines)
+			if (engine.name() == engine2.name())
+				if (++count > 1)
+					return QBrush(Qt::gray);
+
 		return QVariant();
 	}
 


### PR DESCRIPTION
This patch shows duplicate entries in the list of tournament engine configurations. Non-unique entries are marked grey (the user has to resolve the duplicates by renaming or removing entries).

This is not optimised for speed. However, lists with several hundred entries are no problem on my modest laptop.

This PR refers to issue #213 and PR #271. 