### PR TITLE
output of end positions of tournament games into a file (gui)

### DIFF
--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -91,6 +91,15 @@ NewTournamentDialog::NewTournamentDialog(EngineManager* engineManager,
 		dlg->setAcceptMode(QFileDialog::AcceptSave);
 		dlg->open();
 	});
+	connect(ui->m_browseEpdoutBtn, &QPushButton::clicked, this, [=]()
+	{
+		auto dlg = new QFileDialog(this, tr("Select EPD output file"),
+			QString(), tr("Extended Position Description (*.epd)"));
+		connect(dlg, &QFileDialog::fileSelected, ui->m_epdoutEdit, &QLineEdit::setText);
+		dlg->setAttribute(Qt::WA_DeleteOnClose);
+		dlg->setAcceptMode(QFileDialog::AcceptSave);
+		dlg->open();
+	});
 
 	m_addedEnginesManager = new EngineManager(this);
 	m_addedEnginesModel = new EngineConfigurationModel(
@@ -250,6 +259,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	t->setSite(ui->m_siteEdit->text());
 	t->setVariant(ui->m_gameSettings->chessVariant());
 	t->setPgnOutput(ui->m_pgnoutEdit->text());
+	t->setEpdOutput(ui->m_epdoutEdit->text());
 
 	t->setSeedCount(ts->seedCount());
 	t->setGamesPerEncounter(ts->gamesPerEncounter());
@@ -292,5 +302,13 @@ void NewTournamentDialog::readSettings()
 		pgnName = QSettings().value("tournament/default_pgn_output_file",
 					    QString()).toString();
 		ui->m_pgnoutEdit->setText(pgnName);
+	}
+
+	QString epdName = ui->m_epdoutEdit->text();
+	if (epdName.isEmpty())
+	{
+		epdName = QSettings().value("tournament/default_epd_output_file",
+					    QString()).toString();
+		ui->m_epdoutEdit->setText(epdName);
 	}
 }

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -68,12 +68,20 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("tournament/default_pgn_output_file", tourFile);
 	});
 
+	connect(ui->m_tournamentDefaultEpdOutFileEdit, &QLineEdit::textChanged,
+		[=](const QString& tourEpdFile)
+	{
+		QSettings().setValue("tournament/default_epd_output_file", tourEpdFile);
+	});
+
 	connect(ui->m_browseTbPathBtn, &QPushButton::clicked,
 		this, &SettingsDialog::browseTbPath);
 	connect(ui->m_defaultPgnOutFileBtn, &QPushButton::clicked,
 		this, &SettingsDialog::browseDefaultPgnOutFile);
 	connect(ui->m_tournamentDefaultPgnOutFileBtn, &QPushButton::clicked,
 		this, &SettingsDialog::browseTournamentDefaultPgnOutFile);
+	connect(ui->m_tournamentDefaultEpdOutFileBtn, &QPushButton::clicked,
+		this, &SettingsDialog::browseTournamentDefaultEpdOutFile);
 
 	ui->m_gameSettings->onHumanCountChanged(0);
 	ui->m_gameSettings->enableSettingsUpdates();
@@ -141,6 +149,21 @@ void SettingsDialog::browseTournamentDefaultPgnOutFile()
 	dlg->open();
 }
 
+void SettingsDialog::browseTournamentDefaultEpdOutFile()
+{
+	auto dlg = new QFileDialog(
+		this, tr("Select EPD output file"),
+		QString(),
+		tr("Extended Position Description (*.epd)"));
+	dlg->setAttribute(Qt::WA_DeleteOnClose);
+	dlg->setAcceptMode(QFileDialog::AcceptSave);
+	connect(dlg,
+		&QFileDialog::fileSelected,
+		ui->m_tournamentDefaultEpdOutFileEdit,
+		&QLineEdit::setText);
+	dlg->open();
+}
+
 void SettingsDialog::readSettings()
 {
 	QSettings s;
@@ -165,6 +188,8 @@ void SettingsDialog::readSettings()
 	s.beginGroup("tournament");
 	ui->m_tournamentDefaultPgnOutFileEdit
 		->setText(s.value("default_pgn_output_file").toString());
+	ui->m_tournamentDefaultEpdOutFileEdit
+		->setText(s.value("default_epd_output_file").toString());
 	ui->m_concurrencySpin->setValue(s.value("concurrency", 1).toInt());
 	s.endGroup();
 }

--- a/projects/gui/src/settingsdlg.h
+++ b/projects/gui/src/settingsdlg.h
@@ -45,6 +45,7 @@ class SettingsDialog : public QDialog
 		void browseTbPath();
 		void browseDefaultPgnOutFile();
 		void browseTournamentDefaultPgnOutFile();
+		void browseTournamentDefaultEpdOutFile();
 
 	private:
 		void readSettings();

--- a/projects/gui/ui/newtournamentdlg.ui
+++ b/projects/gui/ui/newtournamentdlg.ui
@@ -47,6 +47,16 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Site:</string>
+            </property>
+            <property name="buddy">
+             <cstring>m_siteEdit</cstring>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
            <widget class="QLineEdit" name="m_siteEdit">
             <property name="maxLength">
@@ -94,15 +104,29 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Site:</string>
-            </property>
-            <property name="buddy">
-             <cstring>m_siteEdit</cstring>
+             <string>EPD output:</string>
             </property>
            </widget>
+          </item>
+          <item row="3" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLineEdit" name="m_epdoutEdit"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="m_browseEpdoutBtn">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -10,6 +10,12 @@
     <height>395</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>90</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Settings</string>
   </property>
@@ -177,7 +183,7 @@
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
-           <verstretch>90</verstretch>
+           <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="title">
@@ -253,17 +259,29 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="m_tournamentDefaultEpdOutFileLabel">
+              <property name="text">
+               <string>EPD output:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="m_tournamentDefaultEpdOutFileEdit">
+              <property name="text">
+               <string>tournaments.epd</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="m_tournamentDefaultEpdOutFileBtn">
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
This patch helps to save end positions of tournament games in FEN format, one position per line when using the GUI.

This is part of #251 and complements PR #266. 