### PR TITLE
support Embassy Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -63,6 +63,8 @@ Co-regal Chess
 Crazyhouse (Drop Chess Variant)
 .It displacedgrid
 Displaced Grid Chess
+.It embassy
+Embassy Chess
 .It extinction
 Extinction Chess
 .It fischerandom

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -24,6 +24,7 @@ Options:
 			'coregal': Co-regal Chess
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'discplacedgrid': Displaced Grid Chess
+			'embassy': Embassy Chess
 			'extinction': Extinction Chess
 			'fischerandom': Fischer Random Chess/Chess 960
 			'giveaway': Giveaway Chess (Losing Chess)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -15,6 +15,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/threekingsboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
+    $$PWD/embassyboard.cpp \
     $$PWD/janusboard.cpp \
     $$PWD/knightmateboard.cpp \
     $$PWD/twokingseachboard.cpp \
@@ -57,6 +58,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/threekingsboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \
+    $$PWD/embassyboard.h \
     $$PWD/janusboard.h \
     $$PWD/knightmateboard.h \
     $$PWD/twokingseachboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -26,6 +26,7 @@
 #include "chessgiboard.h"
 #include "coregalboard.h"
 #include "crazyhouseboard.h"
+#include "embassyboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
 #include "giveawayboard.h"
@@ -61,6 +62,7 @@ REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
+REGISTER_BOARD(EmbassyBoard, "embassy")
 REGISTER_BOARD(ExtinctionBoard, "extinction")
 REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")

--- a/projects/lib/src/board/embassyboard.cpp
+++ b/projects/lib/src/board/embassyboard.cpp
@@ -1,0 +1,49 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "embassyboard.h"
+
+
+namespace Chess {
+
+EmbassyBoard::EmbassyBoard()
+	: CapablancaBoard()
+{
+}
+
+Board* EmbassyBoard::copy() const
+{
+	return new EmbassyBoard(*this);
+}
+
+QString EmbassyBoard::variant() const
+{
+	return "embassy";
+}
+
+QString EmbassyBoard::defaultFenString() const
+{
+	return "rnbqkcabnr/pppppppppp/10/10/10/10/PPPPPPPPPP/RNBQKCABNR w KQkq - 0 1";
+}
+
+int EmbassyBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	return castlingSide == QueenSide ? 1 : 7; // b-file and h-file
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/embassyboard.h
+++ b/projects/lib/src/board/embassyboard.h
@@ -1,0 +1,52 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef EMBASSYBOARD_H
+#define EMBASSYBOARD_H
+
+#include "capablancaboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Embassy chess
+ *
+ * Embassy chess is a variant of Capablanca chess that uses a
+ * different starting position. It is similar to the line-up
+ * of Grand Chess. The king goes to the b- or i-file when castling.
+ *
+ * This variant was introduced in 2005 by Kevin Hill.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Embassy_Chess
+ * \sa CapablancaBoard
+ * \sa GothicBoard
+ */
+class LIB_EXPORT EmbassyBoard : public CapablancaBoard
+{
+	public:
+		/*! Creates a new EmbassyBoard object. */
+		EmbassyBoard();
+
+		// Inherited from CapablancaBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual int castlingFile(CastlingSide castlingSide) const;
+};
+
+} // namespace Chess
+#endif // EMBASSYBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -259,6 +259,21 @@ void tst_Board::moveStrings_data() const
 		<< "e4 e5 Nf3 d6 Bb5+ c6 Bxc6+"
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 3+3 0 1"
 		<< "rnbqkbnr/pp3ppp/2Bp4/4p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 1+3 0 4";
+	QTest::newRow("embassy castling san1")
+		<< "embassy"
+		<< "O-O-O O-O-O Ng4"
+		<< "r3kcab1r/pppq1p1ppp/2np2pn2/4pb4/4B5/2NPB1PN2/PPPQPP1PPP/R3KCA2R b KQkq - 3 1"
+		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 1 2";
+	QTest::newRow("embassy castling san2")
+		<< "embassy"
+		<< "Cf1 O-O g3"
+		<< "r2qk4r/ppp4cpp/3p1ppba1/4nb1p2/2P1N1nB2/P1KP2CNP1/1P2P1PP1P/R5AB1R w kq - 0 1"
+		<< "r2q2rk2/ppp4cpp/3p1ppba1/4nb1p2/2P1N1nB2/P1KP2PNP1/1P2P2P1P/R4CAB1R b - - 0 2";
+	QTest::newRow("embassy castling lan")
+		<< "embassy"
+		<< "e8b8 e1b1 h6g4"
+		<< "r3kcab1r/pppq1p1ppp/2np2pn2/4pb4/4B5/2NPB1PN2/PPPQPP1PPP/R3KCA2R b KQkq - 3 1"
+		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 1 2";
 	QTest::newRow("janus castling san1")
 		<< "janus"
 		<< "Kb8 Be3 Ng6 Ki1"
@@ -681,6 +696,13 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5
 		<< Q_UINT64_C(4835050);
+
+	variant = "embassy";
+	QTest::newRow("embassy startpos")
+		<< variant
+		<< "rnbqkcabnr/pppppppppp/10/10/10/10/PPPPPPPPPP/RNBQKCABNR w KQkq - 0 1"
+		<< 4 //4 plies: 809539, 5 plies: 28937546, 6 plies: 1023746640
+		<< Q_UINT64_C(809539);
 
 	variant = "coregal";
 	QTest::newRow("coregal startpos")


### PR DESCRIPTION
This is a suggestion to support Embassy Chess, a free Capablanca Chess variant by Kevin Hill, introduced in 2005. Its 10x8 starting position resembles both standard chess (8x8) and Grand Chess (10x10).

The implementation of `CapablancaBoard` castling does not match the castling rules for Embassy Chess (3 squares from e-file to b- or h-file). `EmbassyBoard` is a light-weight subclass of `CapablancaBoard`. SAN notation of castling is O-O-O for lower file castling (to b-file, king-side in chess and Embassy variant) and O-O for upper-file castling. This is consistent with xboard and with the engines I used for testing: Sjaak II (versions 1.3.1 and 1.4.1) and Fairy-Max 5.0b.

I hope this is useful.