### PR TITLE
Eight piece sets by Maurizio Monge

### DIFF
--- a/projects/gui/res/chessboard/MaurizioMonge/celtic.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/celtic.svg
@@ -1,0 +1,1633 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="celtic.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title3185">Celtic Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7935" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop7937" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop7929"
+         offset="0"
+         style="stop-color:#ede3de;stop-opacity:1;" />
+      <stop
+         id="stop7931"
+         offset="1"
+         style="stop-color:#8a6737;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7192" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="1"
+         id="stop7194" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         id="stop2268"
+         offset="0"
+         style="stop-color:#000e1c;stop-opacity:1;" />
+      <stop
+         id="stop2270"
+         offset="1"
+         style="stop-color:#50506f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3204"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1090.1432,131.11598)"
+       x1="1081.4321"
+       y1="164.36575"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3207"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1111.7492,89.858365)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3210"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-855.97561,151.24228)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3213"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1081.3063,78.358293)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3216"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1088.0259,146.67243)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1076.7187,182.65363)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3222"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1076.7187,196.65372)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3225"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-849.98684,151.24228)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3227"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-849.98684,151.24228)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3231"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,64.378515,195.70774)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3234"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.520128,191.19823)"
+       x1="906.48578"
+       y1="78.619972"
+       x2="986.08551"
+       y2="78.619972" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3237"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,68.523871,205.17203)"
+       x1="906.48578"
+       y1="78.619972"
+       x2="986.08551"
+       y2="78.619972" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3240"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,193.86357)"
+       x1="916.03479"
+       y1="100.62866"
+       x2="923.01733"
+       y2="100.62866" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3243"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.828332,200.77924)"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3246"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89304794,-0.22959621,0.22959621,0.89304794,81.552855,402.74644)"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3249"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89304794,-0.22959621,0.22959621,0.89304794,79.478155,404.12957)"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3252"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,195.70774)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,195.70774)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3258"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-657.65413,150.24227)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3261"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-881.59827,154.83975)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-878.89623,184.65365)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3267"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-878.89623,200.65375)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-651.66536,150.24227)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-651.66536,150.24227)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3276"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-453.66161,149.33756)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-690.07806,90.974124)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-668.55167,108.14472)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3285"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-668.55167,179.09672)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-673.84504,197.53703)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3291"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-447.67284,149.33756)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-447.67284,149.33756)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3297"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,987.79605,226.61867)"
+       x1="477.83588"
+       y1="745.69482"
+       x2="1070.0619"
+       y2="749.1748" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,148.44011)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,183.12756)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3306"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,216.01534)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,994.85389,225.91288)"
+       x1="462.12891"
+       y1="776.05182"
+       x2="1135.1661"
+       y2="839.35919" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,994.85389,225.91288)"
+       x1="477.83588"
+       y1="745.69482"
+       x2="1070.0619"
+       y2="749.1748" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3316"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-256.18016,144.6729)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-484.54564,115.73251)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3322"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,137.83077)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3325"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,180.78674)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3328"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,197.91283)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient3331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-250.52328,147.50135)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient3333"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-250.52328,147.50135)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3336"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1090.1432,-68.884034)"
+       x1="1081.4321"
+       y1="164.36575"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1111.7492,-110.14164)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-855.97561,-48.757737)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3345"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1081.3063,-121.64171)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1088.0259,-53.327586)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3351"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1076.7187,-17.346379)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-1076.7187,-3.3462911)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3357"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-849.98684,-48.757737)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-849.98684,-48.757737)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3363"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,64.378515,-4.292257)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3366"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.520128,-8.801762)"
+       x1="906.48578"
+       y1="78.619972"
+       x2="986.08551"
+       y2="78.619972" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3369"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,68.523871,5.1720371)"
+       x1="906.48578"
+       y1="78.619972"
+       x2="986.08551"
+       y2="78.619972" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,-6.1364362)"
+       x1="916.03479"
+       y1="100.62866"
+       x2="923.01733"
+       y2="100.62866" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.828332,0.77923533)"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3378"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89304794,-0.22959621,0.22959621,0.89304794,81.552855,202.74644)"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3381"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89304794,-0.22959621,0.22959621,0.89304794,79.478155,204.12957)"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,-4.292257)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3386"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92208958,0,0,0.92208958,70.367286,-4.292257)"
+       x1="824.63312"
+       y1="119.49339"
+       x2="992.65851"
+       y2="168.48677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3390"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-657.65413,-49.757744)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3393"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-881.59827,-45.160265)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3397"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-878.89623,-15.346369)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3400"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0703804,-878.89623,0.65373112)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-651.66536,-49.757744)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3406"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5265609,-651.66536,-49.757744)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3410"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-453.66161,-50.662439)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3414"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-690.07806,-109.02588)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-668.55167,-91.85528)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3420"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-668.55167,-20.903273)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0683705,0,0,1.0683705,-673.84504,-2.4629753)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3426"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-447.67284,-50.662439)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3389577,0,0,1.5236944,-447.67284,-50.662439)"
+       x1="660.51819"
+       y1="90.376785"
+       x2="757.72223"
+       y2="103.71878" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,987.79605,26.618668)"
+       x1="477.83588"
+       y1="745.69482"
+       x2="1070.0619"
+       y2="749.1748" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3438"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,-51.55988)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3441"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,-16.872447)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96536025,0,0,0.96536025,37.962697,16.015337)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3447"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,994.85389,25.912884)"
+       x1="462.12891"
+       y1="776.05182"
+       x2="1135.1661"
+       y2="839.35919" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3449"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13841417,0,0,0.13870064,994.85389,25.912884)"
+       x1="477.83588"
+       y1="745.69482"
+       x2="1070.0619"
+       y2="749.1748" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3453"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-256.18016,-55.327104)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3456"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-484.54564,-84.267504)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3459"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,-62.169236)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3462"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,-19.213271)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0703804,0,0,1.0703804,-478.18164,-2.0871841)"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-250.52328,-52.498659)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient3470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3414767,0,0,1.5265609,-250.52328,-52.498659)"
+       x1="683"
+       y1="74"
+       x2="739.5"
+       y2="69" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="557.39597"
+     inkscape:cy="258.63299"
+     inkscape:document-units="px"
+     inkscape:current-layer="WhitePieces"
+     showgrid="false"
+     inkscape:window-width="1602"
+     inkscape:window-height="874"
+     inkscape:window-x="99"
+     inkscape:window-y="24"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="-568.51385,608.11183"
+       id="guide8313" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Celtic Chess Piece Set</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:description>Chess piece set &quot;Celtic&quot; by Maurizio Monge.
+</dc:description>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2017-10-29</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect3532"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cscccccsssscccsccscccsc"
+         id="path4041"
+         d="m 699.91657,14.275362 c -7.37192,0 -13.35493,4.985847 -13.35493,11.129121 0,1.777106 0.50101,3.447826 1.39112,4.938548 -15.24897,4.282287 -26.25775,16.91218 -26.25777,35.161068 0.60456,16.636146 9.02233,32.053715 22.53648,41.629871 -13.48885,5.29181 -0.6609,11.20031 -0.66079,25.30566 -9.80706,17.69122 -13.18247,19.37042 -29.87474,31.78756 -1.30079,0.91951 -11.3221,1.98751 -12.24204,3.16483 -6.88667,8.81354 -3.18293,23.53411 9.73798,24.37974 9.07579,0.59399 89.32679,0.75636 98.7014,-0.27823 14.3847,-1.58751 16.61929,-16.62937 9.98143,-24.93618 -1.01667,-1.27228 -11.1333,-2.38539 -12.55503,-3.26918 -13.13062,-7.17075 -29.77021,-17.66836 -34.29161,-30.84854 -2e-5,-14.1032 15.05042,-20.01258 1.56503,-25.30566 13.94102,-9.613557 21.97261,-23.601759 23.54505,-41.629871 0.85943,-9.853453 -4.58528,-19.717846 -13.00715,-26.744669 l -13.7723,31.196318 c -1.40461,3.18646 -5.09082,4.639014 -8.27728,3.234401 -3.18646,-1.404611 -4.63902,-5.125605 -3.2344,-8.312063 l 14.46785,-32.796129 c -0.94179,-0.408673 -1.88369,-0.773352 -2.85183,-1.112913 1.14505,-1.641306 1.80848,-3.530518 1.80848,-5.564561 0,-6.143274 -5.98301,-11.129121 -13.35495,-11.129121 z"
+         style="fill:url(#linearGradient3468);fill-opacity:1;stroke:url(#linearGradient3470);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4061"
+         d="m 662.47857,172.8467 76.0289,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3465);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3462);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 683.88618,155.72061 31.07292,0"
+         id="path4063"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4065"
+         d="m 688.1677,112.76465 22.50989,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3459);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4213"
+         d="m 674.69373,91.373485 c 8.59576,10.396035 50.64385,7.60574 61.47871,-27.577337"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3456);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3453);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 744.2364,188.66508 c 14.3847,-1.58751 16.61928,-10.62933 9.98143,-18.93614 -1.01668,-1.27228 -11.1333,-2.38539 -12.55504,-3.26918 -13.13061,-7.17075 -29.77021,-19.66838 -34.2916,-32.84855 -2e-5,-14.1032 15.05041,-24.01261 1.56503,-29.30568 13.94101,-9.613561 21.9726,-23.601764 23.54504,-41.629876 0.85944,-9.853453 -1.04972,-11.232512 -9.4716,-18.259335"
+         id="path4225"
+         sodipodi:nodetypes="cscccsc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect5972"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cscsccssccscss"
+         id="path35272"
+         d="m 1100.04,49.169428 c -15.4625,0.174482 -27.8162,12.392882 -28.8402,26.607743 -0.5078,7.050203 9.7072,19.076362 15.6872,22.836803 -29.4485,6.638046 -0.5733,15.126706 -0.5732,27.361936 0,8.45448 -11.456,14.0871 -5.1837,19.51317 -3.4101,13.74236 -13.4071,18.71326 -25.5489,24.32366 -5.9737,7.64502 -2.769,20.41046 8.4388,21.14398 7.8725,0.51523 65.8993,0.65609 74.0311,-0.24134 12.4775,-1.37704 14.426,-14.42356 8.6682,-21.62905 -12.2307,-3.78939 -25.4272,-9.13976 -28.1013,-23.29558 6.4917,-5.44318 -6.7522,-11.1987 -6.7523,-19.81484 0,-12.23338 32.1681,-19.35757 1.3575,-27.361936 5.9799,-3.760442 15.5132,-15.770471 15.6871,-22.836803 0.3414,-13.873558 -14.0863,-26.774568 -28.8703,-26.607743 z"
+         style="fill:url(#linearGradient3447);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3449);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path36149"
+         d="m 1066.7072,173.78561 68.5694,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3444);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3441);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1088.0107,140.89783 24.0317,0"
+         id="path3989"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3993"
+         d="m 1089.8759,106.2104 20.3013,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3438);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3433);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 1130.9932,191.42117 c 12.4775,-1.37704 14.426,-12.4273 8.6682,-19.63279 -12.2306,-3.7894 -25.4272,-11.13602 -28.1013,-25.29184 6.4918,-5.44319 -6.7522,-11.1987 -6.7523,-19.81485 0,-12.23337 32.1682,-19.35756 1.3575,-27.361933 5.9799,-3.760442 15.5133,-15.77047 15.6871,-22.836803 0.3414,-13.873558 -12.09,-24.77831 -26.874,-24.611485"
+         id="path4229"
+         sodipodi:nodetypes="cccscss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect5557"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccccccccccsssssscccc"
+         id="path4173"
+         d="m 567.2801,30.068621 -27.04304,0.124766 0,17.217717 -24.45415,1.996257 0,-17.124142 -27.9476,0.155958 0,17.467248 -23.45602,-2.495321 0,-17.373674 -25.10917,0.62383 c -2.45774,21.16773 10.41494,26.02901 1.59077,41.048035 l 21.65691,11.423756 c 1.03975,22.881099 6.07203,52.850619 4.11739,67.395639 -7.63417,5.81461 6.81976,11.3197 -11.80051,15.12945 -2.23213,0.4567 -19.2627,1.97524 -20.18091,3.15034 -6.87373,8.79699 -3.19608,23.48534 9.70057,24.32939 9.05875,0.59286 107.1433,0.75192 116.50031,-0.28073 14.35768,-1.58453 16.57548,-16.56842 9.95009,-24.85964 -1.0148,-1.26988 -16.78086,-2.63577 -20.52402,-3.2751 -16.64645,-2.84321 -4.01698,-9.32759 -11.49849,-13.25454 -2.39977,-15.8829 1.87413,-44.95778 4.38681,-68.735961 l 22.14599,-10.866646 c -6.8327,-16.428121 4.25756,-18.896889 1.96507,-41.796632 z"
+         style="fill:url(#linearGradient3426);fill-opacity:1;stroke:url(#linearGradient3428);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4175"
+         d="m 456.68826,172.14242 91.8562,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3423);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3420);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 473.95918,153.70213 51.93106,0"
+         id="path4209"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4235"
+         d="m 473.95918,82.750113 45.94228,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3417);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3414);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 452.43278,65.579511 83.34881,0.352892"
+         id="path3375"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3410);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 554.86588,192.85714 c 14.35768,-1.58453 16.57548,-12.57591 9.95009,-20.86712 -1.0148,-1.26989 -16.78087,-2.63578 -20.52402,-3.27511 -16.64646,-2.84321 -4.01699,-13.3201 -11.49849,-17.24705 -2.39977,-15.8829 1.87413,-48.95029 4.38681,-72.728475 l 22.14599,-10.866646 c -6.00991,-12.601373 4.38972,-20.212103 1.96507,-37.804118"
+         id="path3434"
+         sodipodi:nodetypes="csscccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect4547"
+         width="200"
+         height="200"
+         x="200"
+         y="0" />
+      <path
+         sodipodi:nodetypes="cscccssscccsssscsssssssssscsssscccsc"
+         id="path4239"
+         d="m 328.38428,19.218871 c -6.23348,0 -11.29133,4.590345 -11.29133,10.250064 0,3.667678 2.14185,6.875322 5.33375,8.687554 -9.10196,22.476472 -17.72308,43.148272 -24.95321,66.031671 -6.98357,-20.582489 -13.61499,-42.270917 -22.0524,-65.125415 3.39605,-1.768555 5.67684,-5.067842 5.67685,-8.875056 0,-5.659717 -5.05785,-10.281314 -11.29133,-10.281314 -6.23348,0 -11.29132,4.621597 -11.29133,10.281314 0,4.971533 3.90254,9.095893 9.07673,10.031313 0.007,23.981396 4.90599,36.608045 -3.68059,70.219198 -13.00581,-24.930811 -20.58154,-35.572546 -36.58765,-59.000378 1.75767,-1.807777 2.83843,-4.182129 2.83843,-6.781292 0,-5.659718 -5.05785,-10.250065 -11.29133,-10.250064 -6.23349,0 -11.29133,4.590345 -11.29133,10.250064 0,5.659717 5.05785,10.250063 11.29133,10.250064 0.021,0 0.0414,1.04e-4 0.0624,0 10.70134,27.261935 15.248,40.405178 24.53411,65.597266 2.94988,8.00264 9.70549,8.28207 13.43024,17.42778 1.62484,3.98963 2.40474,19.78583 -6.05543,25.03813 -1.28193,0.79586 -17.26644,3.97897 -18.18465,5.15629 -6.87373,8.81353 -3.19609,23.52951 9.70056,24.37515 9.05875,0.59398 103.15079,0.75333 112.5078,-0.28125 14.35768,-1.58751 16.57548,-16.5996 9.95009,-24.90641 -1.0148,-1.27228 -15.34728,-2.92846 -18.52776,-5.28128 -5.80845,-4.29694 -8.66079,-18.75215 -7.29941,-24.19438 2.06758,-8.26534 9.77218,-7.60953 11.8565,-14.51865 9.08608,-30.118788 16.66945,-41.465656 29.66,-68.475147 0.30955,0.02316 0.61965,0.0625 0.93575,0.0625 6.23348,0 11.29134,-4.590347 11.29133,-10.250064 0,-5.659718 -5.05787,-10.250065 -11.29133,-10.250064 -6.23348,0 -11.29133,4.590345 -11.29133,10.250064 0,2.645302 1.11829,5.055754 2.932,6.875043 -21.02753,25.280912 -27.72722,34.563556 -43.04429,59.844128 -5.4889,-26.833867 -0.0742,-46.296734 1.27885,-72.031704 4.81429,-1.172677 8.35933,-5.135488 8.35933,-9.875062 0,-5.659718 -5.05787,-10.250064 -11.29133,-10.250064 z"
+         style="fill:url(#linearGradient3403);fill-opacity:1;stroke:url(#linearGradient3406);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3400);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 251.63707,175.58761 91.8562,0"
+         id="path4241"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path4245"
+         d="m 263.61461,159.58751 51.93106,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3397);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3393);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 260.91257,129.77362 67.90111,0"
+         id="path4289"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3390);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 324.04866,111.3757 c -5.4889,-26.833866 -0.0742,-46.296733 1.27885,-72.031703 4.81428,-1.172677 8.35933,-5.135488 8.35933,-9.875062 0,-5.659718 -5.05787,-8.250052 -11.29133,-8.250052 m 26.4816,171.001077 c 14.35767,-1.58751 16.57548,-14.59958 9.95009,-22.9064 -1.0148,-1.27227 -15.34728,-2.92845 -18.52776,-5.28128 -5.80845,-4.29694 -8.66079,-22.75217 -7.29942,-28.19441 2.06759,-8.26534 9.77219,-7.60952 11.8565,-14.51865 9.08609,-30.11878 16.66946,-39.465636 29.66001,-66.475127 0.30955,0.02316 0.61965,0.0625 0.93575,0.0625 6.23348,0 11.29134,-4.590347 11.29133,-10.250064 0,-5.659718 -5.05787,-8.250053 -11.29133,-8.250052"
+         id="path2601"
+         sodipodi:nodetypes="ccsccsssscsss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect5867"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccsscccccssccscscsssscc"
+         id="path8413"
+         d="m 892.41016,10.613254 -5.07149,17.980747 -12.90925,-14.753433 c 0,0 -0.45932,10.505274 -0.92209,19.306251 -19.79844,19.995787 -8.32851,24.339506 -37.56604,69.066131 -1.89937,2.90558 -5.46819,5.3376 -6.23322,9.21704 -3.44061,17.44714 19.11956,13.02985 23.12456,15.0235 15.44149,-12.45388 21.79646,-12.59053 29.89559,-21.47813 9.20253,3.40789 23.45613,-0.55956 32.0426,-9.681933 -5.58124,16.851473 -29.64352,28.815843 -36.8061,58.135773 8.3811,8.24857 0.0128,16.18775 -10.43757,15.62708 -11.22039,2.60832 -7.35691,23.74886 4.2574,23.69182 l 98.58555,-0.48422 c 13.77123,-0.0677 15.71398,-20.17938 6.58993,-23.64547 -8.65736,-0.0237 -12.72537,-9.06779 -5.58795,-15.08662 0.80395,-16.15731 0.64412,-31.32178 -2.78027,-46.65553 -0.35197,-1.57606 0.50923,-4.90062 2.33157,-5.23386 -1.37823,-5.145491 -6.64174,-9.824235 -8.88976,-15.077865 -1.08063,-2.525417 -3.91506,-3.727903 4.30193,-4.064703 -2.48602,-4.653446 -13.28824,-12.575184 -16.70248,-16.906272 -1.17198,-1.486697 5.51772,-2.863364 4.19055,-4.272623 -7.53952,-8.005842 -18.49187,-10.846633 -23.76085,-14.822009 -1.79722,-1.355982 5.02895,-3.153722 3.073,-4.443172 -7.20322,-4.748676 -22.20902,-10.554351 -31.76405,-14.268583 l -8.96156,-17.173919 z"
+         style="fill:url(#linearGradient3384);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3386);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31294"
+         d="m 879.93611,62.45862 c -6.2277,0.431326 -10.99705,3.498383 -14.20078,8.890264"
+         style="fill:none;stroke:url(#linearGradient3381);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31298"
+         d="m 874.09278,70.023415 c 2.69511,1.626995 5.43653,1.018938 4.93368,-2.793859"
+         style="fill:none;stroke:url(#linearGradient3378);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31300"
+         d="m 840.33662,110.22049 c -2.92555,-1.01045 -5.04209,3.70309 -3.17546,3.89538"
+         style="fill:none;stroke:url(#linearGradient3375);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3191"
+         d="m 917.45808,89.301013 c 2.03857,-2.762761 1.8305,-4.117057 2.3228,-5.745878"
+         style="fill:none;stroke:url(#linearGradient3372);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3971"
+         d="m 885.1841,167.41456 75.80877,-0.007"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3369);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3366);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 887.18036,153.44076 59.83871,-0.007"
+         id="path3416"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3363);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 964.38133,192.26388 c 13.77123,-0.0677 15.71398,-16.18686 6.58993,-19.65296 -8.65736,-0.0237 -12.72537,-13.0603 -5.58795,-19.07913 0.80395,-16.15731 0.64412,-31.32178 -2.78027,-46.65553 -0.35197,-1.57606 0.50922,-4.90062 2.33157,-5.23386 -1.37823,-5.145491 -6.64174,-7.827978 -8.88976,-13.081607 -1.08063,-2.525418 -3.91506,-3.727904 4.30193,-4.064704 -2.48602,-4.653446 -13.28824,-12.575184 -16.70248,-16.906272 -1.17199,-1.486697 5.51772,-2.863364 4.19055,-4.272623 -7.53952,-8.005842 -18.49187,-10.846633 -23.76085,-14.822009 -1.79722,-1.355982 5.02895,-3.153722 3.073,-4.443172 -7.20322,-4.748676 -16.22025,-12.550608 -25.77528,-16.26484"
+         id="path3446"
+         sodipodi:nodetypes="cccscscssssc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect3452"
+         width="200"
+         height="200"
+         x="0"
+         y="0" />
+      <path
+         style="fill:url(#linearGradient3357);fill-opacity:1;stroke:url(#linearGradient3359);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 90.798503,12.68758 c -4.380574,3.961845 1.90645,7.228385 0,13.531334 l -17.529632,-0.0312 0,16.500103 17.529632,0.0312 -8.92261,8.145581 -1.405134,3.19293 8.28088,8.517833 1.41936,9.452659 -10.778525,-0.659964 c -39.78189,-16.814504 -72.084622,-29.253772 -42.27457,25.4763 2.796761,5.134744 16.072318,16.246074 8.359326,23.656404 2.94988,8.00264 9.687606,6.29189 13.412352,15.43759 1.624843,3.98964 2.409013,19.77911 -6.051154,25.03141 -1.281926,0.79586 -17.266445,3.97897 -18.184654,5.15628 -6.873732,8.81354 -3.196087,23.52952 9.700562,24.37516 9.058754,0.59398 103.150794,0.75333 112.507794,-0.28126 14.35768,-1.58751 16.57548,-16.59959 9.9501,-24.9064 -1.0148,-1.27228 -15.34729,-2.92846 -18.52776,-5.28128 -5.80845,-4.29694 -8.6602,-18.74542 -7.29882,-24.18766 2.06759,-8.26534 9.76847,-7.62221 11.85278,-14.53134 -12.17404,-8.61826 6.53982,-17.79863 9.5446,-23.468897 28.63908,-54.044139 0.55097,-43.257241 -40.37581,-26.181784 l -11.99474,0.681624 1.55197,-9.58473 8.20773,-8.419073 -1.55633,-2.996328 -8.98316,-8.625054 17.52963,0.03125 0,-16.468853 -17.52963,-0.03125 c -3.1509,-6.009228 4.73986,-8.448123 0,-13.562585 l -18.434187,0 z"
+         id="path3454"
+         sodipodi:nodetypes="ccccccccccscsssssssscsccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3354);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 53.814662,171.58759 91.856198,0"
+         id="path3456"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3458"
+         d="m 65.792204,157.5875 51.931056,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3351);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3460"
+         d="m 54.484975,121.6063 c 32.537064,3.63337 59.005935,3.22204 81.874915,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3348);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3462"
+         d="m 89.152207,53.292164 14.002173,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3345);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssscscccccccccc"
+         id="path3464"
+         d="m 150.87336,190.21994 c 14.35768,-1.58751 16.57548,-14.59958 9.9501,-22.90639 -1.0148,-1.27228 -13.35103,-1.92845 -16.53151,-4.28128 -5.80845,-4.29693 -10.65645,-21.74543 -9.29507,-27.18767 2.06758,-8.26534 9.76846,-7.62221 11.85278,-14.53134 -10.17778,-9.61827 6.53981,-15.79862 9.5446,-21.468885 28.63908,-54.044138 8.94943,-38.782343 -36.3833,-22.681762 l -14.98913,-0.818385 0.55385,-13.584755 8.20773,-8.419073 -1.55634,-2.996328 -8.98315,-12.625079 17.52963,0.0312 0,-8.468803 -17.52963,-0.0312 c -3.1509,-6.009228 4.73986,-12.448148 0,-17.56261"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3342);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3466"
+         d="m 30.761689,64.792236 c 1.18298,-9.067577 33.879457,5.930977 48.936667,9.500059"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3339);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3336);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 44.211345,101.17114 c 12.3872,15.225 105.763935,12.64992 118.847225,-20.198623"
+         id="path3468"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <path
+         sodipodi:nodetypes="cscccccsssscccsccscccsc"
+         id="path6213"
+         d="m 699.91657,214.27536 c -7.37192,0 -13.35493,4.98585 -13.35493,11.12912 0,1.77711 0.50101,3.44783 1.39112,4.93855 -15.24897,4.28229 -26.25775,16.91218 -26.25777,35.16107 0.60456,16.63615 9.02233,32.05371 22.53648,41.62987 -13.48885,5.29181 -0.6609,11.20031 -0.66079,25.30566 -9.80706,17.69122 -13.18247,19.37042 -29.87474,31.78756 -1.30079,0.91951 -11.3221,1.98751 -12.24204,3.16483 -6.88667,8.81354 -3.18293,23.53411 9.73798,24.37974 9.07579,0.59399 89.32679,0.75636 98.7014,-0.27823 14.3847,-1.58751 16.61929,-16.62937 9.98143,-24.93618 -1.01667,-1.27228 -11.1333,-2.38539 -12.55503,-3.26918 -13.13062,-7.17075 -29.77021,-17.66836 -34.29161,-30.84854 -2e-5,-14.1032 15.05042,-20.01258 1.56503,-25.30566 13.94102,-9.61356 21.97261,-23.60175 23.54505,-41.62987 0.85943,-9.85345 -4.58528,-19.71784 -13.00715,-26.74466 l -13.7723,31.19631 c -1.40461,3.18646 -5.09082,4.63901 -8.27728,3.2344 -3.18646,-1.40461 -4.63902,-5.1256 -3.2344,-8.31206 l 14.46785,-32.79612 c -0.94179,-0.40868 -1.88369,-0.77336 -2.85183,-1.11292 1.14505,-1.64131 1.80848,-3.53052 1.80848,-5.56457 0,-6.14327 -5.98301,-11.12912 -13.35495,-11.12912 z"
+         style="fill:url(#linearGradient3331);fill-opacity:1;stroke:url(#linearGradient3333);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6215"
+         d="m 662.47857,372.8467 76.0289,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3328);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3325);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 683.88618,355.72061 31.07292,0"
+         id="path6217"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6219"
+         d="m 688.1677,312.76465 22.50989,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3322);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6221"
+         d="m 674.69373,291.37349 c 8.59576,10.39603 50.64385,7.60574 61.47871,-27.57734"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3319);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3316);stroke-width:5.00003147;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 744.2364,388.66508 c 14.3847,-1.58751 16.61928,-10.62933 9.98143,-18.93614 -1.01668,-1.27228 -11.1333,-2.38539 -12.55504,-3.26918 -13.13061,-7.17075 -29.77021,-19.66838 -34.2916,-32.84855 -2e-5,-14.1032 15.05041,-24.01261 1.56503,-29.30568 13.94101,-9.61355 21.9726,-23.60176 23.54504,-41.62987 0.85944,-9.85346 -1.04972,-11.23251 -9.4716,-18.25934"
+         id="path6223"
+         sodipodi:nodetypes="cscccsc"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="200"
+         x="600"
+         height="200"
+         width="200"
+         id="rect6211"
+         style="fill:none;stroke:none" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         y="200"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect6227"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cscsccssccscss"
+         id="path6229"
+         d="m 1100.04,249.16943 c -15.4625,0.17448 -27.8162,12.39288 -28.8402,26.60774 -0.5078,7.0502 9.7072,19.07636 15.6872,22.8368 -29.4485,6.63805 -0.5733,15.12671 -0.5732,27.36194 0,8.45448 -11.456,14.0871 -5.1837,19.51317 -3.4101,13.74236 -13.4071,18.71326 -25.5489,24.32366 -5.9737,7.64502 -2.769,20.41046 8.4388,21.14398 7.8725,0.51523 65.8993,0.65609 74.0311,-0.24134 12.4775,-1.37704 14.426,-14.42356 8.6682,-21.62905 -12.2307,-3.78939 -25.4272,-9.13976 -28.1013,-23.29558 6.4917,-5.44318 -6.7522,-11.1987 -6.7523,-19.81484 0,-12.23338 32.1681,-19.35757 1.3575,-27.36194 5.9799,-3.76044 15.5132,-15.77047 15.6871,-22.8368 0.3414,-13.87356 -14.0863,-26.77457 -28.8703,-26.60774 z"
+         style="fill:url(#linearGradient3309);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3311);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6231"
+         d="m 1066.7072,373.78561 68.5694,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3306);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3303);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1088.0107,340.89783 24.0317,0"
+         id="path6233"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6235"
+         d="m 1089.8759,306.2104 20.3013,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3300);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3297);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 1130.9932,391.42117 c 12.4775,-1.37704 14.426,-12.4273 8.6682,-19.63279 -12.2306,-3.7894 -25.4272,-11.13602 -28.1013,-25.29184 6.4918,-5.44319 -6.7522,-11.1987 -6.7523,-19.81485 0,-12.23337 32.1682,-19.35756 1.3575,-27.36193 5.9799,-3.76044 15.5133,-15.77047 15.6871,-22.83681 0.3414,-13.87355 -12.09,-24.77831 -26.874,-24.61148"
+         id="path6237"
+         sodipodi:nodetypes="cccscss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         y="200"
+         x="400"
+         height="200"
+         width="200"
+         id="rect6241"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccccccccccccsssssscccc"
+         id="path6243"
+         d="m 567.2801,230.06862 -27.04304,0.12477 0,17.21771 -24.45415,1.99626 0,-17.12414 -27.9476,0.15596 0,17.46725 -23.45602,-2.49533 0,-17.37367 -25.10917,0.62383 c -2.45774,21.16773 10.41494,26.02901 1.59077,41.04804 l 21.65691,11.42375 c 1.03975,22.8811 6.07203,52.85062 4.11739,67.39564 -7.63417,5.81461 6.81976,11.3197 -11.80051,15.12945 -2.23213,0.4567 -19.2627,1.97524 -20.18091,3.15034 -6.87373,8.79699 -3.19608,23.48534 9.70057,24.32939 9.05875,0.59286 107.1433,0.75192 116.50031,-0.28073 14.35768,-1.58453 16.57548,-16.56842 9.95009,-24.85964 -1.0148,-1.26988 -16.78086,-2.63577 -20.52402,-3.2751 -16.64645,-2.84321 -4.01698,-9.32759 -11.49849,-13.25454 -2.39977,-15.8829 1.87413,-44.95778 4.38681,-68.73596 l 22.14599,-10.86665 c -6.8327,-16.42811 4.25756,-18.89689 1.96507,-41.79663 z"
+         style="fill:url(#linearGradient3291);fill-opacity:1;stroke:url(#linearGradient3293);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6245"
+         d="m 456.68826,372.14242 91.8562,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3288);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3285);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 473.95918,353.70213 51.93106,0"
+         id="path6247"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6249"
+         d="m 473.95918,282.75011 45.94228,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3282);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3279);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 452.43278,265.57951 83.34881,0.3529"
+         id="path6251"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3276);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 554.86588,392.85714 c 14.35768,-1.58453 16.57548,-12.57591 9.95009,-20.86712 -1.0148,-1.26989 -16.78087,-2.63578 -20.52402,-3.27511 -16.64646,-2.84321 -4.01699,-13.3201 -11.49849,-17.24705 -2.39977,-15.8829 1.87413,-48.95029 4.38681,-72.72848 l 22.14599,-10.86664 c -6.00991,-12.60137 4.38972,-20.2121 1.96507,-37.80412"
+         id="path6253"
+         sodipodi:nodetypes="csscccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6259"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         sodipodi:nodetypes="cscccssscccsssscsssssssssscsssscccsc"
+         id="path6261"
+         d="m 328.38428,219.21887 c -6.23348,0 -11.29133,4.59035 -11.29133,10.25007 0,3.66767 2.14185,6.87532 5.33375,8.68755 -9.10196,22.47647 -17.72308,43.14827 -24.95321,66.03167 -6.98357,-20.58248 -13.61499,-42.27092 -22.0524,-65.12541 3.39605,-1.76855 5.67684,-5.06784 5.67685,-8.87506 0,-5.65971 -5.05785,-10.28131 -11.29133,-10.28131 -6.23348,0 -11.29132,4.6216 -11.29133,10.28131 0,4.97153 3.90254,9.0959 9.07673,10.03132 0.007,23.9814 4.90599,36.60805 -3.68059,70.21919 -13.00581,-24.93081 -20.58154,-35.57255 -36.58765,-59.00037 1.75767,-1.80779 2.83843,-4.18213 2.83843,-6.7813 0,-5.65971 -5.05785,-10.25006 -11.29133,-10.25006 -6.23349,0 -11.29133,4.59035 -11.29133,10.25006 0,5.65972 5.05785,10.25007 11.29133,10.25007 0.021,0 0.0414,1e-4 0.0624,0 10.70134,27.26193 15.248,40.40517 24.53411,65.59726 2.94988,8.00264 9.70549,8.28207 13.43024,17.42778 1.62484,3.98963 2.40474,19.78583 -6.05543,25.03813 -1.28193,0.79586 -17.26644,3.97897 -18.18465,5.15629 -6.87373,8.81353 -3.19609,23.52951 9.70056,24.37515 9.05875,0.59398 103.15079,0.75333 112.5078,-0.28125 14.35768,-1.58751 16.57548,-16.5996 9.95009,-24.90641 -1.0148,-1.27228 -15.34728,-2.92846 -18.52776,-5.28128 -5.80845,-4.29694 -8.66079,-18.75215 -7.29941,-24.19438 2.06758,-8.26534 9.77218,-7.60953 11.8565,-14.51865 9.08608,-30.11878 16.66945,-41.46565 29.66,-68.47514 0.30955,0.0232 0.61965,0.0625 0.93575,0.0625 6.23348,0 11.29134,-4.59035 11.29133,-10.25007 0,-5.65971 -5.05787,-10.25006 -11.29133,-10.25006 -6.23348,0 -11.29133,4.59035 -11.29133,10.25006 0,2.64531 1.11829,5.05576 2.932,6.87505 -21.02753,25.2809 -27.72722,34.56355 -43.04429,59.84412 -5.4889,-26.83387 -0.0742,-46.29673 1.27885,-72.0317 4.81429,-1.17268 8.35933,-5.13549 8.35933,-9.87506 0,-5.65972 -5.05787,-10.25007 -11.29133,-10.25007 z"
+         style="fill:url(#linearGradient3270);fill-opacity:1;stroke:url(#linearGradient3272);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3267);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 251.63707,375.58761 91.8562,0"
+         id="path6263"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6265"
+         d="m 263.61461,359.58751 51.93106,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3264);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3261);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 260.91257,329.77362 67.90111,0"
+         id="path6267"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3258);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 324.04866,311.3757 c -5.4889,-26.83387 -0.0742,-46.29673 1.27885,-72.0317 4.81428,-1.17268 8.35933,-5.13549 8.35933,-9.87506 0,-5.65972 -5.05787,-8.25005 -11.29133,-8.25005 m 26.4816,171.00107 c 14.35767,-1.58751 16.57548,-14.59958 9.95009,-22.9064 -1.0148,-1.27227 -15.34728,-2.92845 -18.52776,-5.28128 -5.80845,-4.29694 -8.66079,-22.75217 -7.29942,-28.19441 2.06759,-8.26534 9.77219,-7.60952 11.8565,-14.51865 9.08609,-30.11878 16.66946,-39.46563 29.66001,-66.47512 0.30955,0.0232 0.61965,0.0625 0.93575,0.0625 6.23348,0 11.29134,-4.59035 11.29133,-10.25007 0,-5.65971 -5.05787,-8.25005 -11.29133,-8.25005"
+         id="path6269"
+         sodipodi:nodetypes="ccsccsssscsss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         y="200"
+         x="800"
+         height="200"
+         width="200"
+         id="rect6273"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccsscccccssccscscsssscc"
+         id="path6275"
+         d="m 892.41016,210.61325 -5.07149,17.98075 -12.90925,-14.75343 c 0,0 -0.45932,10.50527 -0.92209,19.30625 -19.79844,19.99579 -8.32851,24.3395 -37.56604,69.06613 -1.89937,2.90558 -5.46819,5.3376 -6.23322,9.21704 -3.44061,17.44714 19.11956,13.02985 23.12456,15.0235 15.44149,-12.45388 21.79646,-12.59053 29.89559,-21.47813 9.20253,3.40789 23.45613,-0.55956 32.0426,-9.68194 -5.58124,16.85148 -29.64352,28.81585 -36.8061,58.13578 8.3811,8.24857 0.0128,16.18775 -10.43757,15.62708 -11.22039,2.60832 -7.35691,23.74886 4.2574,23.69182 l 98.58555,-0.48422 c 13.77123,-0.0677 15.71398,-20.17938 6.58993,-23.64547 -8.65736,-0.0237 -12.72537,-9.06779 -5.58795,-15.08662 0.80395,-16.15731 0.64412,-31.32178 -2.78027,-46.65553 -0.35197,-1.57606 0.50923,-4.90062 2.33157,-5.23386 -1.37823,-5.14549 -6.64174,-9.82424 -8.88976,-15.07787 -1.08063,-2.52541 -3.91506,-3.7279 4.30193,-4.0647 -2.48602,-4.65344 -13.28824,-12.57518 -16.70248,-16.90627 -1.17198,-1.4867 5.51772,-2.86336 4.19055,-4.27263 -7.53952,-8.00584 -18.49187,-10.84663 -23.76085,-14.82201 -1.79722,-1.35597 5.02895,-3.15371 3.073,-4.44316 -7.20322,-4.74868 -22.20902,-10.55436 -31.76405,-14.26859 l -8.96156,-17.17392 z"
+         style="fill:url(#linearGradient3252);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3254);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path6277"
+         d="m 879.93611,262.45862 c -6.2277,0.43132 -10.99705,3.49838 -14.20078,8.89026"
+         style="fill:none;stroke:url(#linearGradient3249);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path6279"
+         d="m 874.09278,270.02342 c 2.69511,1.627 5.43653,1.01894 4.93368,-2.79387"
+         style="fill:none;stroke:url(#linearGradient3246);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path6281"
+         d="m 840.33662,310.22049 c -2.92555,-1.01045 -5.04209,3.70309 -3.17546,3.89538"
+         style="fill:none;stroke:url(#linearGradient3243);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6283"
+         d="m 917.45808,289.30101 c 2.03857,-2.76276 1.8305,-4.11705 2.3228,-5.74588"
+         style="fill:none;stroke:url(#linearGradient3240);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6285"
+         d="m 885.1841,367.41456 75.80877,-0.007"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3237);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3234);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 887.18036,353.44076 59.83871,-0.007"
+         id="path6287"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3231);stroke-width:4.99064255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 964.38133,392.26388 c 13.77123,-0.0677 15.71398,-16.18686 6.58993,-19.65296 -8.65736,-0.0237 -12.72537,-13.0603 -5.58795,-19.07913 0.80395,-16.15731 0.64412,-31.32178 -2.78027,-46.65553 -0.35197,-1.57606 0.50922,-4.90062 2.33157,-5.23386 -1.37823,-5.14549 -6.64174,-7.82798 -8.88976,-13.08161 -1.08063,-2.52542 -3.91506,-3.7279 4.30193,-4.0647 -2.48602,-4.65344 -13.28824,-12.57518 -16.70248,-16.90627 -1.17199,-1.4867 5.51772,-2.86337 4.19055,-4.27263 -7.53952,-8.00584 -18.49187,-10.84663 -23.76085,-14.82201 -1.79722,-1.35598 5.02895,-3.15372 3.073,-4.44317 -7.20322,-4.74867 -16.22025,-12.55061 -25.77528,-16.26484"
+         id="path6289"
+         sodipodi:nodetypes="cccscscssssc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         y="200"
+         x="0"
+         height="200"
+         width="200"
+         id="rect6295"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccccccccscsssssssscsccccccccccc"
+         id="path6297"
+         d="m 90.798503,212.68758 c -4.380574,3.96185 1.90645,7.22839 0,13.53134 l -17.529632,-0.0312 0,16.5001 17.529632,0.0312 -8.92261,8.14558 -1.405134,3.19293 8.28088,8.51784 1.41936,9.45266 -10.778525,-0.65997 c -39.78189,-16.8145 -72.084622,-29.25377 -42.27457,25.4763 2.796761,5.13474 16.072318,16.24607 8.359326,23.6564 2.94988,8.00264 9.687606,6.29189 13.412352,15.43759 1.624843,3.98964 2.409013,19.77911 -6.051154,25.03141 -1.281926,0.79586 -17.266445,3.97897 -18.184654,5.15628 -6.873732,8.81354 -3.196087,23.52952 9.700562,24.37516 9.058754,0.59398 103.150794,0.75333 112.507794,-0.28126 14.35768,-1.58751 16.57548,-16.59959 9.9501,-24.9064 -1.0148,-1.27228 -15.34729,-2.92846 -18.52776,-5.28128 -5.80845,-4.29694 -8.6602,-18.74542 -7.29882,-24.18766 2.06759,-8.26534 9.76847,-7.62221 11.85278,-14.53134 -12.17404,-8.61826 6.53982,-17.79863 9.5446,-23.46889 28.63908,-54.04414 0.55097,-43.25724 -40.37581,-26.18179 l -11.99474,0.68163 1.55197,-9.58473 8.20773,-8.41908 -1.55633,-2.99632 -8.98316,-8.62506 17.52963,0.0312 0,-16.46885 -17.52963,-0.0312 c -3.1509,-6.00923 4.73986,-8.44812 0,-13.56259 l -18.434187,0 z"
+         style="fill:url(#linearGradient3225);fill-opacity:1;stroke:url(#linearGradient3227);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6305"
+         d="m 53.814662,371.58759 91.856198,0"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3222);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3219);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 65.792204,357.5875 51.931056,0"
+         id="path6307"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3216);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 54.484975,321.6063 c 32.537064,3.63337 59.005935,3.22204 81.874915,0"
+         id="path6313"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3213);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 89.152207,253.29217 14.002173,0"
+         id="path2631"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3210);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         d="m 150.87336,390.21994 c 14.35768,-1.58751 16.57548,-14.59958 9.9501,-22.90639 -1.0148,-1.27228 -13.35103,-1.92845 -16.53151,-4.28128 -5.80845,-4.29693 -10.65645,-21.74543 -9.29507,-27.18767 2.06758,-8.26534 9.76846,-7.62221 11.85278,-14.53134 -10.17778,-9.61827 6.53981,-15.79862 9.5446,-21.46888 28.63908,-54.04414 8.94943,-38.78234 -36.3833,-22.68176 l -14.98913,-0.81839 0.55385,-13.58475 8.20773,-8.41908 -1.55634,-2.99632 -8.98315,-12.62508 17.52963,0.0312 0,-8.46881 -17.52963,-0.0312 c -3.1509,-6.00922 4.73986,-12.44814 0,-17.56261"
+         id="path2635"
+         sodipodi:nodetypes="cssscscccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3207);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 30.761689,264.79224 c 1.18298,-9.06758 33.879457,5.93098 48.936667,9.50006"
+         id="path3430"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path3435"
+         d="m 44.211345,301.17114 c 12.3872,15.225 105.763935,12.64992 118.847225,-20.19862"
+         style="opacity:0.5;fill:none;stroke:url(#linearGradient3204);stroke-width:4.99533463;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/eyes.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/eyes.svg
@@ -1,0 +1,2593 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg10114"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="eyes.svg">
+  <title
+     id="title11171">Eyes Chess Piece Set</title>
+  <defs
+     id="defs10116">
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         id="stop11900"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop11902"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop11490" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="1"
+         id="stop11492" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22762766,0,0,0.19465417,2.74708,37.31243)"
+       x1="43.573158"
+       y1="333.44388"
+       x2="800.5191"
+       y2="598.4873" />
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop2509-4" />
+      <stop
+         style="stop-color:#505070;stop-opacity:1"
+         offset="1"
+         id="stop2511-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop12734"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop12736"
+         offset="1"
+         style="stop-color:#d0b090;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10266"
+       gradientUnits="userSpaceOnUse"
+       x1="331.76324"
+       y1="305.12201"
+       x2="423.26685"
+       y2="338.0408" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10276"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,-0.06024,0.97226)"
+       x1="323.8295"
+       y1="142.8746"
+       x2="554.56183"
+       y2="278.80081" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10262"
+       gradientUnits="userSpaceOnUse"
+       x1="340.95712"
+       y1="313.54886"
+       x2="473.57257"
+       y2="397.77173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10260"
+       gradientUnits="userSpaceOnUse"
+       x1="340.95712"
+       y1="313.54886"
+       x2="473.57257"
+       y2="397.77173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1342"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="120.35538"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="126.04134"
+       y2="285.82776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1334"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="127.46282"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10327"
+       x1="31.999996"
+       y1="245.83333"
+       x2="128.88431"
+       y2="288.96759"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10007"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19287063,0,0,0.2151728,214.47626,9.1749504)"
+       x1="32"
+       y1="385"
+       x2="733.7486"
+       y2="624.01056" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5799-3"
+       gradientUnits="userSpaceOnUse"
+       x1="290.95712"
+       y1="590.21552"
+       x2="448.875"
+       y2="663.43127"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-0.76189959)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2229-2"
+       x1="460.95712"
+       y1="666.4375"
+       x2="617.15698"
+       y2="756.83856"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-0.76189959)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient13034"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.18124526,403.44481,17.3959)"
+       x1="296.44843"
+       y1="-160.70204"
+       x2="739.72266"
+       y2="253.50563" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5753"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.20145326,401.52381,17.30008)"
+       x1="102"
+       y1="801.66663"
+       x2="769.66669"
+       y2="801.66663" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2446"
+       gradientUnits="userSpaceOnUse"
+       x1="442.08737"
+       y1="413.31122"
+       x2="667.427"
+       y2="504.29163"
+       gradientTransform="matrix(0.21522263,0,0,0.20736686,356.41691,-3.8030696)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2440"
+       x1="458.29816"
+       y1="411.12521"
+       x2="667.42706"
+       y2="514.29163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21522263,0,0,0.20013074,407.06586,2.0553804)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient4315"
+       x1="13.155726"
+       y1="426.90005"
+       x2="759.8902"
+       y2="674.65308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20569692,0,0,0.22857143,410.35042,-1.0774996)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07645234,-0.00589498,0.00961476,0.12635223,713.60462,43.303528)"
+       x1="-685.27356"
+       y1="274.73871"
+       x2="-199.66586"
+       y2="439.2937" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23799086,0,0,0.22261783,599.37953,-6.7335617)"
+       x1="193.54391"
+       y1="362.5"
+       x2="641.33331"
+       y2="550.2157" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7567"
+       gradientUnits="userSpaceOnUse"
+       x1="500.21057"
+       y1="376.73962"
+       x2="216.33333"
+       y2="486.99237"
+       gradientTransform="matrix(-0.23799086,0,0,0.22261783,800.05591,-8.9597417)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23799086,0,0,0.22261783,601.75944,15.027408)"
+       x1="193.54391"
+       y1="362.5"
+       x2="628"
+       y2="362.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient4957"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21342286,0,0,0.20212617,605.15097,23.395808)"
+       x1="300.95712"
+       y1="606.8822"
+       x2="470.23923"
+       y2="701.10504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient4955"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21342286,0,0,0.20212617,604.44534,23.622228)"
+       x1="470.95712"
+       y1="633.10419"
+       x2="616.90588"
+       y2="694.43842" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2229-6"
+       x1="340.95712"
+       y1="313.54886"
+       x2="553.43683"
+       y2="414.99799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,4.1259766e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2513"
+       x1="63.677078"
+       y1="137.90625"
+       x2="741.16382"
+       y2="814.15625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.45714,2.7428604)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20848549,0,0,0.20045097,1013.463,34.04674)"
+       x1="224.06509"
+       y1="423.88376"
+       x2="710.13196"
+       y2="599.74866" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2226"
+       gradientUnits="userSpaceOnUse"
+       x1="321.98315"
+       y1="380.02527"
+       x2="469.97644"
+       y2="469.5921" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2243"
+       x1="338.48233"
+       y1="308.13605"
+       x2="550.11517"
+       y2="385.91779"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000.3918,2.15499)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5897"
+       gradientUnits="userSpaceOnUse"
+       x1="204.24982"
+       y1="662.38818"
+       x2="421.71808"
+       y2="792"
+       gradientTransform="matrix(0.2516928,0,0,0.2516928,989.76084,-15.09882)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5901"
+       gradientUnits="userSpaceOnUse"
+       x1="468.23636"
+       y1="681.24438"
+       x2="270.86862"
+       y2="792"
+       gradientTransform="matrix(-0.2516928,0,0,0.2516928,1212.6818,-15.09882)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11746"
+       gradientUnits="userSpaceOnUse"
+       x1="340.95712"
+       y1="313.54886"
+       x2="473.57257"
+       y2="397.77173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11750"
+       gradientUnits="userSpaceOnUse"
+       x1="340.95712"
+       y1="313.54886"
+       x2="473.57257"
+       y2="397.77173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,-0.06024,200.97226)"
+       x1="323.8295"
+       y1="142.8746"
+       x2="554.56183"
+       y2="278.80081" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11762"
+       gradientUnits="userSpaceOnUse"
+       x1="331.76324"
+       y1="305.12201"
+       x2="423.26685"
+       y2="338.0408" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11766"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22762766,0,0,0.19465417,2.74708,237.31243)"
+       x1="43.573158"
+       y1="333.44388"
+       x2="800.5191"
+       y2="598.4873" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11772"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,199.2381)"
+       x1="460.95712"
+       y1="666.4375"
+       x2="617.15698"
+       y2="756.83856" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,199.2381)"
+       x1="290.95712"
+       y1="590.21552"
+       x2="448.875"
+       y2="663.43127" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19287063,0,0,0.2151728,214.47626,209.17495)"
+       x1="32"
+       y1="385"
+       x2="733.7486"
+       y2="624.01056" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11788"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="128.88431"
+       y2="288.96759" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11794"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="127.46282"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11798"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="126.04134"
+       y2="285.82776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11802"
+       gradientUnits="userSpaceOnUse"
+       x1="31.999996"
+       y1="245.83333"
+       x2="120.35538"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20569692,0,0,0.22857143,410.35042,198.9225)"
+       x1="13.155726"
+       y1="426.90005"
+       x2="759.8902"
+       y2="674.65308" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11810"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21522263,0,0,0.20013074,407.06586,202.05538)"
+       x1="458.29816"
+       y1="411.12521"
+       x2="667.42706"
+       y2="514.29163" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21522263,0,0,0.20736686,356.41691,196.19693)"
+       x1="442.08737"
+       y1="413.31122"
+       x2="667.427"
+       y2="504.29163" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11818"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.20145326,401.52381,217.30008)"
+       x1="102"
+       y1="801.66663"
+       x2="769.66669"
+       y2="801.66663" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11822"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.18124526,403.44481,217.3959)"
+       x1="296.44843"
+       y1="-160.70204"
+       x2="739.72266"
+       y2="253.50563" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11834"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21342286,0,0,0.20212617,604.44534,223.62223)"
+       x1="470.95712"
+       y1="633.10419"
+       x2="616.90588"
+       y2="694.43842" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11838"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21342286,0,0,0.20212617,605.15097,223.39581)"
+       x1="300.95712"
+       y1="606.8822"
+       x2="470.23923"
+       y2="701.10504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11846"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23799086,0,0,0.22261783,601.75944,215.02741)"
+       x1="193.54391"
+       y1="362.5"
+       x2="628"
+       y2="362.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11850"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.23799086,0,0,0.22261783,800.05591,191.04026)"
+       x1="500.21057"
+       y1="376.73962"
+       x2="216.33333"
+       y2="486.99237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11854"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23799086,0,0,0.22261783,599.37953,193.26644)"
+       x1="193.54391"
+       y1="362.5"
+       x2="641.33331"
+       y2="550.2157" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11858"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07645234,-0.00589498,0.00961476,0.12635223,713.60462,243.30353)"
+       x1="-685.27356"
+       y1="274.73871"
+       x2="-199.66586"
+       y2="439.2937" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11864"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.45714,202.74286)"
+       x1="63.677078"
+       y1="137.90625"
+       x2="741.16382"
+       y2="814.15625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11868"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200)"
+       x1="340.95712"
+       y1="313.54886"
+       x2="553.43683"
+       y2="414.99799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11874"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.2516928,0,0,0.2516928,1212.6818,184.90118)"
+       x1="468.23636"
+       y1="681.24438"
+       x2="270.86862"
+       y2="792" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2516928,0,0,0.2516928,989.76084,184.90118)"
+       x1="204.24982"
+       y1="662.38818"
+       x2="421.71808"
+       y2="792" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11886"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000.3918,202.15499)"
+       x1="338.48233"
+       y1="308.13605"
+       x2="550.11517"
+       y2="385.91779" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11890"
+       gradientUnits="userSpaceOnUse"
+       x1="321.98315"
+       y1="380.02527"
+       x2="469.97644"
+       y2="469.5921" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient11894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20848549,0,0,0.20045097,1013.463,234.04674)"
+       x1="224.06509"
+       y1="423.88376"
+       x2="710.13196"
+       y2="599.74866" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11910"
+       x1="1048.6277"
+       y1="123.99675"
+       x2="1155.115"
+       y2="123.99675"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11912"
+       x1="320.72302"
+       y1="422.45166"
+       x2="471.23657"
+       y2="422.45166"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11914"
+       x1="1078.4449"
+       y1="72.58609"
+       x2="1121.2837"
+       y2="72.58609"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11916"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11918"
+       x1="1053.1915"
+       y1="160.27998"
+       x2="1101.7916"
+       y2="160.27998"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11920"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11922"
+       x1="1100.6512"
+       y1="160.27998"
+       x2="1149.2513"
+       y2="160.27998"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11924"
+       x1="365.43918"
+       y1="340.25049"
+       x2="432.26566"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11926"
+       x1="866.25714"
+       y1="70.971428"
+       x2="910.46429"
+       y2="70.971428"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11928"
+       x1="827.92651"
+       y1="105.49463"
+       x2="974.56012"
+       y2="105.49463"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11930"
+       x1="690.55066"
+       y1="146.53426"
+       x2="706.93567"
+       y2="146.53426"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11932"
+       x1="668.59705"
+       y1="96.503098"
+       x2="709.49426"
+       y2="96.503098"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11934"
+       x1="644.69092"
+       y1="76.544586"
+       x2="745.35193"
+       y2="76.544586"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11936"
+       x1="660.58929"
+       y1="73.779846"
+       x2="753.43573"
+       y2="73.779846"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11938"
+       x1="658.13135"
+       y1="114.83434"
+       x2="738.08429"
+       y2="114.83434"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11940"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11942"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11944"
+       x1="656.17798"
+       y1="173.41995"
+       x2="701.07245"
+       y2="173.41995"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11946"
+       x1="698.4704"
+       y1="172.55678"
+       x2="743.36493"
+       y2="172.55678"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11948"
+       x1="483.78497"
+       y1="150.07507"
+       x2="513.65399"
+       y2="150.07507"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11950"
+       x1="480.61533"
+       y1="149.94077"
+       x2="520.30194"
+       y2="149.94077"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11952"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11954"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11956"
+       x1="417.95316"
+       y1="40.867519"
+       x2="582.47638"
+       y2="40.867519"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11958"
+       x1="424.8381"
+       y1="179.77798"
+       x2="573.25952"
+       y2="179.77798"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11960"
+       x1="452.70697"
+       y1="86.454453"
+       x2="500.16919"
+       y2="86.454453"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11962"
+       x1="502.69141"
+       y1="89.134148"
+       x2="549.44672"
+       y2="89.134148"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11964"
+       x1="445.49747"
+       y1="112.7225"
+       x2="557.88916"
+       y2="112.7225"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11966"
+       x1="32.829494"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11968"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11970"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11972"
+       x1="264.0762"
+       y1="136.56403"
+       x2="338.59048"
+       y2="136.56403"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11974"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11976"
+       x1="224.00957"
+       y1="93.224358"
+       x2="373.61008"
+       y2="93.224358"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11978"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11980"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11982"
+       x1="254.77856"
+       y1="169.65237"
+       x2="302.60001"
+       y2="169.65237"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11984"
+       x1="300.82858"
+       y1="168.42024"
+       x2="348.64999"
+       y2="168.42024"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11986"
+       x1="59.698338"
+       y1="137.37466"
+       x2="141.24326"
+       y2="137.37466"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11988"
+       x1="23.485004"
+       y1="112.1781"
+       x2="177.66451"
+       y2="112.1781"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11990"
+       x1="298.91412"
+       y1="338.0408"
+       x2="459.01593"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11992"
+       x1="60.532261"
+       y1="46.829197"
+       x2="134.64749"
+       y2="46.829197"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11994"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11996"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11998"
+       x1="310.70657"
+       y1="338.0408"
+       x2="447.22351"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12000"
+       x1="310.70657"
+       y1="338.0408"
+       x2="447.22351"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12784"
+       x1="1048.6277"
+       y1="323.99677"
+       x2="1155.115"
+       y2="323.99677"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12786"
+       x1="320.72302"
+       y1="422.45166"
+       x2="471.23657"
+       y2="422.45166"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12788"
+       x1="1078.4449"
+       y1="272.58609"
+       x2="1121.2837"
+       y2="272.58609"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12790"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12792"
+       x1="1053.1915"
+       y1="360.28"
+       x2="1101.7916"
+       y2="360.28"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12794"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12796"
+       x1="1100.6512"
+       y1="360.28"
+       x2="1149.2513"
+       y2="360.28"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12798"
+       x1="365.43918"
+       y1="340.25049"
+       x2="432.26566"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12800"
+       x1="866.25714"
+       y1="270.97141"
+       x2="910.46429"
+       y2="270.97141"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12802"
+       x1="827.92651"
+       y1="305.49463"
+       x2="974.56012"
+       y2="305.49463"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12804"
+       x1="690.55066"
+       y1="346.53424"
+       x2="706.93567"
+       y2="346.53424"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12806"
+       x1="668.59705"
+       y1="296.50311"
+       x2="709.49426"
+       y2="296.50311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12808"
+       x1="644.69092"
+       y1="276.54459"
+       x2="745.35193"
+       y2="276.54459"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12810"
+       x1="660.58929"
+       y1="273.77985"
+       x2="753.43573"
+       y2="273.77985"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12812"
+       x1="658.13135"
+       y1="314.83435"
+       x2="738.08429"
+       y2="314.83435"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12814"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12816"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12818"
+       x1="656.17798"
+       y1="373.41995"
+       x2="701.07245"
+       y2="373.41995"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12820"
+       x1="698.4704"
+       y1="372.55679"
+       x2="743.36493"
+       y2="372.55679"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12822"
+       x1="483.78497"
+       y1="350.07507"
+       x2="513.65399"
+       y2="350.07507"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12824"
+       x1="480.61533"
+       y1="349.94077"
+       x2="520.30194"
+       y2="349.94077"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12826"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12828"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12830"
+       x1="417.95316"
+       y1="240.86752"
+       x2="582.47638"
+       y2="240.86752"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12832"
+       x1="424.8381"
+       y1="379.77798"
+       x2="573.25952"
+       y2="379.77798"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12834"
+       x1="452.70697"
+       y1="286.45444"
+       x2="500.16919"
+       y2="286.45444"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12836"
+       x1="502.69141"
+       y1="289.13412"
+       x2="549.44672"
+       y2="289.13412"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12838"
+       x1="445.49747"
+       y1="312.7225"
+       x2="557.88916"
+       y2="312.7225"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12840"
+       x1="32.829494"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12842"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12844"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12846"
+       x1="264.0762"
+       y1="336.56403"
+       x2="338.59048"
+       y2="336.56403"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12848"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12850"
+       x1="224.00957"
+       y1="293.22437"
+       x2="373.61008"
+       y2="293.22437"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12852"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12854"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12856"
+       x1="254.77856"
+       y1="369.65237"
+       x2="302.60001"
+       y2="369.65237"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12858"
+       x1="300.82858"
+       y1="368.42023"
+       x2="348.64999"
+       y2="368.42023"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12860"
+       x1="59.698338"
+       y1="337.37466"
+       x2="141.24326"
+       y2="337.37466"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12862"
+       x1="23.485004"
+       y1="312.1781"
+       x2="177.66451"
+       y2="312.1781"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12864"
+       x1="298.91412"
+       y1="338.0408"
+       x2="459.01593"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12866"
+       x1="60.532261"
+       y1="246.82919"
+       x2="134.64749"
+       y2="246.82919"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12868"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12870"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12872"
+       x1="310.70657"
+       y1="338.0408"
+       x2="447.22351"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12874"
+       x1="310.70657"
+       y1="338.0408"
+       x2="447.22351"
+       y2="338.0408"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12882"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12884"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12886"
+       x1="365.43918"
+       y1="340.25049"
+       x2="432.26566"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12888"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12890"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12892"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12894"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12896"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12898"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12900"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12902"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12910"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12912"
+       x1="366.4368"
+       y1="340.25049"
+       x2="431.26804"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12914"
+       x1="365.43918"
+       y1="340.25049"
+       x2="432.26566"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12916"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12918"
+       x1="365.68268"
+       y1="340.25049"
+       x2="432.02216"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12920"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12922"
+       x1="367.3364"
+       y1="340.25049"
+       x2="430.36841"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12924"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12926"
+       x1="366.27344"
+       y1="340.25049"
+       x2="431.4314"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12928"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12930"
+       x1="366.59531"
+       y1="340.25049"
+       x2="431.10953"
+       y2="340.25049"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="614.71491"
+     inkscape:cy="150.27397"
+     inkscape:document-units="px"
+     inkscape:current-layer="WhitePieces"
+     showgrid="false"
+     inkscape:window-width="1835"
+     inkscape:window-height="812"
+     inkscape:window-x="65"
+     inkscape:window-y="142"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata10119">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Eyes Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:description>Chess piece set &quot;Eyes&quot; by Maurizio Monge.</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2017-10-29</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title> Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         y="0"
+         x="0"
+         height="200"
+         width="200"
+         id="rect8054"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.36076343,0,0,0.33223223,-12.13919,57.38034)"
+         d="m 441.94172,338.0408 a 62.976696,70.710678 0 1 1 -125.95339,0 62.976696,70.710678 0 1 1 125.95339,0 z"
+         sodipodi:ry="70.710678"
+         sodipodi:rx="62.976696"
+         sodipodi:cy="338.0408"
+         sodipodi:cx="378.96503"
+         id="path1345"
+         style="opacity:0.98999999;fill:url(#linearGradient10260);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12000);stroke-width:10.56354809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient10262);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11998);stroke-width:10.56354809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5795"
+         sodipodi:cx="378.96503"
+         sodipodi:cy="338.0408"
+         sodipodi:rx="62.976696"
+         sodipodi:ry="70.710678"
+         d="m 441.94172,338.0408 a 62.976696,70.710678 0 1 1 -125.95339,0 62.976696,70.710678 0 1 1 125.95339,0 z"
+         transform="matrix(0.36076343,0,0,0.33223223,-59.51915,58.67741)" />
+      <path
+         transform="matrix(0.19839474,0,0,0.20554171,47.08745,105.5604)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path2231"
+         style="opacity:0.98999999;fill:url(#linearGradient12928);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11996);stroke-width:18.11034966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12930);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11994);stroke-width:18.11034966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5797"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19839474,0,0,0.20554171,-1.24412,106.27574)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsccccscs"
+         id="path2671"
+         d="m 94.61678,14.17295 c -9.10736,0.14873 -12.3162,10.35883 -5.21566,24.62641 -12.42017,-2.9652 -27.12405,-0.88262 -27.03993,8.68718 0.07,8.21 12.82495,8.80813 27.34311,8.30861 1.88215,6.61613 3.44275,15.21918 6.7926,23.34139 l 5.62143,0.35 c 2.24504,-8.41815 3.13602,-18.07207 3.85344,-24.97194 15.28766,1.29487 27.1942,-0.36964 26.83942,-9.39234 -0.37202,-9.46077 -16.11072,-10.69615 -28.61085,-6.72832 1.34702,-12.2934 -1.17204,-24.35431 -9.58356,-24.22099 z"
+         style="fill:url(#linearGradient10276);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11992);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient10266);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11990);stroke-width:11.78353214;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path10413"
+         sodipodi:cx="378.96503"
+         sodipodi:cy="338.0408"
+         sodipodi:rx="74.159134"
+         sodipodi:ry="70.710678"
+         d="m 453.12416,338.0408 a 74.159134,70.710678 0 1 1 -148.31827,0 74.159134,70.710678 0 1 1 148.31827,0 z"
+         transform="matrix(0.31083566,0,0,0.30988594,-17.66356,-11.00959)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csscsscc"
+         id="path10402"
+         d="m 56.07907,151.9819 c 3.26291,-14.3782 -23.66029,-11.50127 -29.64153,-38.17633 -4.78545,-21.3421 5.88153,-38.67172 28.72724,-40.39315 26.55914,-2.00124 45.00011,35.69275 45.00011,35.69275 0,0 15.79519,-31.27416 36.5935,-35.87573 22.62874,-5.00656 42.21046,12.5852 38.65906,36.69851 -3.81315,25.89052 -34.54492,24.15707 -31.73597,39.93958 -31.02747,-2.54882 -59.19786,-0.94423 -87.60241,2.11437 z"
+         style="fill:url(#linearGradient10272);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11988);stroke-width:3.65714145;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path1677"
+         d="m 61.52691,138.69569 c 11.20432,-2.65946 64.84662,-3.65287 77.88777,-1.37143"
+         style="fill:none;stroke:url(#linearGradient11986);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="0"
+         x="200"
+         height="200"
+         width="200"
+         id="rect8054-8"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsssc"
+         id="path1345-7"
+         d="m 332.2,146.5381 c -9.22143,4.84781 -18.44286,10.66073 -27.66429,12.12142 -1.20575,2.78363 -1.87857,5.86232 -1.87857,9.1 0,12.44267 9.88993,22.54287 22.07857,22.54286 12.18865,0 22.08572,-10.10019 22.08572,-22.54286 0,-9.76943 -6.10146,-18.09553 -14.62143,-21.22142 z"
+         style="opacity:0.98999999;fill:url(#linearGradient2229-2);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11984);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscc"
+         id="path5795-5"
+         d="m 271.3,147.75952 c -8.55654,3.1059 -14.69286,11.4467 -14.69286,21.24286 0,12.44267 9.89707,22.54285 22.08572,22.54286 12.18864,0 22.07857,-10.10019 22.07857,-22.54286 0,-3.77759 -0.91754,-7.33584 -2.52857,-10.46428 -10.90735,-3.11126 -18.81742,-6.97184 -26.94286,-10.77858 z"
+         style="opacity:0.98999999;fill:url(#linearGradient5799-3);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11982);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.19281646,0,0,0.19721851,249.05328,98.82089)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path2231-6"
+         style="opacity:0.98999999;fill:url(#linearGradient12924);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11980);stroke-width:18.75409126;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12926);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11978);stroke-width:18.75409126;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5797-0"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19281646,0,0,0.19721851,204.81647,99.58683)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path8557"
+         d="m 226.36995,65.4785 c 8.89009,16.18909 24.52299,42.66542 43.50902,48.06831 -11.02943,-22.21749 -5.11876,-54.99511 -0.67042,-77.14817 9.18162,23.17249 11.71395,46.26792 27.23771,63.51566 9.25699,-11.22922 21.27353,-39.82633 25.07317,-64.20137 10.00545,24.42113 7.84316,51.10973 5.35152,74.60139 19.93739,-8.59448 32.40293,-24.51091 44.47339,-45.55307 4.40199,48.66775 -25.81728,65.85106 -28.9306,85.25729 -27.43048,-2.53737 -54.86096,-2.83085 -82.29144,0.71725 0.0797,-17.13655 -39.27803,-22.67846 -33.75235,-85.25729 z"
+         style="fill:url(#linearGradient10007);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11976);stroke-width:3.65714264;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,202.66185,3.9653504)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path9446"
+         style="opacity:0.98999999;fill:url(#linearGradient10327);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11974);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path1677-4"
+         d="m 265.90476,137.90476 c 11.20433,-2.65946 58.16711,-4.38815 70.85715,0"
+         style="fill:none;stroke:url(#linearGradient11972);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient1334);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11970);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path1332"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,246.47138,-22.32037)" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,299.04281,-21.93942)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path1336"
+         style="opacity:0.98999999;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11968);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient1342);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11966);stroke-width:14.34100723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path1340"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,348.56663,4.3462904)" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect8054-6"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="rect2553"
+         d="m 447.33354,45.91536 c -0.18143,44.19145 3.02331,90.14887 0,133.61429 l 108.72706,0 c -4.73457,-43.04372 -0.77545,-90.61513 0,-133.61429 l -108.72706,0 z"
+         style="fill:url(#linearGradient4315);fill-opacity:1;stroke:url(#linearGradient11964);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccscc"
+         id="path1327"
+         d="m 515.56314,73.68795 c -5.96443,4.86603 -11.04316,10.94085 -11.04316,20.2616 0,8.28746 2.61864,10.23678 7.49838,15.20092 l 28.98782,0.68571 c 4.87973,-4.96413 6.612,-10.70821 6.61199,-18.99567 0,-9.32074 -2.55094,-17.54237 -8.51537,-22.4084 l -23.53966,5.25584 z"
+         style="fill:url(#linearGradient2440);fill-opacity:1;stroke:url(#linearGradient11962);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccscc"
+         style="fill:url(#linearGradient2446);fill-opacity:1;stroke:url(#linearGradient11960);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 463.27949,64.97363 c -5.96443,5.04197 -8.74394,13.56087 -8.74394,23.21861 0,8.58711 1.95409,14.59941 6.83384,19.74303 l 28.98782,-0.21799 c 4.87973,-5.14361 7.98342,-10.93793 7.98342,-19.52504 -10e-6,-9.65774 -3.99921,-11.44711 -9.96364,-16.48908 l -25.0975,-6.72953 z"
+         id="path2442" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="rect4830"
+         d="m 434.38095,170.07089 c -4.30163,0.11599 -7.71428,2.62789 -7.71428,5.72883 l 0,7.0068 c 0,3.17536 3.58157,5.72882 8.02857,5.72882 41.29256,0.94589 83.15949,1.55429 128.70714,0 4.447,0 8.02858,-2.55346 8.02858,-5.72882 l 0,-7.0068 c 0,-3.17536 -3.58159,-5.72883 -8.02858,-5.72883 -42.23549,1.76331 -85.03648,2.03139 -128.70714,0 -0.10423,0 -0.21105,-0.003 -0.31429,0 z"
+         style="opacity:0.98999999;fill:url(#linearGradient5753);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11958);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccssssssssccccccccccccc"
+         id="rect5730"
+         d="m 464.68571,23.47143 0,12.23571 c 0,4.02491 -3.4069,7.26429 -7.64285,7.26429 l -3.75715,0 c -4.23595,0 -7.65,-3.23938 -7.65,-7.26429 l 0,-15.48571 C 439.31709,20.44317 435.12086,20.73703 434.1,21.1 c -5.79532,2.06054 -11.37676,1.17453 -12.87857,7.71429 -1.73878,7.57165 -2.09231,17.46991 0,24.96428 1.12733,4.03795 5.75512,8.05954 12.87857,7.71429 41.87926,-2.02974 82.86851,-1.38204 132.1,0 7.12986,0.20236 11.75125,-3.67634 12.87858,-7.71429 2.09231,-7.49437 2.09231,-17.46991 0,-24.96428 C 577.95125,24.77633 573.25742,22.02762 566.2,21.1 c -2.2398,-0.2944 -7.33261,-0.55307 -14.27857,-0.76429 l 0,16.51429 c 0,4.0249 -3.40691,7.26429 -7.64286,7.26429 l -3.75714,0 c -4.23595,0 -7.64286,-3.23939 -7.64286,-7.26429 l 0,-13.26429 c -7.81126,-0.11767 -16.39492,-1.11307 -25.14286,-1.15714 l 0,12.9 c 0,4.02491 -3.41404,7.26429 -7.65,7.26429 l -3.75714,0 c -4.23595,-1e-5 -7.64286,-3.23939 -7.64286,-7.26429 l 0,-12.93571 c -0.038,6e-5 -17.13181,0.99128 -24,1.07857 z"
+         style="opacity:0.98999999;fill:url(#linearGradient13034);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11956);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12922);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11954);stroke-width:16.62813377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5797-01"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.23211817,0,0,0.2083952,385.53051,24.61872)" />
+      <path
+         transform="matrix(0.23211817,0,0,0.2083952,430.00976,26.69239)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path5758"
+         style="opacity:0.98999999;fill:url(#linearGradient12920);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11952);stroke-width:16.62813377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path5000"
+         d="m 482.64078,171.44635 c 0,-4.30998 -0.87895,-16.78517 1.07749,-31.24738 2.30422,-17.03293 33.49555,-14.27676 34.47988,0 0.61928,8.98213 0,30.16989 0,30.16989"
+         style="fill:none;stroke:url(#linearGradient11950);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path5903"
+         d="m 485.61354,135.12708 c 8.61997,-9.33829 24.71641,-7.32614 25.85991,7.54247 0.8285,10.77273 -0.0654,28.0149 -0.0654,28.0149"
+         style="fill:none;stroke:url(#linearGradient11948);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect8054-60"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsssc"
+         id="path1345-8"
+         d="m 727.88392,153.20633 c -8.20149,4.15374 -15.84708,9.0972 -25.83086,10.71902 -1.12584,2.46157 -1.75407,5.18406 -1.75407,8.04716 0,11.00309 9.23448,19.93473 20.61533,19.93472 11.38086,0 20.62201,-8.93163 20.62201,-19.93472 0,-8.63914 -5.69709,-16.00194 -13.65241,-18.76618 z"
+         style="opacity:0.98999999;fill:url(#linearGradient4955);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11946);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscc"
+         id="path5795-8"
+         d="m 671.72564,154.06004 c -7.98947,2.74655 -13.71911,10.12235 -13.71911,18.78512 0,11.00309 9.24115,19.93472 20.62201,19.93472 11.38086,0 20.61534,-8.93162 20.61533,-19.93472 0,-3.34054 -0.85672,-6.4871 -2.36099,-9.2536 -9.08998,-1.1763 -16.94691,-5.85597 -25.15724,-9.53152 z"
+         style="opacity:0.98999999;fill:url(#linearGradient4957);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11944);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.18638903,0,0,0.18055314,643.65253,113.88438)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path2231-7"
+         style="opacity:0.98999999;fill:url(#linearGradient12916);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11942);stroke-width:19.93559647;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12918);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11940);stroke-width:19.93559647;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5797-08"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.18638903,0,0,0.18055314,606.91218,113.84164)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient7571);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11938);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 663.24042,158.2448 c -4.32832,-33.19523 -11.03162,-33.41083 29.74886,-86.820912 56.85619,39.599872 39.59811,52.792502 43.26641,86.599542 -34.75638,-4.02329 -43.38045,-3.25901 -73.01527,0.22137 z"
+         id="path7569"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient7567);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11936);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 742.09672,134.22516 c 18.03946,-44.106302 10.0488,-83.600362 -20.84997,-120.890632 -19.62859,14.16379 -56.32329,71.92373 -58.82886,109.421212 32.46933,-6.375 47.48974,3.46289 79.67883,11.46942 z"
+         id="path7565"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5801"
+         d="m 658.25389,142.01327 c -24.83891,-31.02279 -6.77109,-89.848102 21.88388,-130.937412 46.06812,42.32989 71.84082,88.957462 60.87191,130.867352 -32.46933,-6.37501 -50.56669,-7.93647 -82.75579,0.0701 z"
+         style="fill:url(#linearGradient3939);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11934);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect3643"
+         d="m 689.17175,72.866318 c -3.58114,-0.0996 -6.69577,3.38392 -6.41926,6.93938 -0.0397,2.04707 -0.12878,4.09273 -0.20606,6.13859 -2.40102,-0.14842 -4.84229,-0.70616 -7.23352,-0.25666 -3.16944,0.84498 -5.51964,4.33957 -4.73519,7.62056 0.58687,3.00552 3.5123,5.31184 6.55082,5.1941 2.10208,0.10978 4.19842,0.3052 6.29487,0.49103 0.52593,5.262162 1.52923,10.472782 2.8562,15.586482 0.535,3.36553 3.96178,6.09096 7.36094,5.47769 3.44578,-0.4723 6.1244,-4.11509 5.42246,-7.57615 -0.30071,-1.72934 -0.91863,-3.38696 -1.2047,-5.12139 -0.6242,-2.88972 -1.1561,-5.80729 -1.44783,-8.747722 2.56906,-0.25709 5.28058,-0.0337 7.6892,-1.11677 2.73432,-1.40521 4.32181,-4.92376 3.20497,-7.87825 -0.96465,-2.86719 -4.0515,-4.75602 -7.02659,-4.39224 -1.62375,0.064 -3.23738,0.26871 -4.85718,0.38888 0.0376,-0.76856 -0.0474,-1.55729 0.0177,-2.33466 0.032,-1.67886 0.2734,-3.36467 0.15846,-5.0397 -0.59813,-2.96265 -3.34244,-5.49647 -6.42528,-5.37317 z"
+         style="opacity:0.98999999;fill:url(#linearGradient3723);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11932);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path3941"
+         d="m 692.69856,143.37637 c -2.80152,7.34654 13.79171,9.38918 12.31532,0.11128"
+         style="fill:none;stroke:url(#linearGradient11930);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect8054-9"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscccccsc"
+         id="path4618"
+         d="m 886.00254,20.22922 c -0.38571,26.59625 0.97294,16.55231 -15.81037,4.27446 2.59012,17.34932 0.83202,17.92092 -3.65158,25.3449 -2.45377,4.06296 -4.6162,16.85608 -6.15158,19.67596 -9.30365,17.08709 -30.67072,39.3941 -30.63386,46.66632 0.0467,9.20542 10.99488,17.4454 21.00958,7.71103 -9.36939,13.71566 18.91836,-0.0622 30.77285,-8.52211 15.69174,9.65995 37.61437,-0.9107 38.02187,-16.4317 7.14077,35.10764 -59.5404,41.20523 -63.10231,86.74289 32.91102,8.13038 80.59136,4.38303 107.66824,2.96523 15.48476,-44.89767 16.91374,-119.94615 -55.07284,-148.08412 -9.78397,-3.82434 -13.89416,-13.66176 -23.05,-20.34286 z"
+         style="fill:url(#linearGradient2513);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11928);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsssc"
+         id="path1345-9"
+         d="m 896.25,51.08571 c -12.73179,7.55869 -18.57687,8.57581 -26.35714,10.52858 -1.15934,2.60544 -1.80715,5.49638 -1.80715,8.54285 0,11.42612 9.07857,20.7 20.27143,20.7 11.19286,0 20.27857,-9.27387 20.27857,-20.7 0,-8.56959 -5.10883,-15.92769 -12.38571,-19.07143 z"
+         style="opacity:0.98999999;fill:url(#linearGradient2229-6);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11926);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.17706354,0,0,0.18110606,813.30416,12.78792)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path2231-9"
+         style="opacity:0.98999999;fill:url(#linearGradient12914);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11924);stroke-width:20.42259026;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect8054-64"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscc"
+         style="opacity:0.98999999;fill:url(#linearGradient5901);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11922);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 1136.0493,138.83497 c 6.7912,3.94809 11.3734,11.4031 11.3734,19.94666 0,12.6633 -10.0667,22.94338 -22.4715,22.94338 -12.4048,0 -22.4714,-10.28008 -22.4714,-22.94338 0,-3.92954 0.9663,-7.62786 2.6742,-10.86212 10.2984,-0.53002 18.2239,-2.15625 30.8953,-9.08454 z"
+         id="path5899" />
+      <path
+         transform="matrix(0.19623543,0,0,0.20071543,1043.3034,91.95029)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path2231-1"
+         style="opacity:0.98999999;fill:url(#linearGradient12910);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11920);stroke-width:18.42734718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscc"
+         id="path5795-50"
+         d="m 1066.3935,138.83497 c -6.7912,3.94809 -11.3734,11.4031 -11.3734,19.94666 0,12.6633 10.0667,22.94338 22.4714,22.94338 12.4048,0 22.4715,-10.28008 22.4715,-22.94338 0,-3.92954 -0.9664,-7.62786 -2.6742,-10.86212 -12.1819,-1.14471 -21.8501,-4.8032 -30.8953,-9.08454 z"
+         style="opacity:0.98999999;fill:url(#linearGradient5897);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11918);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12912);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11916);stroke-width:18.42734718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path5797-7"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19623543,0,0,0.20071543,1001.4702,90.88407)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path1340-6"
+         d="m 1099.3582,49.15055 c -4.8345,10.8381 -11.3897,21.7842 -19.0847,29.76187 l 19.7867,17.10921 19.3949,-16.70119 c -10.4885,-8.31423 -15.2918,-19.01393 -20.0969,-30.16989 z"
+         style="fill:url(#linearGradient2243);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11914);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.19746697,0,0,0.19746697,1021.5679,12.77037)"
+         d="m 461.97643,422.45166 a 65.996635,61.282589 0 1 1 -131.99327,0 65.996635,61.282589 0 1 1 131.99327,0 z"
+         sodipodi:ry="61.282589"
+         sodipodi:rx="65.996635"
+         sodipodi:cy="422.45166"
+         sodipodi:cx="395.9798"
+         id="path1331"
+         style="fill:url(#linearGradient2226);fill-opacity:1;stroke:url(#linearGradient11912);stroke-width:18.52027702;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path4352"
+         d="m 1050.4674,150.22972 c -1.2181,-67.80712 98.1998,-71.75183 102.819,-0.9225 -17.1649,-14.45238 -88.2355,-15.60088 -102.819,0.9225 z"
+         style="fill:url(#linearGradient5892);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11910);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11642"
+         width="200"
+         height="200"
+         x="0"
+         y="200" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient11746);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12874);stroke-width:10.56354809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11644"
+         sodipodi:cx="378.96503"
+         sodipodi:cy="338.0408"
+         sodipodi:rx="62.976696"
+         sodipodi:ry="70.710678"
+         d="m 441.94172,338.0408 a 62.976696,70.710678 0 1 1 -125.95339,0 62.976696,70.710678 0 1 1 125.95339,0 z"
+         transform="matrix(0.36076343,0,0,0.33223223,-12.13919,257.38034)" />
+      <path
+         transform="matrix(0.36076343,0,0,0.33223223,-59.51915,258.67741)"
+         d="m 441.94172,338.0408 a 62.976696,70.710678 0 1 1 -125.95339,0 62.976696,70.710678 0 1 1 125.95339,0 z"
+         sodipodi:ry="70.710678"
+         sodipodi:rx="62.976696"
+         sodipodi:cy="338.0408"
+         sodipodi:cx="378.96503"
+         id="path11646"
+         style="opacity:0.98999999;fill:url(#linearGradient11750);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12872);stroke-width:10.56354809;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12900);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12870);stroke-width:18.11034966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11648"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19839474,0,0,0.20554171,47.08745,305.5604)" />
+      <path
+         transform="matrix(0.19839474,0,0,0.20554171,-1.24412,306.27574)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path11650"
+         style="opacity:0.98999999;fill:url(#linearGradient12902);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12868);stroke-width:18.11034966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient11758);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12866);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 94.61678,214.17295 c -9.10736,0.14873 -12.3162,10.35883 -5.21566,24.62641 -12.42017,-2.9652 -27.12405,-0.88262 -27.03993,8.68718 0.07,8.21 12.82495,8.80813 27.34311,8.30861 1.88215,6.61613 3.44275,15.21918 6.7926,23.34139 l 5.62143,0.35 c 2.24504,-8.41815 3.13602,-18.07207 3.85344,-24.97194 15.28766,1.29487 27.1942,-0.36964 26.83942,-9.39234 -0.37202,-9.46077 -16.11072,-10.69615 -28.61085,-6.72832 1.34702,-12.2934 -1.17204,-24.35431 -9.58356,-24.22099 z"
+         id="path11652"
+         sodipodi:nodetypes="ccsccccscs"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.31083566,0,0,0.30988594,-17.66356,188.99041)"
+         d="m 453.12416,338.0408 a 74.159134,70.710678 0 1 1 -148.31827,0 74.159134,70.710678 0 1 1 148.31827,0 z"
+         sodipodi:ry="70.710678"
+         sodipodi:rx="74.159134"
+         sodipodi:cy="338.0408"
+         sodipodi:cx="378.96503"
+         id="path11654"
+         style="opacity:0.98999999;fill:url(#linearGradient11762);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12864);stroke-width:11.78353214;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient11766);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12862);stroke-width:3.65714145;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 56.07907,351.9819 c 3.26291,-14.3782 -23.66029,-11.50127 -29.64153,-38.17633 -4.78545,-21.3421 5.88153,-38.67172 28.72724,-40.39315 26.55914,-2.00124 45.00011,35.69275 45.00011,35.69275 0,0 15.79519,-31.27416 36.5935,-35.87573 22.62874,-5.00656 42.21046,12.5852 38.65906,36.69851 -3.81315,25.89052 -34.54492,24.15707 -31.73597,39.93958 -31.02747,-2.54882 -59.19786,-0.94423 -87.60241,2.11437 z"
+         id="path11656"
+         sodipodi:nodetypes="csscsscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12860);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 61.52691,338.69569 c 11.20432,-2.65946 64.84662,-3.65287 77.88777,-1.37143"
+         id="path11658"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11660"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11772);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12858);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 332.2,346.5381 c -9.22143,4.84781 -18.44286,10.66073 -27.66429,12.12142 -1.20575,2.78363 -1.87857,5.86232 -1.87857,9.1 0,12.44267 9.88993,22.54287 22.07857,22.54286 12.18865,0 22.08572,-10.10019 22.08572,-22.54286 0,-9.76943 -6.10146,-18.09553 -14.62143,-21.22142 z"
+         id="path11662"
+         sodipodi:nodetypes="ccsssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11776);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12856);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 271.3,347.75952 c -8.55654,3.1059 -14.69286,11.4467 -14.69286,21.24286 0,12.44267 9.89707,22.54285 22.08572,22.54286 12.18864,0 22.07857,-10.10019 22.07857,-22.54286 0,-3.77759 -0.91754,-7.33584 -2.52857,-10.46428 -10.90735,-3.11126 -18.81742,-6.97184 -26.94286,-10.77858 z"
+         id="path11664"
+         sodipodi:nodetypes="cssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12896);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12854);stroke-width:18.75409126;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11666"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19281646,0,0,0.19721851,249.05328,298.82089)" />
+      <path
+         transform="matrix(0.19281646,0,0,0.19721851,204.81647,299.58683)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path11668"
+         style="opacity:0.98999999;fill:url(#linearGradient12898);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12852);stroke-width:18.75409126;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient11784);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12850);stroke-width:3.65714264;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 226.36995,265.4785 c 8.89009,16.18909 24.52299,42.66542 43.50902,48.06831 -11.02943,-22.21749 -5.11876,-54.99511 -0.67042,-77.14817 9.18162,23.17249 11.71395,46.26792 27.23771,63.51566 9.25699,-11.22922 21.27353,-39.82633 25.07317,-64.20137 10.00545,24.42113 7.84316,51.10973 5.35152,74.60139 19.93739,-8.59448 32.40293,-24.51091 44.47339,-45.55307 4.40199,48.66775 -25.81728,65.85106 -28.9306,85.25729 -27.43048,-2.53737 -54.86096,-2.83085 -82.29144,0.71725 0.0797,-17.13655 -39.27803,-22.67846 -33.75235,-85.25729 z"
+         id="path11670"
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient11788);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12848);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11672"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,202.66185,203.96535)" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12846);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 265.90476,337.90476 c 11.20433,-2.65946 58.16711,-4.38815 70.85715,0"
+         id="path11674"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,246.47138,177.67963)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path11676"
+         style="opacity:0.98999999;fill:url(#linearGradient11794);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12844);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient11798);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12842);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11678"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,299.04281,178.06058)" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,348.56663,204.34629)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path11680"
+         style="opacity:0.98999999;fill:url(#linearGradient11802);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12840);stroke-width:14.34100723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11682"
+         width="200"
+         height="200"
+         x="400"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient11806);fill-opacity:1;stroke:url(#linearGradient12838);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 447.33354,245.91536 c -0.18143,44.19145 3.02331,90.14887 0,133.61429 l 108.72706,0 c -4.73457,-43.04372 -0.77545,-90.61513 0,-133.61429 l -108.72706,0 z"
+         id="path11684"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient11810);fill-opacity:1;stroke:url(#linearGradient12836);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 515.56314,273.68795 c -5.96443,4.86603 -11.04316,10.94085 -11.04316,20.2616 0,8.28746 2.61864,10.23678 7.49838,15.20092 l 28.98782,0.68571 c 4.87973,-4.96413 6.612,-10.70821 6.61199,-18.99567 0,-9.32074 -2.55094,-17.54237 -8.51537,-22.4084 l -23.53966,5.25584 z"
+         id="path11686"
+         sodipodi:nodetypes="csccscc"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path11688"
+         d="m 463.27949,264.97363 c -5.96443,5.04197 -8.74394,13.56087 -8.74394,23.21861 0,8.58711 1.95409,14.59941 6.83384,19.74303 l 28.98782,-0.21799 c 4.87973,-5.14361 7.98342,-10.93793 7.98342,-19.52504 -10e-6,-9.65774 -3.99921,-11.44711 -9.96364,-16.48908 l -25.0975,-6.72953 z"
+         style="fill:url(#linearGradient11814);fill-opacity:1;stroke:url(#linearGradient12834);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:nodetypes="csccscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11818);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12832);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 434.38095,370.07089 c -4.30163,0.11599 -7.71428,2.62789 -7.71428,5.72883 l 0,7.0068 c 0,3.17536 3.58157,5.72882 8.02857,5.72882 41.29256,0.94589 83.15949,1.55429 128.70714,0 4.447,0 8.02858,-2.55346 8.02858,-5.72882 l 0,-7.0068 c 0,-3.17536 -3.58159,-5.72883 -8.02858,-5.72883 -42.23549,1.76331 -85.03648,2.03139 -128.70714,0 -0.10423,0 -0.21105,-0.003 -0.31429,0 z"
+         id="path11690"
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11822);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12830);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 464.68571,223.47143 0,12.23571 c 0,4.02491 -3.4069,7.26429 -7.64285,7.26429 l -3.75715,0 c -4.23595,0 -7.65,-3.23938 -7.65,-7.26429 l 0,-15.48571 c -6.31862,0.22174 -10.51485,0.5156 -11.53571,0.87857 -5.79532,2.06054 -11.37676,1.17453 -12.87857,7.71429 -1.73878,7.57165 -2.09231,17.46991 0,24.96428 1.12733,4.03795 5.75512,8.05954 12.87857,7.71429 41.87926,-2.02974 82.86851,-1.38204 132.1,0 7.12986,0.20236 11.75125,-3.67634 12.87858,-7.71429 2.09231,-7.49437 2.09231,-17.46991 0,-24.96428 -1.12733,-4.03796 -5.82116,-6.78667 -12.87858,-7.71429 -2.2398,-0.2944 -7.33261,-0.55307 -14.27857,-0.76429 l 0,16.51429 c 0,4.0249 -3.40691,7.26429 -7.64286,7.26429 l -3.75714,0 c -4.23595,0 -7.64286,-3.23939 -7.64286,-7.26429 l 0,-13.26429 c -7.81126,-0.11767 -16.39492,-1.11307 -25.14286,-1.15714 l 0,12.9 c 0,4.02491 -3.41404,7.26429 -7.65,7.26429 l -3.75714,0 c -4.23595,-1e-5 -7.64286,-3.23939 -7.64286,-7.26429 l 0,-12.93571 c -0.038,6e-5 -17.13181,0.99128 -24,1.07857 z"
+         id="path11692"
+         sodipodi:nodetypes="ccccccssssssssccccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.23211817,0,0,0.2083952,385.53051,224.61872)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path11694"
+         style="opacity:0.98999999;fill:url(#linearGradient12894);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12828);stroke-width:16.62813377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12892);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12826);stroke-width:16.62813377;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11696"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.23211817,0,0,0.2083952,430.00976,226.69239)" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12824);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 482.64078,371.44635 c 0,-4.30998 -0.87895,-16.78517 1.07749,-31.24738 2.30422,-17.03293 33.49555,-14.27676 34.47988,0 0.61928,8.98213 0,30.16989 0,30.16989"
+         id="path11698"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12822);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 485.61354,335.12708 c 8.61997,-9.33829 24.71641,-7.32614 25.85991,7.54247 0.8285,10.77273 -0.0654,28.0149 -0.0654,28.0149"
+         id="path11700"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11722"
+         width="200"
+         height="200"
+         x="800"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient11864);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12802);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 886.00254,220.22922 c -0.38571,26.59625 0.97294,16.55231 -15.81037,4.27446 2.59012,17.34932 0.83202,17.92092 -3.65158,25.3449 -2.45377,4.06296 -4.6162,16.85608 -6.15158,19.67596 -9.30365,17.08709 -30.67072,39.3941 -30.63386,46.66632 0.0467,9.20542 10.99488,17.4454 21.00958,7.71103 -9.36939,13.71566 18.91836,-0.0622 30.77285,-8.52211 15.69174,9.65995 37.61437,-0.9107 38.02187,-16.4317 7.14077,35.10764 -59.5404,41.20523 -63.10231,86.74289 32.91102,8.13038 80.59136,4.38303 107.66824,2.96523 15.48476,-44.89767 16.91374,-119.94615 -55.07284,-148.08412 -9.78397,-3.82434 -13.89416,-13.66176 -23.05,-20.34286 z"
+         id="path11724"
+         sodipodi:nodetypes="ccssscccccsc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11868);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12800);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 896.25,251.08571 c -12.73179,7.55869 -18.57687,8.57581 -26.35714,10.52858 -1.15934,2.60544 -1.80715,5.49638 -1.80715,8.54285 0,11.42612 9.07857,20.7 20.27143,20.7 11.19286,0 20.27857,-9.27387 20.27857,-20.7 0,-8.56959 -5.10883,-15.92769 -12.38571,-19.07143 z"
+         id="path11726"
+         sodipodi:nodetypes="ccsssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12886);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12798);stroke-width:20.42259026;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11728"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.17706354,0,0,0.18110606,813.30416,212.78792)" />
+    </g>
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11702"
+         width="200"
+         height="200"
+         x="600"
+         y="200" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11834);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12820);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 727.88392,353.20633 c -8.20149,4.15374 -15.84708,9.0972 -25.83086,10.71902 -1.12584,2.46157 -1.75407,5.18406 -1.75407,8.04716 0,11.00309 9.23448,19.93473 20.61533,19.93472 11.38086,0 20.62201,-8.93163 20.62201,-19.93472 0,-8.63914 -5.69709,-16.00194 -13.65241,-18.76618 z"
+         id="path11704"
+         sodipodi:nodetypes="ccsssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11838);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12818);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 671.72564,354.06004 c -7.98947,2.74655 -13.71911,10.12235 -13.71911,18.78512 0,11.00309 9.24115,19.93472 20.62201,19.93472 11.38086,0 20.61534,-8.93162 20.61533,-19.93472 0,-3.34054 -0.85672,-6.4871 -2.36099,-9.2536 -9.08998,-1.1763 -16.94691,-5.85597 -25.15724,-9.53152 z"
+         id="path11706"
+         sodipodi:nodetypes="cssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12888);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12816);stroke-width:19.93559647;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11708"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.18638903,0,0,0.18055314,643.65253,313.88438)" />
+      <path
+         transform="matrix(0.18638903,0,0,0.18055314,606.91218,313.84164)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path11710"
+         style="opacity:0.98999999;fill:url(#linearGradient12890);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12814);stroke-width:19.93559647;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path11712"
+         d="m 663.24042,358.2448 c -4.32832,-33.19523 -11.03162,-33.41083 29.74886,-86.82091 56.85619,39.59987 39.59811,52.7925 43.26641,86.59954 -34.75638,-4.02329 -43.38045,-3.25901 -73.01527,0.22137 z"
+         style="fill:url(#linearGradient11846);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12812);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path11714"
+         d="m 742.09672,334.22516 c 18.03946,-44.1063 10.0488,-83.60036 -20.84997,-120.89063 -19.62859,14.16379 -56.32329,71.92373 -58.82886,109.42121 32.46933,-6.375 47.48974,3.46289 79.67883,11.46942 z"
+         style="fill:url(#linearGradient11850);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12810);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient11854);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12808);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 658.25389,342.01327 c -24.83891,-31.02279 -6.77109,-89.8481 21.88388,-130.93741 46.06812,42.32989 71.84082,88.95746 60.87191,130.86735 -32.46933,-6.37501 -50.56669,-7.93647 -82.75579,0.0701 z"
+         id="path11716"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11858);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12806);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 689.17175,272.86632 c -3.58114,-0.0996 -6.69577,3.38392 -6.41926,6.93938 -0.0397,2.04707 -0.12878,4.09273 -0.20606,6.13859 -2.40102,-0.14842 -4.84229,-0.70616 -7.23352,-0.25666 -3.16944,0.84498 -5.51964,4.33957 -4.73519,7.62056 0.58687,3.00552 3.5123,5.31184 6.55082,5.1941 2.10208,0.10978 4.19842,0.3052 6.29487,0.49103 0.52593,5.26216 1.52923,10.47278 2.8562,15.58648 0.535,3.36553 3.96178,6.09096 7.36094,5.47769 3.44578,-0.4723 6.1244,-4.11509 5.42246,-7.57615 -0.30071,-1.72934 -0.91863,-3.38696 -1.2047,-5.12139 -0.6242,-2.88972 -1.1561,-5.80729 -1.44783,-8.74772 2.56906,-0.25709 5.28058,-0.0337 7.6892,-1.11677 2.73432,-1.40521 4.32181,-4.92376 3.20497,-7.87825 -0.96465,-2.86719 -4.0515,-4.75602 -7.02659,-4.39224 -1.62375,0.064 -3.23738,0.26871 -4.85718,0.38888 0.0376,-0.76856 -0.0474,-1.55729 0.0177,-2.33466 0.032,-1.67886 0.2734,-3.36467 0.15846,-5.0397 -0.59813,-2.96265 -3.34244,-5.49647 -6.42528,-5.37317 z"
+         id="path11718"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12804);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 692.69856,343.37637 c -2.80152,7.34654 13.79171,9.38918 12.31532,0.11128"
+         id="path11720"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect11730"
+         width="200"
+         height="200"
+         x="1000"
+         y="200" />
+      <path
+         id="path11732"
+         d="m 1136.0493,338.83497 c 6.7912,3.94809 11.3734,11.4031 11.3734,19.94666 0,12.6633 -10.0667,22.94338 -22.4715,22.94338 -12.4048,0 -22.4714,-10.28008 -22.4714,-22.94338 0,-3.92954 0.9663,-7.62786 2.6742,-10.86212 10.2984,-0.53002 18.2239,-2.15625 30.8953,-9.08454 z"
+         style="opacity:0.98999999;fill:url(#linearGradient11874);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12796);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:nodetypes="cssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient12882);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12794);stroke-width:18.42734718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path11734"
+         sodipodi:cx="398.85242"
+         sodipodi:cy="340.25049"
+         sodipodi:rx="23.201941"
+         sodipodi:ry="22.097088"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         transform="matrix(0.19623543,0,0,0.20071543,1043.3034,291.95029)" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient11880);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12792);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 1066.3935,338.83497 c -6.7912,3.94809 -11.3734,11.4031 -11.3734,19.94666 0,12.6633 10.0667,22.94338 22.4714,22.94338 12.4048,0 22.4715,-10.28008 22.4715,-22.94338 0,-3.92954 -0.9664,-7.62786 -2.6742,-10.86212 -12.1819,-1.14471 -21.8501,-4.8032 -30.8953,-9.08454 z"
+         id="path11736"
+         sodipodi:nodetypes="cssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19623543,0,0,0.20071543,1001.4702,290.88407)"
+         d="m 422.05436,340.25049 a 23.201941,22.097088 0 1 1 -46.40388,0 23.201941,22.097088 0 1 1 46.40388,0 z"
+         sodipodi:ry="22.097088"
+         sodipodi:rx="23.201941"
+         sodipodi:cy="340.25049"
+         sodipodi:cx="398.85242"
+         id="path11738"
+         style="opacity:0.98999999;fill:url(#linearGradient12884);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12790);stroke-width:18.42734718;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient11886);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12788);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1099.3582,249.15055 c -4.8345,10.8381 -11.3897,21.7842 -19.0847,29.76187 l 19.7867,17.10921 19.3949,-16.70119 c -10.4885,-8.31423 -15.2918,-19.01393 -20.0969,-30.16989 z"
+         id="path11740"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient11890);fill-opacity:1;stroke:url(#linearGradient12786);stroke-width:18.52027702;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path11742"
+         sodipodi:cx="395.9798"
+         sodipodi:cy="422.45166"
+         sodipodi:rx="65.996635"
+         sodipodi:ry="61.282589"
+         d="m 461.97643,422.45166 a 65.996635,61.282589 0 1 1 -131.99327,0 65.996635,61.282589 0 1 1 131.99327,0 z"
+         transform="matrix(0.19746697,0,0,0.19746697,1021.5679,212.77037)" />
+      <path
+         style="fill:url(#linearGradient11894);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12784);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1050.4674,350.22972 c -1.2181,-67.80712 98.1998,-71.75183 102.819,-0.9225 -17.1649,-14.45238 -88.2355,-15.60088 -102.819,0.9225 z"
+         id="path11744"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/fantasy.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/fantasy.svg
@@ -1,0 +1,5553 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="fantasy.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title5251">Fantasy Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7925"
+       gradientUnits="userSpaceOnUse"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7923"
+       gradientUnits="userSpaceOnUse"
+       x1="1053.1838"
+       y1="105.03224"
+       x2="1150.4736"
+       y2="105.03224" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7921"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,1000,0)"
+       x1="275.24356"
+       y1="458.6561"
+       x2="672.69525"
+       y2="525.81299" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7919"
+       gradientUnits="userSpaceOnUse"
+       x1="1055.0989"
+       y1="142.84614"
+       x2="1147.7171"
+       y2="142.84614" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7917"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,1000,0)"
+       x1="271.88867"
+       y1="669.63373"
+       x2="664.87592"
+       y2="767.08215" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7915"
+       gradientUnits="userSpaceOnUse"
+       x1="582.45242"
+       y1="373.33334"
+       x2="937.54758"
+       y2="373.33334" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7913"
+       gradientUnits="userSpaceOnUse"
+       x1="559.771"
+       y1="313.20999"
+       x2="911.98419"
+       y2="460.03769" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7911"
+       gradientUnits="userSpaceOnUse"
+       x1="892.60011"
+       y1="174.09663"
+       x2="902.16768"
+       y2="174.09663" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7909"
+       gradientUnits="userSpaceOnUse"
+       x1="960.82851"
+       y1="96.396319"
+       x2="984.5351"
+       y2="96.396319" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7907"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7905"
+       gradientUnits="userSpaceOnUse"
+       x1="949.18222"
+       y1="72.811045"
+       x2="972.39326"
+       y2="72.811045" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7903"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800.916,0.916)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7901"
+       gradientUnits="userSpaceOnUse"
+       x1="930.78402"
+       y1="51.229487"
+       x2="961.56683"
+       y2="51.229487" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7899"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7897"
+       gradientUnits="userSpaceOnUse"
+       x1="901.95467"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800.916,-0.458)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7893"
+       gradientUnits="userSpaceOnUse"
+       x1="885.02086"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7891"
+       gradientUnits="userSpaceOnUse"
+       x1="870.47832"
+       y1="37.851393"
+       x2="876.45823"
+       y2="37.851393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7889"
+       gradientUnits="userSpaceOnUse"
+       x1="919.25245"
+       y1="81.701929"
+       x2="922.98304"
+       y2="81.701929" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7887"
+       gradientUnits="userSpaceOnUse"
+       x1="870.73263"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7885"
+       gradientUnits="userSpaceOnUse"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7883"
+       gradientUnits="userSpaceOnUse"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7881"
+       gradientUnits="userSpaceOnUse"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7879"
+       gradientUnits="userSpaceOnUse"
+       x1="822.23922"
+       y1="101.81162"
+       x2="972.98854"
+       y2="101.81162" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7875"
+       gradientUnits="userSpaceOnUse"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7873"
+       gradientUnits="userSpaceOnUse"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7871"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7869"
+       gradientUnits="userSpaceOnUse"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7867"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7865"
+       gradientUnits="userSpaceOnUse"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7863"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7861"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7859"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7857"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7855"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7853"
+       gradientUnits="userSpaceOnUse"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7851"
+       gradientUnits="userSpaceOnUse"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7849"
+       gradientUnits="userSpaceOnUse"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7847"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7845"
+       gradientUnits="userSpaceOnUse"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7843"
+       gradientUnits="userSpaceOnUse"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7841"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7839"
+       gradientUnits="userSpaceOnUse"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7837"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7835"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7833"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7831"
+       gradientUnits="userSpaceOnUse"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7827"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7825"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7823"
+       gradientUnits="userSpaceOnUse"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7819"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7817"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7815"
+       gradientUnits="userSpaceOnUse"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7813"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7811"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7809"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7807"
+       gradientUnits="userSpaceOnUse"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7803"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7801"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7799"
+       gradientUnits="userSpaceOnUse"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7795"
+       gradientUnits="userSpaceOnUse"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7791"
+       gradientUnits="userSpaceOnUse"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7787"
+       gradientUnits="userSpaceOnUse"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7785"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7783"
+       gradientUnits="userSpaceOnUse"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7781"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7779"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7777"
+       gradientUnits="userSpaceOnUse"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7775"
+       gradientUnits="userSpaceOnUse"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7773"
+       gradientUnits="userSpaceOnUse"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7771"
+       gradientUnits="userSpaceOnUse"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7769"
+       gradientUnits="userSpaceOnUse"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7767"
+       gradientUnits="userSpaceOnUse"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7765"
+       gradientUnits="userSpaceOnUse"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7761"
+       gradientUnits="userSpaceOnUse"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7757"
+       gradientUnits="userSpaceOnUse"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74068"
+       y2="115.58561" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7753"
+       gradientUnits="userSpaceOnUse"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7747"
+       gradientUnits="userSpaceOnUse"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7743"
+       gradientUnits="userSpaceOnUse"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7741"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7739"
+       gradientUnits="userSpaceOnUse"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7735"
+       gradientUnits="userSpaceOnUse"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7733"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.229,0.22857)"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7731"
+       gradientUnits="userSpaceOnUse"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,631.83902,-0.8897215)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7727"
+       gradientUnits="userSpaceOnUse"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7725"
+       gradientUnits="userSpaceOnUse"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7723"
+       gradientUnits="userSpaceOnUse"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7721"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7719"
+       gradientUnits="userSpaceOnUse"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7717"
+       gradientUnits="userSpaceOnUse"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7715"
+       gradientUnits="userSpaceOnUse"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7713"
+       gradientUnits="userSpaceOnUse"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7709"
+       gradientUnits="userSpaceOnUse"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7705"
+       gradientUnits="userSpaceOnUse"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149" />
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7935" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop7937" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7701"
+       gradientUnits="userSpaceOnUse"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812" />
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop7929"
+         offset="0"
+         style="stop-color:#ede3de;stop-opacity:1;" />
+      <stop
+         id="stop7931"
+         offset="1"
+         style="stop-color:#8a6737;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7699"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507" />
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7192" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="1"
+         id="stop7194" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         id="stop2268"
+         offset="0"
+         style="stop-color:#000e1c;stop-opacity:1;" />
+      <stop
+         id="stop2270"
+         offset="1"
+         style="stop-color:#50506f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="460.03769"
+       x2="911.98419"
+       y1="313.20999"
+       x1="559.771"
+       id="linearGradient3076"
+       xlink:href="#linearGradientBlackPieces"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6688"
+       gradientUnits="userSpaceOnUse"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6691"
+       gradientUnits="userSpaceOnUse"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6694"
+       gradientUnits="userSpaceOnUse"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6697"
+       gradientUnits="userSpaceOnUse"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6700"
+       gradientUnits="userSpaceOnUse"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6703"
+       gradientUnits="userSpaceOnUse"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6706"
+       gradientUnits="userSpaceOnUse"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6709"
+       gradientUnits="userSpaceOnUse"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6712"
+       gradientUnits="userSpaceOnUse"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625"
+       gradientTransform="scale(0.229,0.22857)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6729"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6737"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6745"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6749"
+       gradientUnits="userSpaceOnUse"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6753"
+       gradientUnits="userSpaceOnUse"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6757"
+       gradientUnits="userSpaceOnUse"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6761"
+       gradientUnits="userSpaceOnUse"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6765"
+       gradientUnits="userSpaceOnUse"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6768"
+       gradientUnits="userSpaceOnUse"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6771"
+       gradientUnits="userSpaceOnUse"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6774"
+       gradientUnits="userSpaceOnUse"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6777"
+       gradientUnits="userSpaceOnUse"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6780"
+       gradientUnits="userSpaceOnUse"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066"
+       gradientTransform="matrix(0.229,0,0,0.229,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6783"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6785"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6787"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6789"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6791"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6808"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6812"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6815"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2393531,0,0,0.2323184,392.25325,-2.7102173)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6819"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857,0,0,0.22857,631.83902,-0.8897215)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6823"
+       gradientUnits="userSpaceOnUse"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6828"
+       gradientUnits="userSpaceOnUse"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6831"
+       gradientUnits="userSpaceOnUse"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6834"
+       gradientUnits="userSpaceOnUse"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6837"
+       gradientUnits="userSpaceOnUse"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507"
+       gradientTransform="matrix(0.22857,0,0,0.22857,600,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6846"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6854"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6858"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800.916,0.916)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6864"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800.916,-0.458)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.229,0,0,0.229,800,0.916)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6882"
+       gradientUnits="userSpaceOnUse"
+       x1="275.24356"
+       y1="458.6561"
+       x2="672.69525"
+       y2="525.81299"
+       gradientTransform="matrix(0.229,0,0,0.229,1000,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6885"
+       gradientUnits="userSpaceOnUse"
+       x1="271.88867"
+       y1="669.63373"
+       x2="664.87592"
+       y2="767.08215"
+       gradientTransform="matrix(0.229,0,0,0.229,1000,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7196"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7198"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74067"
+       y2="115.58561"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7200"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7202"
+       x1="1053.1838"
+       y1="105.03224"
+       x2="1150.4736"
+       y2="105.03224"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7204"
+       x1="1055.0989"
+       y1="142.84614"
+       x2="1147.7171"
+       y2="142.84614"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7206"
+       x1="582.45242"
+       y1="373.33334"
+       x2="937.54758"
+       y2="373.33334"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7208"
+       x1="892.60011"
+       y1="174.09663"
+       x2="902.16768"
+       y2="174.09663"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7210"
+       x1="960.82851"
+       y1="96.396319"
+       x2="984.5351"
+       y2="96.396319"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7212"
+       x1="949.18222"
+       y1="72.811045"
+       x2="972.39326"
+       y2="72.811045"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7214"
+       x1="930.78402"
+       y1="51.229487"
+       x2="961.56683"
+       y2="51.229487"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7216"
+       x1="901.95467"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7218"
+       x1="885.02086"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7220"
+       x1="870.47832"
+       y1="37.851393"
+       x2="876.45823"
+       y2="37.851393"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7222"
+       x1="919.25245"
+       y1="81.701929"
+       x2="922.98304"
+       y2="81.701929"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7224"
+       x1="870.73263"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7226"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7228"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7230"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7232"
+       x1="822.23922"
+       y1="101.81162"
+       x2="972.98854"
+       y2="101.81162"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7234"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7236"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7238"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7240"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7242"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7244"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7246"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7248"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7250"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7252"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7254"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7256"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7258"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7260"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7262"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7264"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7266"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7268"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7270"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7272"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7274"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7276"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7278"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7280"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7282"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7284"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7286"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7288"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7290"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7292"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7294"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7296"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7298"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7300"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7302"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7304"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7306"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7308"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7310"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7312"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7314"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7316"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7318"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7320"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7322"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7324"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7326"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient7328"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4780"
+       gradientUnits="userSpaceOnUse"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4783"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4785"
+       gradientUnits="userSpaceOnUse"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4790"
+       gradientUnits="userSpaceOnUse"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74068"
+       y2="115.58561"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4795"
+       gradientUnits="userSpaceOnUse"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4798"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4803"
+       gradientUnits="userSpaceOnUse"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4808"
+       gradientUnits="userSpaceOnUse"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4813"
+       gradientUnits="userSpaceOnUse"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4816"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,200.00001)"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4818"
+       gradientUnits="userSpaceOnUse"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4823"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4825"
+       gradientUnits="userSpaceOnUse"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4831"
+       gradientUnits="userSpaceOnUse"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4835"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4837"
+       gradientUnits="userSpaceOnUse"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4841"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4843"
+       gradientUnits="userSpaceOnUse"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4847"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4849"
+       gradientUnits="userSpaceOnUse"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4852"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4854"
+       gradientUnits="userSpaceOnUse"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4859"
+       gradientUnits="userSpaceOnUse"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4862"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4864"
+       gradientUnits="userSpaceOnUse"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4869"
+       gradientUnits="userSpaceOnUse"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4872"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4876"
+       gradientUnits="userSpaceOnUse"
+       x1="892.60011"
+       y1="174.09663"
+       x2="902.16768"
+       y2="174.09663"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4881"
+       gradientUnits="userSpaceOnUse"
+       x1="960.82851"
+       y1="96.396319"
+       x2="984.5351"
+       y2="96.396319"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4884"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,200.91429)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4886"
+       gradientUnits="userSpaceOnUse"
+       x1="949.18222"
+       y1="72.811045"
+       x2="972.39326"
+       y2="72.811045"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4889"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4891"
+       gradientUnits="userSpaceOnUse"
+       x1="930.78402"
+       y1="51.229487"
+       x2="961.56683"
+       y2="51.229487"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,199.54286)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4896"
+       gradientUnits="userSpaceOnUse"
+       x1="901.95467"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4899"
+       gradientUnits="userSpaceOnUse"
+       x1="885.02086"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4902"
+       gradientUnits="userSpaceOnUse"
+       x1="870.47832"
+       y1="37.851393"
+       x2="876.45823"
+       y2="37.851393"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4905"
+       gradientUnits="userSpaceOnUse"
+       x1="919.25245"
+       y1="81.701929"
+       x2="922.98304"
+       y2="81.701929"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4908"
+       gradientUnits="userSpaceOnUse"
+       x1="870.73263"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4911"
+       gradientUnits="userSpaceOnUse"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4914"
+       gradientUnits="userSpaceOnUse"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4917"
+       gradientUnits="userSpaceOnUse"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4920"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4922"
+       gradientUnits="userSpaceOnUse"
+       x1="822.23922"
+       y1="101.81162"
+       x2="972.98854"
+       y2="101.81162"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4926"
+       gradientUnits="userSpaceOnUse"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4929"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4931"
+       gradientUnits="userSpaceOnUse"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4934"
+       gradientUnits="userSpaceOnUse"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4937"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4940"
+       gradientUnits="userSpaceOnUse"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4943"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4946"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4949"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4952"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4955"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4958"
+       gradientUnits="userSpaceOnUse"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4961"
+       gradientUnits="userSpaceOnUse"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4964"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4966"
+       gradientUnits="userSpaceOnUse"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4969"
+       gradientUnits="userSpaceOnUse"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4974"
+       gradientUnits="userSpaceOnUse"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4979"
+       gradientUnits="userSpaceOnUse"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4983"
+       gradientUnits="userSpaceOnUse"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4986"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000,200)"
+       x1="275.24356"
+       y1="458.6561"
+       x2="672.69525"
+       y2="525.81299" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4988"
+       gradientUnits="userSpaceOnUse"
+       x1="1053.1838"
+       y1="105.03224"
+       x2="1150.4736"
+       y2="105.03224"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4991"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000,200)"
+       x1="271.88867"
+       y1="669.63373"
+       x2="664.87592"
+       y2="767.08215" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient4993"
+       gradientUnits="userSpaceOnUse"
+       x1="1055.0989"
+       y1="142.84614"
+       x2="1147.7171"
+       y2="142.84614"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient4998"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,631.83923,199.11029)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5000"
+       gradientUnits="userSpaceOnUse"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5003"
+       gradientUnits="userSpaceOnUse"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5005"
+       gradientUnits="userSpaceOnUse"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5008"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,200.00001)"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5010"
+       gradientUnits="userSpaceOnUse"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5013"
+       gradientUnits="userSpaceOnUse"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5015"
+       gradientUnits="userSpaceOnUse"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5018"
+       gradientUnits="userSpaceOnUse"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5021"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,200.00001)"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5023"
+       gradientUnits="userSpaceOnUse"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,200.00001)"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5028"
+       gradientUnits="userSpaceOnUse"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,200.00001)"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5033"
+       gradientUnits="userSpaceOnUse"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,200.00001)"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5038"
+       gradientUnits="userSpaceOnUse"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,200.00001)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5042"
+       gradientUnits="userSpaceOnUse"
+       x1="1075.8267"
+       y1="163.4315"
+       x2="1122.5205"
+       y2="163.4315"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5045"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000,0)"
+       x1="275.24356"
+       y1="458.6561"
+       x2="672.69525"
+       y2="525.81299" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5047"
+       gradientUnits="userSpaceOnUse"
+       x1="1053.1838"
+       y1="105.03224"
+       x2="1150.4736"
+       y2="105.03224"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5050"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,1000,0)"
+       x1="271.88867"
+       y1="669.63373"
+       x2="664.87592"
+       y2="767.08215" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5052"
+       gradientUnits="userSpaceOnUse"
+       x1="1055.0989"
+       y1="142.84614"
+       x2="1147.7171"
+       y2="142.84614"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.871491,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5057"
+       gradientUnits="userSpaceOnUse"
+       x1="892.60011"
+       y1="174.09663"
+       x2="902.16768"
+       y2="174.09663"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.9142857)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5062"
+       gradientUnits="userSpaceOnUse"
+       x1="960.82851"
+       y1="96.396319"
+       x2="984.5351"
+       y2="96.396319"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,0.9142857)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5067"
+       gradientUnits="userSpaceOnUse"
+       x1="949.18222"
+       y1="72.811045"
+       x2="972.39326"
+       y2="72.811045"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.9142857)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5072"
+       gradientUnits="userSpaceOnUse"
+       x1="930.78402"
+       y1="51.229487"
+       x2="961.56683"
+       y2="51.229487"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,-0.45714286)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5077"
+       gradientUnits="userSpaceOnUse"
+       x1="901.95467"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5080"
+       gradientUnits="userSpaceOnUse"
+       x1="885.02086"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5083"
+       gradientUnits="userSpaceOnUse"
+       x1="870.47832"
+       y1="37.851393"
+       x2="876.45823"
+       y2="37.851393"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5086"
+       gradientUnits="userSpaceOnUse"
+       x1="919.25245"
+       y1="81.701929"
+       x2="922.98304"
+       y2="81.701929"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5089"
+       gradientUnits="userSpaceOnUse"
+       x1="870.73263"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5092"
+       gradientUnits="userSpaceOnUse"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5095"
+       gradientUnits="userSpaceOnUse"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5098"
+       gradientUnits="userSpaceOnUse"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.9142857)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5103"
+       gradientUnits="userSpaceOnUse"
+       x1="822.23922"
+       y1="101.81162"
+       x2="972.98854"
+       y2="101.81162"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5107"
+       gradientUnits="userSpaceOnUse"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5110"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051452)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5112"
+       gradientUnits="userSpaceOnUse"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5115"
+       gradientUnits="userSpaceOnUse"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5118"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5121"
+       gradientUnits="userSpaceOnUse"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5124"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5127"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5130"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5133"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5136"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5139"
+       gradientUnits="userSpaceOnUse"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5142"
+       gradientUnits="userSpaceOnUse"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5145"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051452)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5147"
+       gradientUnits="userSpaceOnUse"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5150"
+       gradientUnits="userSpaceOnUse"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5153"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051452)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5155"
+       gradientUnits="userSpaceOnUse"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051452)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5160"
+       gradientUnits="userSpaceOnUse"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.74859638,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5167"
+       gradientUnits="userSpaceOnUse"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5173"
+       gradientUnits="userSpaceOnUse"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5177"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5179"
+       gradientUnits="userSpaceOnUse"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5183"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5185"
+       gradientUnits="userSpaceOnUse"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5189"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5191"
+       gradientUnits="userSpaceOnUse"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5194"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5196"
+       gradientUnits="userSpaceOnUse"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5199"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5201"
+       gradientUnits="userSpaceOnUse"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5204"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5206"
+       gradientUnits="userSpaceOnUse"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5209"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5211"
+       gradientUnits="userSpaceOnUse"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.37429819,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5221"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5223"
+       gradientUnits="userSpaceOnUse"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5226"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5228"
+       gradientUnits="userSpaceOnUse"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5231"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5233"
+       gradientUnits="userSpaceOnUse"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74067"
+       y2="115.58561"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5238"
+       gradientUnits="userSpaceOnUse"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857143)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5246"
+       gradientUnits="userSpaceOnUse"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5249"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5251"
+       gradientUnits="userSpaceOnUse"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5256"
+       gradientUnits="userSpaceOnUse"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857144)"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5261"
+       gradientUnits="userSpaceOnUse"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303"
+       gradientTransform="scale(0.99812851,1.0000063)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5265"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,631.83923,-0.88972711)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5267"
+       gradientUnits="userSpaceOnUse"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5270"
+       gradientUnits="userSpaceOnUse"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5272"
+       gradientUnits="userSpaceOnUse"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,0)"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5277"
+       gradientUnits="userSpaceOnUse"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5280"
+       gradientUnits="userSpaceOnUse"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5282"
+       gradientUnits="userSpaceOnUse"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5285"
+       gradientUnits="userSpaceOnUse"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,0)"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5290"
+       gradientUnits="userSpaceOnUse"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,0)"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5295"
+       gradientUnits="userSpaceOnUse"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5298"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,0)"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5300"
+       gradientUnits="userSpaceOnUse"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600.00001,0)"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5305"
+       gradientUnits="userSpaceOnUse"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00376895,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5308"
+       gradientUnits="userSpaceOnUse"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5310"
+       gradientUnits="userSpaceOnUse"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5312"
+       gradientUnits="userSpaceOnUse"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5314"
+       gradientUnits="userSpaceOnUse"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5316"
+       gradientUnits="userSpaceOnUse"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5318"
+       gradientUnits="userSpaceOnUse"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5335"
+       gradientUnits="userSpaceOnUse"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5337"
+       gradientUnits="userSpaceOnUse"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5339"
+       gradientUnits="userSpaceOnUse"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5341"
+       gradientUnits="userSpaceOnUse"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5343"
+       gradientUnits="userSpaceOnUse"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5345"
+       gradientUnits="userSpaceOnUse"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5362"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5364"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5366"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5368"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5370"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5372"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5374"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5376"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5378"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5380"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5400"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5402"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5404"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5406"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5408"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5410"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5412"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5414"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5416"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5418"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5532"
+       gradientUnits="userSpaceOnUse"
+       x1="559.771"
+       y1="313.20999"
+       x2="911.98419"
+       y2="460.03769" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient5534"
+       gradientUnits="userSpaceOnUse"
+       x1="582.45242"
+       y1="373.33334"
+       x2="937.54758"
+       y2="373.33334" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient5543"
+       gradientUnits="userSpaceOnUse"
+       x1="559.771"
+       y1="313.20999"
+       x2="911.98419"
+       y2="460.03769" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient5545"
+       gradientUnits="userSpaceOnUse"
+       x1="582.45242"
+       y1="373.33334"
+       x2="937.54758"
+       y2="373.33334" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="352.58418"
+     inkscape:cy="123.82747"
+     inkscape:document-units="px"
+     inkscape:current-layer="WhitePieces"
+     showgrid="false"
+     inkscape:window-width="1635"
+     inkscape:window-height="845"
+     inkscape:window-x="110"
+     inkscape:window-y="449"
+     showguides="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Fantasy Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:date>2017-10-29</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:description>Chess piece set &quot;Fantasy&quot; by Maurizio Monge.</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect3532"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccsss"
+         id="path9790"
+         d="m 699.63574,49.570122 c 2.47308,-4.17302 8.95019,-11.540435 15.62922,-15.371943 8.28185,7.784208 19.57487,25.913334 25.16109,43.334025 4.3538,13.57739 5.25671,19.678129 5.48338,34.182516 0.22668,14.50438 -7.40135,28.79221 -12.08341,34.07786"
+         style="fill:url(#linearGradient5303);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5305);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccscc"
+         id="path9792"
+         d="m 729.25014,157.04189 c 1.38027,-12.22151 -67.22774,-11.31942 -64.42223,0.6871 2.26677,5.0028 0.47896,11.43659 0.47896,11.43659 0,0 15.83487,-2.24694 33.45899,-1.96694 17.62412,0.28001 29.55199,1.67739 29.55199,1.67739 0,0 -0.44799,-8.23261 0.93229,-11.83414 z"
+         style="fill:url(#linearGradient5298);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5300);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csscscc"
+         id="path9786"
+         d="m 663.87066,155.95067 c -5.20925,-1.84795 -9.00165,-9.2425 -12.28798,-13.95879 -5.24563,-7.52811 -8.33832,-23.18377 -5.2662,-40.73934 3.07213,-17.555572 19.76846,-51.478738 36.86548,-66.526372 20.83702,15.047634 34.27476,37.797124 44.87973,68.110342 5.67522,16.22203 8.49209,33.97462 3.28283,52.58617 -12.15493,-2.50794 -53.31428,-4.88687 -67.47386,0.52799 z"
+         style="fill:url(#linearGradient5293);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5295);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path12426"
+         d="m 680.09808,31.707132 c 2.8525,-4.844739 -4.50993,-7.935602 -0.65877,-11.31926 2.16269,-1.900157 5.86256,-2.090257 7.93989,0.374469 2.99515,3.553697 -5.19882,6.63662 -1.16731,10.8976"
+         style="fill:url(#linearGradient5288);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5290);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssss"
+         id="path13305"
+         d="m 699.74395,162.82256 c -2.17892,-0.58827 -4.13767,0.44726 -4.93659,-0.21476 -0.98036,-0.81234 -0.92296,-4.19212 -0.2739,-5.05007 0.55496,-0.73356 7.68718,-0.82514 8.38705,-0.14934 0.65242,0.62892 -0.0189,4.7234 -0.62337,5.75943"
+         style="fill:none;stroke:url(#linearGradient5285);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18555"
+         d="m 687.15713,79.67143 c -2.61208,0.41425 -3.91211,3.278244 -3.58511,5.707013 -0.045,2.076336 0.86451,4.751528 -0.84347,6.3787 -2.31052,0.768723 -4.81096,-0.193961 -7.16527,-0.395208 -1.93832,-0.1771 -4.27577,-0.909831 -5.99901,0.338066 -1.31897,1.562455 0.22173,3.923461 1.92143,4.45 3.41781,1.486779 7.47558,0.711268 10.76429,2.471428 1.13526,1.047317 0.9031,2.871431 1.25,4.264291 1.06913,8.29763 1.01265,16.82704 3.52142,24.86428 0.65668,1.76462 1.68241,4.21296 3.87857,4.22858 1.69536,-0.58013 1.48132,-2.83199 1.57143,-4.28572 -0.20534,-9.11357 -2.73457,-17.99681 -3.13571,-27.09286 -0.0451,-0.895476 0.035,-2.019281 1.19286,-2.114284 4.10561,-1.181656 8.90265,0.132751 12.63571,-2.364286 1.53308,-0.830759 2.81271,-3.93038 0.32857,-4.335714 -4.37871,-0.644439 -8.80472,1.242762 -13.15714,0.421428 -1.3474,-0.477036 -1.2294,-2.342196 -1.38572,-3.514286 -0.25509,-2.761218 0.58401,-5.700292 -0.46428,-8.335714 -0.26287,-0.45966 -0.79112,-0.752152 -1.32857,-0.685714 z"
+         style="fill:url(#linearGradient5280);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5282);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssssssss"
+         id="path5000"
+         d="m 672.6554,183.60888 c 12.75959,-0.14292 18.9024,-7.40145 24.55023,-7.41002 5.64784,-0.009 10.8007,7.23279 24.53757,7.2569 7.37046,0.0129 46.17116,0.78734 44.01473,-5.09377 -2.15638,-5.88112 -26.66059,2.01678 -34.86539,-2.16602 -4.29474,-2.18946 -5.55472,-2.70835 -11.11038,-3.55006 -14.98719,-2.27063 -30.31065,-2.18012 -43.86266,-0.0859 -6.03322,0.93235 -8.48725,1.97055 -11.88523,4.25765 -5.71575,3.84714 -29.79279,-4.15201 -31.68782,1.46772 -1.89503,5.61973 24.80429,5.49711 40.30895,5.32345 z"
+         style="fill:url(#linearGradient5275);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5277);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5875"
+         d="m 745.29998,20.835715 c -4.70532,0.0451 -8.21546,3.906818 -10.16704,7.832046 -1.29109,2.492667 -3.56778,4.307326 -4.83295,6.796525 -0.26622,1.499326 1.87191,1.98787 3,1.664286 2.75386,-0.582731 4.93531,-2.759886 5.86528,-5.376478 1.10356,-2.694302 3.59551,-4.813961 6.54901,-5.009236 2.90062,-0.509954 5.58003,1.770158 6.16427,4.542857 0.8443,2.906626 0.46232,6.332846 -1.87857,8.442857 -3.65372,3.832471 -9.19591,5.547495 -12.27142,9.992857 -16.87919,33.309354 -33.73272,66.640311 -50.38525,100.064471 -5.91165,12.12292 -12.15817,24.10907 -17.33618,36.56411 -0.40285,1.55401 -1.61197,3.27714 -0.96428,4.89285 1.02161,0.79383 2.30835,-0.4338 3.19285,-0.97143 3.64051,-3.32308 5.65874,-8.01742 8.07143,-12.24999 10.16578,-19.72332 19.69309,-39.77213 29.58769,-59.63428 10.74342,-21.690558 21.48757,-43.388082 32.4623,-64.958587 3.10474,-4.595265 8.99768,-6.134712 12.47878,-10.379434 2.21679,-2.433148 3.6352,-5.654389 3.27837,-8.991996 -0.2287,-5.553796 -3.44457,-11.564378 -9.19285,-12.885714 -1.17966,-0.298962 -2.40003,-0.390238 -3.62144,-0.335714 z"
+         style="fill:url(#linearGradient5270);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5272);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5265);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5267);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 711.93729,30.817404 c 2.85251,-4.844738 -4.50992,-7.935602 -0.65877,-11.31926 2.16269,-1.900156 5.86257,-2.090256 7.9399,0.374471 2.99515,3.553694 -5.19883,6.636617 -1.16731,10.897598"
+         id="path3155"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         y="0"
+         x="0"
+         height="200"
+         width="200"
+         id="rect5257"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="csssc"
+         id="path3299"
+         d="m 65.973661,139.99662 c 5.301121,-7.65948 -1.61168,-28.76318 0.0042,-38.41182 2.622422,-15.659 23.197554,-26.169238 25.943908,-17.09068 3.257851,10.769371 -9.968434,11.785943 -13.648343,20.7757 -3.380091,8.25731 -2.65696,22.05308 3.92368,30.35651"
+         style="fill:url(#linearGradient5259);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5261);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5254);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5256);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 134.1464,141.10082 c -5.30112,-7.65947 1.61167,-28.76317 -0.004,-38.41181 -2.62245,-15.658982 -23.19758,-26.169233 -25.94393,-17.090684 -3.25785,10.769371 9.96844,11.785943 13.64834,20.775734 3.38009,8.2573 2.65699,22.05307 -3.92368,30.3565"
+         id="path3303"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         id="path24710"
+         d="m 91.706667,65.854917 c 1.201738,-3.428681 4.320983,-16.211442 3.180846,-19.977312 -5.10032,-0.403604 -15.756639,4.27477 -22.663337,2.776012 -1.945257,-3.51675 -3.159817,-11.084184 -0.365554,-15.238216 6.252639,-1.902637 20.052731,1.432798 23.867154,1.943901 1.352229,-3.852085 -3.312983,-15.459995 -2.409235,-19.663204 4.28583,-2.048761 14.929029,-1.846206 18.092209,0.236329 -0.1611,4.414549 -6.60458,15.137098 -6.76098,18.803167 4.29349,-0.220129 17.6671,-3.857177 22.23266,-2.968901 1.96944,3.819529 2.39676,10.643422 -0.78042,15.004759 -4.86738,1.621319 -17.75428,-2.041109 -23.1237,-0.976014 -2.26279,4.563872 1.25507,16.348117 2.12059,19.795516"
+         style="fill:url(#linearGradient5249);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5251);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path3297"
+         d="m 93.350804,84.990188 c -5.653759,-4.895612 -8.144891,-4.936274 -7.047474,-17.189981 0.937143,-10.464289 24.28729,-9.924344 24.83067,-0.455061 0.68136,11.873589 -3.26639,12.76278 -6.01133,18.511809"
+         style="fill:url(#linearGradient5244);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5246);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path25586"
+         d="m 61.93411,189.78267 -14.622904,-44.8555 107.710454,-0.47261 -17.11771,46.70276 -75.96984,-1.37465 z"
+         style="fill:url(#linearGradient5241);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5236);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5238);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 147.07567,163.9107 c -21.41174,-10.9747 -70.203183,-11.49032 -93.167044,0.42868 3.216853,10.16522 4.503609,21.47962 4.503609,21.47962 20.952382,-6.50601 63.513955,-6.76564 84.085385,0.94692 0,0 2.12105,-15.24105 4.57805,-22.85522 z"
+         id="path5264"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccsccscsccssccsc"
+         id="path23833"
+         d="m 126.52143,131.20715 c -8.28366,-3.50017 -17.5324,-13.44604 -27.880719,-13.765 -9.959907,0.23071 -17.955642,8.81457 -23.633568,13.35071 -26.348092,-11.99244 -26.033255,-34.946626 -7.6,-39.157144 C 70.409412,90.949937 79.345815,91.741676 85.25,91.47143 83.369931,86.279294 81.320466,82.597429 83.264285,75.685715 79.097836,73.004138 73.552775,71.081283 67.235714,70.707144 65.349606,70.595436 63.434311,70.547789 61.514286,70.57143 42.954043,70.799957 23.696852,77.551062 20.964286,94.628572 16.976,119.55388 39.042544,134.24348 46.985715,160.60715 72.198866,146.2281 130.33764,147.14368 154.49286,159.57143 c 6.41093,-20.3799 31.9659,-44.1967 26.25,-64.971429 -5.29335,-19.238891 -31.02682,-24.868875 -48.00715,-23.907143 -6.88197,0.38978 -13.48859,2.617669 -18.45,5.678571 0.96046,5.479118 -0.98626,9.958725 -2.59999,14.692858 7.85031,0.0034 21.62321,-1.822128 27.02857,1.235714 11.93817,6.753486 12.84843,31.062089 -12.19286,38.907149 z"
+         style="fill:url(#linearGradient5231);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5233);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5226);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5228);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 75.082964,130.86356 c 8.684595,-6.09788 12.799612,-18.20825 12.45232,-27.98509 -0.500777,-14.097401 -8.041005,-16.554659 -3.734857,-28.894659 2.919886,-8.367415 27.237323,-8.79747 29.983703,0.281084 3.25783,10.769362 -5.10677,17.474093 -3.8029,28.376135 1.521,12.71774 1.61532,21.14791 16.52448,28.93081"
+         id="path2408"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path8563"
+         d="m 63.015198,190.32636 c 20.083218,2.39645 52.162572,2.78986 74.826582,0.53929 -15.67932,-6.39544 -58.641204,-6.32588 -74.826582,-0.53929 z"
+         style="fill:url(#linearGradient5221);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5223);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.22084302,0,0,0.22084298,-76.302058,-33.60624)"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path21809"
+         style="fill:url(#linearGradient5343);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5345);stroke-width:16.55992508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.24288439,-0.0439872,0.02951635,0.16298102,-143.5593,57.039749)"
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5339);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5341);stroke-width:18.08697128;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path21811"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z" />
+      <path
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path21815"
+         style="fill:url(#linearGradient5335);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5337);stroke-width:18.32027817;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc"
+         transform="matrix(0.23748182,0.03854011,-0.02653303,0.16349302,-43.120388,-9.2446012)" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="0"
+         x="200"
+         height="200"
+         width="200"
+         id="rect5420"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path5422"
+         d="m 255.7566,188.54634 -11.51501,-37.99134 99.14697,0.30124 -11.31854,38.78422 -76.31342,-1.09412 z"
+         style="fill:url(#linearGradient5214);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path5424"
+         d="m 340.04874,163.72108 c -27.93136,-9.98142 -64.77863,-10.03939 -91.97573,-0.0238 2.87639,6.9782 3.63842,21.2567 3.63842,21.2567 23.02155,-6.4396 62.16105,-6.24382 85.00231,0.95725 0,0 0.52796,-15.24721 3.335,-22.19017 z"
+         style="fill:url(#linearGradient5209);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5211);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         id="path28221"
+         d="m 244.59516,159.52352 c 27.85155,-12.04272 71.44711,-12.23302 99.56053,0.0937 2.7717,-24.0083 11.50797,-53.64495 28.04178,-74.902734 -12.53664,4.905644 -30.73811,36.311554 -41.32007,42.230354 -8.29808,-17.4316 8.12443,-62.675195 14.50944,-72.258029 -10.71977,6.450011 -33.40524,46.403659 -40.10731,65.093699 -9.66079,-21.587315 -7.39948,-61.961528 -7.63058,-78.881893 -7.26764,15.897915 -16.80412,52.42813 -17.78025,78.243313 -18.55827,-13.91178 -25.1076,-51.490536 -30.05734,-66.378457 -2.72535,21.439477 2.03068,58.782217 5.17107,73.880327 -12.06681,-8.13546 -26.15763,-26.03872 -37.85397,-41.212562 14.8707,35.559682 20.25328,46.329812 27.4667,74.092222 z"
+         style="fill:url(#linearGradient5204);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5206);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscscscs"
+         id="path7672"
+         d="m 293.20307,159.95009 c -4.34242,-0.0223 -1.96238,3.3453 -2.81575,4.82632 -1.95143,1.13118 -8.28466,-0.87581 -6.24601,3.27771 1.4443,2.94263 3.60368,1.5574 6.02905,2.50551 1.20576,1.66093 -0.83269,6.71218 3.43692,6.6062 3.52628,-0.0875 1.60418,-5.12706 2.3579,-6.48491 2.1317,-1.39292 4.92849,0.49481 6.33928,-3.07474 1.07104,-2.70994 -4.23143,-1.70479 -6.32528,-2.87179 -0.87707,-1.31001 1.74188,-4.76063 -2.77611,-4.7843 z"
+         style="fill:url(#linearGradient5199);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5201);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path5428"
+         d="m 255.90247,188.63381 c 20.30223,2.42259 53.19352,3.28242 76.10467,1.00729 -12.92995,-5.77856 -59.40347,-5.7297 -76.10467,-1.00729 z"
+         style="fill:url(#linearGradient5194);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5196);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path1323"
+         d="m 308.48458,18.861369 c -1.95657,0.04289 -7.98708,1.055847 -11.61107,2.863445 -1.09938,2.768007 -0.52829,10.881355 0.0301,17.517506 3.47071,-5.570279 11.13967,-15.143593 11.58093,-20.380951 z"
+         style="fill:url(#linearGradient5189);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5191);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,219.9395,-62.058583)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path29102"
+         style="fill:url(#linearGradient5378);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5380);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient5183);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5185);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 363.40624,47.086749 c -1.0783,-1.292098 -0.39089,-3.657122 -9.14369,-8.469503 l -11.16706,13.949298 c 6.26539,-1.954215 16.17474,-4.905131 20.31075,-5.479795 z"
+         id="path2211"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5374);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5376);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path2203"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,267.48235,-48.344297)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path2213"
+         d="m 393.27089,80.432313 c 0.61126,-3.160512 -2.78183,-4.175618 -6.03682,-8.531246 -4.53406,1.856476 -9.78677,4.070773 -13.48712,9.262115 9.34106,-1.926412 13.58725,0.927561 19.52394,-0.730869 z"
+         style="fill:url(#linearGradient5177);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5179);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,295.50864,-19.599748)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path2205"
+         style="fill:url(#linearGradient5370);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5372);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient5171);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5173);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 251.79887,35.318512 c -2.41372,-2.699971 -5.23276,-2.312505 -11.59959,-3.247765 0.2223,7.708942 4.82388,9.859583 7.56151,15.857287 3.47071,-5.570279 2.9111,-5.772164 4.03808,-12.609522 z"
+         id="path2215"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5366);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5368);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path2207"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,171.71088,-50.172869)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path2217"
+         d="m 211.48865,66.235948 c -3.0736,0.639984 -3.33367,6.928342 -4.29815,10.154395 3.44153,3.793177 6.94093,5.954215 9.94755,11.821691 3.21471,-5.721856 -2.0022,-17.58522 -5.6494,-21.976086 z"
+         style="fill:url(#linearGradient5165);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5167);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,143.06101,-15.753258)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path2209"
+         style="fill:url(#linearGradient5362);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5364);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect5557"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         id="path5877"
+         d="m 445.78352,73.909629 c 0,0 0.74294,-26.795976 4.03537,-35.704134 6.87967,-1.485205 20.42276,-2.185836 28.83567,-0.958005 0.0941,5.449697 -1.24165,16.911936 -0.36368,22.15203 7.64469,-0.362183 23.13148,0.566139 32.98671,-0.541993 0.2195,-6.392917 -1.66181,-15.444709 0.2039,-22.571239 6.25561,-0.470064 20.39748,-0.967262 26.98233,1.862388 -0.87797,9.11776 0.12858,21.6526 0.12858,21.6526 l 17.26446,0.597418 -2.57076,13.714369 c -21.55516,8.079339 -94.01815,6.879755 -107.50258,-0.203434 z"
+         style="fill:url(#linearGradient5158);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5160);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path30874"
+         d="m 457.30676,160.56585 c -5.48294,5.47516 -16.9404,10.98428 -25.1102,12.71378 -1.18486,3.91126 -2.35068,8.4338 0.0549,13.29682 29.11926,0.2639 106.00895,-0.0742 133.83217,-0.17069 1.50133,-5.42439 2.63666,-9.34807 1.1353,-13.61155 -8.56656,-1.69588 -18.91267,-4.25676 -26.57123,-12.22767"
+         style="fill:url(#linearGradient5153);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5155);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5150);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 445.26656,175.6852 c 34.16186,0.0166 71.23736,-1.26013 107.77421,0.13268"
+         id="path28104"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path29124"
+         d="m 457.76994,71.056158 c -0.86145,10.251586 -1.10949,81.665672 -0.8726,90.172142 12.61195,-1.06648 71.22563,-1.13348 84.15137,-0.12963 -0.7319,-16.00677 -0.5294,-89.817639 -0.5294,-89.817639"
+         style="fill:url(#linearGradient5145);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5147);stroke-width:3.6571424;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path34378"
+         d="m 466.60128,145.10477 c 9.11731,-0.67214 28.2216,-1.42914 49.24302,-0.75316"
+         style="fill:none;stroke:url(#linearGradient5142);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5139);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.29087,130.31945 c 11.60061,-1.11679 22.82244,-1.48459 39.15458,-1.31463"
+         id="path2302"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5136);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.41321,115.4173 c 16.51853,-1.14223 16.98386,-1.02096 34.86095,-1.27874"
+         id="path2304"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2306"
+         d="m 466.41321,100.8027 c 8.38523,-0.69331 13.31611,-1.053493 23.35091,-0.81157"
+         style="fill:none;stroke:url(#linearGradient5133);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5130);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 476.51678,104.61814 c 0.20091,6.8416 -0.0402,-0.30543 0.16073,5.61156"
+         id="path28065"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2309"
+         d="m 489.24373,119.14294 c 0.20091,6.84159 -0.0402,-0.30544 0.16073,5.61157"
+         style="fill:none;stroke:url(#linearGradient5127);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5124);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 476.51678,133.83509 c 0.20091,6.84158 -0.0402,-0.30544 0.16073,5.61154"
+         id="path2311"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2313"
+         d="m 503.21234,133.37132 c 0.2009,6.84159 -0.0402,0.15833 0.16073,6.07531"
+         style="fill:none;stroke:url(#linearGradient5121);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5118);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 489.24373,149.08181 c 0.20091,6.84158 -0.0402,0.15832 0.16073,6.0753"
+         id="path2315"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5115);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.70147,87.589543 c 6.36738,-0.693307 9.61192,-0.915861 15.03448,-0.811584"
+         id="path5035"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccc"
+         id="path29999"
+         d="m 430.11375,36.863589 c 1.17855,6.450932 2.0691,12.57112 3.2111,21.837835 7.33191,5.112122 11.43607,6.897506 12.22117,15.464228 22.0234,-3.968271 88.44983,-3.053457 108.42368,-0.08037 1.39189,-7.721737 3.6692,-9.04106 14.42942,-15.52219 1.35941,-10.139883 2.55301,-15.028594 2.62996,-21.091168 -3.22448,-0.784064 -26.3927,-7.722038 -29.25458,-6.725392 -1.01791,6.03259 0.42138,11.21536 -0.91776,16.888691 -8.67267,0.43472 -16.39895,0.104555 -25.37453,-2.231486 0.0446,-7.583552 0.0334,-11.742521 0.40606,-17.611874 -3.79049,-1.349987 -26.3333,-1.589964 -30.58647,-0.197854 -0.73305,7.309339 0.19362,11.291138 -0.39386,17.789961 -7.69911,2.177811 -15.00049,1.612908 -24.19151,2.129139 -0.7405,-7.726821 0.62683,-10.438154 0.45301,-15.861982 -3.79211,-1.036796 -27.47526,4.111421 -31.05569,5.212462 z"
+         style="fill:url(#linearGradient5110);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5112);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path27172"
+         d="m 443.14063,59.942256 c 33.97809,-3.359008 84.23139,-3.567879 113.39331,0.810011"
+         style="fill:none;stroke:url(#linearGradient5107);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect5867"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="csssssssccscssssc"
+         id="path9661"
+         d="m 920.82051,91.841942 c 0.049,17.483918 -20.16603,32.606288 -40.10424,24.990548 -3.05344,-1.16631 -30.75842,23.95503 -35.19852,20.51791 -3.50284,-2.71159 3.88081,-13.88996 3.34401,-12.46223 -2.55581,6.79794 -13.83928,14.36437 -22.90058,4.59714 -3.5436,-3.81967 -2.44779,-14.80597 5.18493,-23.75614 7.94899,-9.321021 16.02018,-23.674761 19.14441,-31.953351 6.28395,-16.651286 3.81839,-17.014997 15.8609,-32.115611 2.26233,-2.836839 -3.67739,-13.850429 -1.51858,-21.039443 8.52749,1.520737 11.81478,10.094284 15.7361,13.692241 2.28585,-5.291813 0.74991,-19.511095 4.81348,-18.848516 4.06357,0.662574 8.73775,12.980934 15.4412,18.391373 80.28857,24.707625 79.63225,153.189417 57.19346,153.605677 -27.69634,0.51379 -60.85496,0.39751 -88.70968,-0.0463 -6.74913,-0.10754 -9.87345,-8.83917 -8.57203,-14.05723 6.20686,-24.88641 32.41901,-42.30551 45.25898,-50.93791 13.18793,-8.86633 15.60252,-17.57942 15.02616,-30.578178 z"
+         style="fill:url(#linearGradient5101);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5103);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31294"
+         d="m 878.85857,67.222556 c -6.64521,-1.226357 -12.47191,0.703581 -17.28388,5.492775"
+         style="fill:none;stroke:url(#linearGradient5098);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31298"
+         d="m 868.14579,74.469163 c 2.38697,2.432112 5.42488,2.533527 5.92538,-1.599225"
+         style="fill:none;stroke:url(#linearGradient5095);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path31300"
+         d="m 834.46197,118.46619 c -3.1668,-1.09378 -5.45786,4.00845 -3.4373,4.21661"
+         style="fill:none;stroke:url(#linearGradient5092);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path31308"
+         d="m 872.42883,108.41242 2.16857,2.69497"
+         style="fill:none;stroke:url(#linearGradient5089);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path31312"
+         d="m 920.85784,84.396784 0.0665,-5.695518"
+         style="fill:none;stroke:url(#linearGradient5086);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path32040"
+         d="m 874.48657,37.177012 -2.31158,1.207084"
+         style="fill:none;stroke:url(#linearGradient5083);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path32768"
+         d="m 886.69032,24.885392 c 6.89193,9.627456 9.38036,11.57494 1.18547,10.193591"
+         style="fill:none;stroke:url(#linearGradient5080);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssss"
+         id="path1849"
+         d="m 903.87285,29.971641 c 19.78804,5.802043 16.45047,1.614235 20.62382,8.410485 2.33812,3.807609 5.57796,-1.29779 13.29052,-0.814817 4.16519,0.260832 -11.42877,-6.221978 -13.46256,-8.814331 -2.8235,-3.598958 -23.35496,0.367424 -20.45178,1.218663 z"
+         style="fill:url(#linearGradient5075);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5077);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssss"
+         id="path1851"
+         d="m 932.46887,45.65086 c 6.21536,4.725174 10.76795,-0.0742 10.52243,8.124763 -0.16858,5.629602 7.42995,1.8683 11.12002,4.216615 3.39955,2.163421 6.80931,-6.563491 4.64701,-6.563491 -3.25317,0 -8.77717,1.526215 -7.77769,-2.147351 2.19387,-8.063535 -20.29693,-4.987696 -18.51177,-3.630536 z"
+         style="fill:url(#linearGradient5070);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5072);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssss"
+         id="path1853"
+         d="m 950.75005,63.47787 c 1.20981,0.423236 7.79901,4.884501 7.49392,7.005991 -1.57365,10.942361 6.49501,10.233086 9.96743,11.389817 4.86586,1.620912 -0.22674,-4.18829 -2.68195,-7.175056 -2.45521,-2.986766 1.67773,-4.32408 1.38837,-6.218549 -1.01786,-6.66422 -16.79938,-5.22317 -16.16777,-5.002203 z"
+         style="fill:url(#linearGradient5065);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5067);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssss"
+         id="path1855"
+         d="m 962.3748,86.547936 c 1.15613,2.015943 3.867,4.299219 4.72632,7.461675 0.85933,3.162459 1.18283,5.981929 2.90148,9.378639 1.71865,3.39671 8.63367,2.95394 11.61554,1.95703 4.0178,-1.34325 -9.71342,-5.51474 -6.61953,-11.874637 1.9582,-4.025315 -13.24774,-8.010661 -12.62381,-6.922707 z"
+         style="fill:url(#linearGradient5060);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5062);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path2732"
+         d="m 900.1479,166.74312 -5.89252,14.05538"
+         style="fill:none;stroke:url(#linearGradient5057);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect5972"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.16787953,0,0,0.16822697,972.4205,6.9567771)"
+         d="m 926.66667,373.33334 a 166.66667,150 0 1 1 -333.33334,0 166.66667,150 0 1 1 333.33334,0 z"
+         sodipodi:ry="150"
+         sodipodi:rx="166.66667"
+         sodipodi:cy="373.33334"
+         sodipodi:cx="760"
+         id="path35272"
+         style="fill:url(#linearGradient5532);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5534);stroke-width:21.76181984;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="cssssss"
+         id="path35274"
+         d="m 1090.8382,106.74527 c 0.3356,38.89697 -19.8248,50.53664 -29.2496,57.19902 -7.8152,5.52462 -5.8201,18.821 4.55,19.49968 6.4257,0.42054 63.2257,0.53965 69.863,-0.19285 11.7442,-1.2961 12.079,-15.24551 4.5001,-19.95682 -12.0249,-7.47486 -31.1294,-15.8943 -31.6567,-56.47758 -0.1008,-7.614197 -18.0666,-6.85922 -18.0068,-0.0715 z"
+         style="fill:url(#linearGradient5050);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5052);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccss"
+         id="path34396"
+         d="m 1077.795,98.910827 c -16.9588,4.357863 -22.8822,15.090073 -22.8822,15.090073 l 93.4506,0 c 0,0 -9.9274,-11.8481 -25.1485,-15.24213 -19.4835,-4.344448 -29.5254,-3.932329 -45.4199,0.152057 z"
+         style="fill:url(#linearGradient5045);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5047);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path36149"
+         d="m 1077.5134,163.12564 42.9492,0"
+         style="fill:none;stroke:url(#linearGradient5042);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7539"
+         width="200"
+         height="200"
+         x="600"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient5036);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5038);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 699.63574,249.57012 c 2.47308,-4.17301 8.95019,-11.54043 15.62922,-15.37194 8.28185,7.78421 19.57487,25.91334 25.16109,43.33403 4.3538,13.57738 5.25671,19.67812 5.48338,34.18251 0.22668,14.50438 -7.40135,28.79221 -12.08341,34.07786"
+         id="path7541"
+         sodipodi:nodetypes="ccsss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5031);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5033);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 729.25014,357.04189 c 1.38027,-12.22151 -67.22774,-11.31942 -64.42223,0.6871 2.26677,5.0028 0.47896,11.43659 0.47896,11.43659 0,0 15.83487,-2.24694 33.45899,-1.96694 17.62412,0.28001 29.55199,1.67739 29.55199,1.67739 0,0 -0.44799,-8.23261 0.93229,-11.83414 z"
+         id="path7543"
+         sodipodi:nodetypes="cccscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5026);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5028);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 663.87066,355.95067 c -5.20925,-1.84795 -9.00165,-9.2425 -12.28798,-13.95879 -5.24563,-7.52811 -8.33832,-23.18377 -5.2662,-40.73934 3.07213,-17.55557 19.76846,-51.47873 36.86548,-66.52637 20.83702,15.04764 34.27476,37.79713 44.87973,68.11034 5.67522,16.22203 8.49209,33.97462 3.28283,52.58617 -12.15493,-2.50794 -53.31428,-4.88687 -67.47386,0.52799 z"
+         id="path7545"
+         sodipodi:nodetypes="csscscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5021);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5023);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 680.09808,231.70713 c 2.8525,-4.84474 -4.50993,-7.9356 -0.65877,-11.31926 2.16269,-1.90015 5.86256,-2.09025 7.93989,0.37447 2.99515,3.5537 -5.19882,6.63663 -1.16731,10.8976"
+         id="path7547"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient5018);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 699.74395,362.82256 c -2.17892,-0.58827 -4.13767,0.44726 -4.93659,-0.21476 -0.98036,-0.81234 -0.92296,-4.19212 -0.2739,-5.05007 0.55496,-0.73356 7.68718,-0.82514 8.38705,-0.14934 0.65242,0.62892 -0.0189,4.7234 -0.62337,5.75943"
+         id="path7549"
+         sodipodi:nodetypes="cssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5013);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5015);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 687.15713,279.67143 c -2.61208,0.41426 -3.91211,3.27825 -3.58511,5.70702 -0.045,2.07633 0.86451,4.75153 -0.84347,6.3787 -2.31052,0.76872 -4.81096,-0.19396 -7.16527,-0.39521 -1.93832,-0.17711 -4.27577,-0.90983 -5.99901,0.33807 -1.31897,1.56245 0.22173,3.92345 1.92143,4.45 3.41781,1.48678 7.47558,0.71126 10.76429,2.47142 1.13526,1.04732 0.9031,2.87143 1.25,4.26429 1.06913,8.29763 1.01265,16.82704 3.52142,24.86428 0.65668,1.76462 1.68241,4.21296 3.87857,4.22858 1.69536,-0.58013 1.48132,-2.83199 1.57143,-4.28572 -0.20534,-9.11357 -2.73457,-17.99681 -3.13571,-27.09286 -0.0451,-0.89547 0.035,-2.01928 1.19286,-2.11428 4.10561,-1.18166 8.90265,0.13275 12.63571,-2.36428 1.53308,-0.83077 2.81271,-3.93039 0.32857,-4.33572 -4.37871,-0.64444 -8.80472,1.24277 -13.15714,0.42143 -1.3474,-0.47704 -1.2294,-2.3422 -1.38572,-3.51429 -0.25509,-2.76122 0.58401,-5.70029 -0.46428,-8.33571 -0.26287,-0.45967 -0.79112,-0.75216 -1.32857,-0.68572 z"
+         id="path7551"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5008);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5010);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 672.6554,383.60888 c 12.75959,-0.14292 18.9024,-7.40145 24.55023,-7.41002 5.64784,-0.009 10.8007,7.23279 24.53757,7.2569 7.37046,0.0129 46.17116,0.78734 44.01473,-5.09377 -2.15638,-5.88112 -26.66059,2.01678 -34.86539,-2.16602 -4.29474,-2.18946 -5.55472,-2.70835 -11.11038,-3.55006 -14.98719,-2.27063 -30.31065,-2.18012 -43.86266,-0.0859 -6.03322,0.93235 -8.48725,1.97055 -11.88523,4.25765 -5.71575,3.84714 -29.79279,-4.15201 -31.68782,1.46772 -1.89503,5.61973 24.80429,5.49711 40.30895,5.32345 z"
+         id="path7553"
+         sodipodi:nodetypes="csssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient5003);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5005);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 745.29998,220.83571 c -4.70532,0.0451 -8.21546,3.90683 -10.16704,7.83205 -1.29109,2.49267 -3.56778,4.30733 -4.83295,6.79653 -0.26622,1.49933 1.87191,1.98787 3,1.66429 2.75386,-0.58274 4.93531,-2.75989 5.86528,-5.37649 1.10356,-2.69429 3.59551,-4.81396 6.54901,-5.00923 2.90062,-0.50995 5.58003,1.77016 6.16427,4.54286 0.8443,2.90663 0.46232,6.33284 -1.87857,8.44285 -3.65372,3.83248 -9.19591,5.5475 -12.27142,9.99287 -16.87919,33.30934 -33.73272,66.6403 -50.38525,100.06446 -5.91165,12.12292 -12.15817,24.10907 -17.33618,36.56411 -0.40285,1.55401 -1.61197,3.27714 -0.96428,4.89285 1.02161,0.79383 2.30835,-0.4338 3.19285,-0.97143 3.64051,-3.32308 5.65874,-8.01742 8.07143,-12.24999 10.16578,-19.72332 19.69309,-39.77213 29.58769,-59.63428 10.74342,-21.69055 21.48757,-43.38808 32.4623,-64.95858 3.10474,-4.59527 8.99768,-6.13472 12.47878,-10.37944 2.21679,-2.43314 3.6352,-5.65438 3.27837,-8.99199 -0.2287,-5.5538 -3.44457,-11.56438 -9.19285,-12.88571 -1.17966,-0.29897 -2.40003,-0.39025 -3.62144,-0.33573 z"
+         id="path7555"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path7557"
+         d="m 711.93729,230.81741 c 2.85251,-4.84474 -4.50992,-7.9356 -0.65877,-11.31926 2.16269,-1.90016 5.86257,-2.09026 7.9399,0.37447 2.99515,3.55369 -5.19883,6.63662 -1.16731,10.8976"
+         style="fill:url(#linearGradient4998);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5000);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7689"
+         width="200"
+         height="200"
+         x="1000"
+         y="200" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5543);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5545);stroke-width:21.76181984;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7691"
+         sodipodi:cx="760"
+         sodipodi:cy="373.33334"
+         sodipodi:rx="166.66667"
+         sodipodi:ry="150"
+         d="m 926.66667,373.33334 a 166.66667,150 0 1 1 -333.33334,0 166.66667,150 0 1 1 333.33334,0 z"
+         transform="matrix(0.16787953,0,0,0.16822697,972.4205,206.95678)" />
+      <path
+         style="fill:url(#linearGradient4991);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4993);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1090.8382,306.74527 c 0.3356,38.89697 -19.8248,50.53664 -29.2496,57.19902 -7.8152,5.52462 -5.8201,18.821 4.55,19.49968 6.4257,0.42054 63.2257,0.53965 69.863,-0.19285 11.7442,-1.2961 12.079,-15.24551 4.5001,-19.95682 -12.0249,-7.47486 -31.1294,-15.8943 -31.6567,-56.47758 -0.1008,-7.61419 -18.0666,-6.85922 -18.0068,-0.0715 z"
+         id="path7693"
+         sodipodi:nodetypes="cssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4986);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4988);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1077.795,298.91082 c -16.9588,4.35787 -22.8822,15.09008 -22.8822,15.09008 l 93.4506,0 c 0,0 -9.9274,-11.8481 -25.1485,-15.24213 -19.4835,-4.34445 -29.5254,-3.93233 -45.4199,0.15205 z"
+         id="path7695"
+         sodipodi:nodetypes="cccss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4983);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1077.5134,363.12564 42.9492,0"
+         id="path7697"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7623"
+         width="200"
+         height="200"
+         x="400"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient4977);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4979);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 445.78352,273.90963 c 0,0 0.74294,-26.79598 4.03537,-35.70414 6.87967,-1.4852 20.42276,-2.18583 28.83567,-0.958 0.0941,5.44969 -1.24165,16.91193 -0.36368,22.15203 7.64469,-0.36219 23.13148,0.56614 32.98671,-0.54199 0.2195,-6.39292 -1.66181,-15.44471 0.2039,-22.57124 6.25561,-0.47007 20.39748,-0.96726 26.98233,1.86238 -0.87797,9.11777 0.12858,21.6526 0.12858,21.6526 l 17.26446,0.59742 -2.57076,13.71437 c -21.55516,8.07934 -94.01815,6.87976 -107.50258,-0.20343 z"
+         id="path7625"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4972);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4974);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 457.30676,360.56585 c -5.48294,5.47516 -16.9404,10.98428 -25.1102,12.71378 -1.18486,3.91126 -2.35068,8.4338 0.0549,13.29682 29.11926,0.2639 106.00895,-0.0742 133.83217,-0.17069 1.50133,-5.42439 2.63666,-9.34807 1.1353,-13.61155 -8.56656,-1.69588 -18.91267,-4.25676 -26.57123,-12.22767"
+         id="path7627"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path7629"
+         d="m 445.26656,375.6852 c 34.16186,0.0166 71.23736,-1.26013 107.77421,0.13268"
+         style="fill:none;stroke:url(#linearGradient4969);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4964);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4966);stroke-width:3.6571424;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 457.76994,271.05616 c -0.86145,10.25159 -1.10949,81.66567 -0.8726,90.17214 12.61195,-1.06648 71.22563,-1.13348 84.15137,-0.12963 -0.7319,-16.00677 -0.5294,-89.81764 -0.5294,-89.81764"
+         id="path7631"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4961);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.60128,345.10477 c 9.11731,-0.67214 28.2216,-1.42914 49.24302,-0.75316"
+         id="path7633"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7635"
+         d="m 466.29087,330.31945 c 11.60061,-1.11679 22.82244,-1.48459 39.15458,-1.31463"
+         style="fill:none;stroke:url(#linearGradient4958);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7637"
+         d="m 466.41321,315.4173 c 16.51853,-1.14223 16.98386,-1.02096 34.86095,-1.27874"
+         style="fill:none;stroke:url(#linearGradient4955);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4952);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.41321,300.8027 c 8.38523,-0.69331 13.31611,-1.05349 23.35091,-0.81157"
+         id="path7639"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7641"
+         d="m 476.51678,304.61814 c 0.20091,6.8416 -0.0402,-0.30543 0.16073,5.61156"
+         style="fill:none;stroke:url(#linearGradient4949);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4946);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 489.24373,319.14294 c 0.20091,6.84159 -0.0402,-0.30544 0.16073,5.61157"
+         id="path7643"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7645"
+         d="m 476.51678,333.83509 c 0.20091,6.84158 -0.0402,-0.30544 0.16073,5.61154"
+         style="fill:none;stroke:url(#linearGradient4943);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4940);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 503.21234,333.37132 c 0.2009,6.84159 -0.0402,0.15833 0.16073,6.07531"
+         id="path7647"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7649"
+         d="m 489.24373,349.08181 c 0.20091,6.84158 -0.0402,0.15832 0.16073,6.0753"
+         style="fill:none;stroke:url(#linearGradient4937);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7651"
+         d="m 466.70147,287.58954 c 6.36738,-0.6933 9.61192,-0.91586 15.03448,-0.81158"
+         style="fill:none;stroke:url(#linearGradient4934);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4929);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4931);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 430.11375,236.86359 c 1.17855,6.45094 2.0691,12.57112 3.2111,21.83783 7.33191,5.11213 11.43607,6.89751 12.22117,15.46423 22.0234,-3.96827 88.44983,-3.05346 108.42368,-0.0804 1.39189,-7.72173 3.6692,-9.04106 14.42942,-15.52219 1.35941,-10.13988 2.55301,-15.02859 2.62996,-21.09117 -3.22448,-0.78406 -26.3927,-7.72203 -29.25458,-6.72539 -1.01791,6.03259 0.42138,11.21536 -0.91776,16.88869 -8.67267,0.43472 -16.39895,0.10456 -25.37453,-2.23148 0.0446,-7.58355 0.0334,-11.74252 0.40606,-17.61188 -3.79049,-1.34998 -26.3333,-1.58996 -30.58647,-0.19785 -0.73305,7.30934 0.19362,11.29114 -0.39386,17.78997 -7.69911,2.1778 -15.00049,1.6129 -24.19151,2.12913 -0.7405,-7.72682 0.62683,-10.43816 0.45301,-15.86199 -3.79211,-1.03679 -27.47526,4.11143 -31.05569,5.21247 z"
+         id="path7653"
+         sodipodi:nodetypes="ccccccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4926);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 443.14063,259.94226 c 33.97809,-3.35901 84.23139,-3.56788 113.39331,0.81001"
+         id="path7655"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7659"
+         width="200"
+         height="200"
+         x="800"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient4920);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4922);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 920.82051,291.84195 c 0.049,17.48391 -20.16603,32.60628 -40.10424,24.99054 -3.05344,-1.16631 -30.75842,23.95503 -35.19852,20.51791 -3.50284,-2.71159 3.88081,-13.88996 3.34401,-12.46223 -2.55581,6.79794 -13.83928,14.36437 -22.90058,4.59714 -3.5436,-3.81967 -2.44779,-14.80597 5.18493,-23.75614 7.94899,-9.32103 16.02018,-23.67476 19.14441,-31.95335 6.28395,-16.65129 3.81839,-17.015 15.8609,-32.11561 2.26233,-2.83684 -3.67739,-13.85043 -1.51858,-21.03944 8.52749,1.52073 11.81478,10.09428 15.7361,13.69223 2.28585,-5.2918 0.74991,-19.51109 4.81348,-18.84851 4.06357,0.66257 8.73775,12.98093 15.4412,18.39137 80.28857,24.70762 79.63225,153.18942 57.19346,153.60568 -27.69634,0.51379 -60.85496,0.39751 -88.70968,-0.0463 -6.74913,-0.10754 -9.87345,-8.83917 -8.57203,-14.05723 6.20686,-24.88641 32.41901,-42.30551 45.25898,-50.93791 13.18793,-8.86633 15.60252,-17.57942 15.02616,-30.57817 z"
+         id="path7661"
+         sodipodi:nodetypes="csssssssccscssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4917);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 878.85857,267.22256 c -6.64521,-1.22636 -12.47191,0.70358 -17.28388,5.49277"
+         id="path7663"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4914);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 868.14579,274.46916 c 2.38697,2.43212 5.42488,2.53353 5.92538,-1.59922"
+         id="path7665"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4911);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 834.46197,318.46619 c -3.1668,-1.09378 -5.45786,4.00845 -3.4373,4.21661"
+         id="path7667"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4908);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 872.42883,308.41242 2.16857,2.69497"
+         id="path7669"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4905);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 920.85784,284.39679 0.0665,-5.69552"
+         id="path7671"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4902);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 874.48657,237.17701 -2.31158,1.20709"
+         id="path7673"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4899);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 886.69032,224.88539 c 6.89193,9.62746 9.38036,11.57494 1.18547,10.1936"
+         id="path7675"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4894);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4896);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 903.87285,229.97164 c 19.78804,5.80204 16.45047,1.61424 20.62382,8.41048 2.33812,3.80761 5.57796,-1.29778 13.29052,-0.81481 4.16519,0.26083 -11.42877,-6.22198 -13.46256,-8.81433 -2.8235,-3.59896 -23.35496,0.36742 -20.45178,1.21866 z"
+         id="path7677"
+         sodipodi:nodetypes="cssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4891);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 932.46887,245.65085 c 6.21536,4.72518 10.76795,-0.0742 10.52243,8.12477 -0.16858,5.62961 7.42995,1.8683 11.12002,4.21661 3.39955,2.16343 6.80931,-6.56348 4.64701,-6.56348 -3.25317,0 -8.77717,1.52621 -7.77769,-2.14735 2.19387,-8.06354 -20.29693,-4.9877 -18.51177,-3.63055 z"
+         id="path7679"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4884);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4886);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 950.75005,263.47787 c 1.20981,0.42324 7.79901,4.8845 7.49392,7.00599 -1.57365,10.94237 6.49501,10.23309 9.96743,11.38982 4.86586,1.62091 -0.22674,-4.18829 -2.68195,-7.17506 -2.45521,-2.98676 1.67773,-4.32408 1.38837,-6.21855 -1.01786,-6.66421 -16.79938,-5.22317 -16.16777,-5.0022 z"
+         id="path7681"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4879);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4881);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 962.3748,286.54793 c 1.15613,2.01595 3.867,4.29922 4.72632,7.46168 0.85933,3.16246 1.18283,5.98193 2.90148,9.37864 1.71865,3.39671 8.63367,2.95394 11.61554,1.95703 4.0178,-1.34325 -9.71342,-5.51474 -6.61953,-11.87464 1.9582,-4.02531 -13.24774,-8.01066 -12.62381,-6.92271 z"
+         id="path7683"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient4876);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 900.1479,366.74312 -5.89252,14.05538"
+         id="path7685"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7589"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient4872);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 255.7566,388.54634 -11.51501,-37.99134 99.14697,0.30124 -11.31854,38.78422 -76.31342,-1.09412 z"
+         id="path7591"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4867);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4869);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 340.04874,363.72108 c -27.93136,-9.98142 -64.77863,-10.03939 -91.97573,-0.0237 2.87639,6.9782 3.63842,21.2567 3.63842,21.2567 23.02155,-6.4396 62.16105,-6.24382 85.00231,0.95725 0,0 0.52796,-15.24721 3.335,-22.19017 z"
+         id="path7593"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4862);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4864);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 244.59516,359.52352 c 27.85155,-12.04272 71.44711,-12.23302 99.56053,0.0937 2.7717,-24.0083 11.50797,-53.64495 28.04178,-74.90273 -12.53664,4.90564 -30.73811,36.31155 -41.32007,42.23035 -8.29808,-17.4316 8.12443,-62.6752 14.50944,-72.25803 -10.71977,6.45001 -33.40524,46.40366 -40.10731,65.0937 -9.66079,-21.58731 -7.39948,-61.96153 -7.63058,-78.88189 -7.26764,15.89792 -16.80412,52.42812 -17.78025,78.24331 -18.55827,-13.91178 -25.1076,-51.49054 -30.05734,-66.37846 -2.72535,21.43948 2.03068,58.78222 5.17107,73.88033 -12.06681,-8.13546 -26.15763,-26.03872 -37.85397,-41.21256 14.8707,35.55968 20.25328,46.32981 27.4667,74.09222 z"
+         id="path7595"
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4857);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4859);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 293.20307,359.95009 c -4.34242,-0.0224 -1.96238,3.3453 -2.81575,4.82632 -1.95143,1.13118 -8.28466,-0.87581 -6.24601,3.27771 1.4443,2.94263 3.60368,1.5574 6.02905,2.50551 1.20576,1.66093 -0.83269,6.71218 3.43692,6.6062 3.52628,-0.0875 1.60418,-5.12706 2.3579,-6.48491 2.1317,-1.39292 4.92849,0.49481 6.33928,-3.07474 1.07104,-2.70994 -4.23143,-1.70479 -6.32528,-2.87179 -0.87707,-1.31001 1.74188,-4.76063 -2.77611,-4.7843 z"
+         id="path7597"
+         sodipodi:nodetypes="ccscscscs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4852);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4854);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 255.90247,388.63381 c 20.30223,2.42259 53.19352,3.28242 76.10467,1.00729 -12.92995,-5.77856 -59.40347,-5.7297 -76.10467,-1.00729 z"
+         id="path7599"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4847);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4849);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 308.48458,218.86136 c -1.95657,0.0429 -7.98708,1.05586 -11.61107,2.86346 -1.09938,2.768 -0.52829,10.88135 0.0301,17.5175 3.47071,-5.57028 11.13967,-15.1436 11.58093,-20.38096 z"
+         id="path7601"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5416);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5418);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7603"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,219.9395,137.94142)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path7605"
+         d="m 363.40624,247.08675 c -1.0783,-1.29209 -0.39089,-3.65712 -9.14369,-8.46951 l -11.16706,13.94931 c 6.26539,-1.95422 16.17474,-4.90514 20.31075,-5.4798 z"
+         style="fill:url(#linearGradient4841);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4843);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,267.48235,151.65571)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path7607"
+         style="fill:url(#linearGradient5412);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5414);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient4835);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4837);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 393.27089,280.43231 c 0.61126,-3.1605 -2.78183,-4.17561 -6.03682,-8.53124 -4.53406,1.85647 -9.78677,4.07077 -13.48712,9.26211 9.34106,-1.92641 13.58725,0.92756 19.52394,-0.73087 z"
+         id="path7609"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5408);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5410);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7611"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,295.50864,180.40025)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path7613"
+         d="m 251.79887,235.31851 c -2.41372,-2.69997 -5.23276,-2.31251 -11.59959,-3.24776 0.2223,7.70894 4.82388,9.85958 7.56151,15.85728 3.47071,-5.57027 2.9111,-5.77216 4.03808,-12.60952 z"
+         style="fill:url(#linearGradient4829);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4831);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,171.71088,149.82713)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path7615"
+         style="fill:url(#linearGradient5404);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5406);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient4823);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4825);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 211.48865,266.23595 c -3.0736,0.63998 -3.33367,6.92834 -4.29815,10.15439 3.44153,3.79318 6.94093,5.95421 9.94755,11.82169 3.21471,-5.72185 -2.0022,-17.58522 -5.6494,-21.97608 z"
+         id="path7617"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5400);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5402);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7619"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,143.06101,184.24674)" />
+    </g>
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7561"
+         width="200"
+         height="200"
+         x="0"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient4816);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4818);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 65.973661,339.99662 c 5.301121,-7.65948 -1.61168,-28.76318 0.0042,-38.41182 2.622422,-15.659 23.197554,-26.16923 25.943908,-17.09068 3.257851,10.76938 -9.968434,11.78595 -13.648343,20.7757 -3.380091,8.25731 -2.65696,22.05308 3.92368,30.35651"
+         id="path7563"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssc"
+         id="path7565"
+         d="m 134.1464,341.10082 c -5.30112,-7.65947 1.61167,-28.76317 -0.004,-38.41181 -2.62245,-15.65898 -23.19758,-26.16923 -25.94393,-17.09068 -3.25785,10.76937 9.96844,11.78594 13.64834,20.77573 3.38009,8.2573 2.65699,22.05307 -3.92368,30.3565"
+         style="fill:url(#linearGradient4811);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4813);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4806);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4808);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 91.706667,265.85493 c 1.201738,-3.4287 4.320983,-16.21146 3.180846,-19.97732 -5.10032,-0.4036 -15.756639,4.27477 -22.663337,2.77601 -1.945257,-3.51675 -3.159817,-11.08418 -0.365554,-15.23822 6.252639,-1.90263 20.052731,1.4328 23.867154,1.94391 1.352229,-3.85209 -3.312983,-15.46 -2.409235,-19.66321 4.28583,-2.04876 14.929029,-1.84621 18.092209,0.23633 -0.1611,4.41455 -6.60458,15.1371 -6.76098,18.80317 4.29349,-0.22013 17.6671,-3.85718 22.23266,-2.96891 1.96944,3.81954 2.39676,10.64343 -0.78042,15.00477 -4.86738,1.62132 -17.75428,-2.04112 -23.1237,-0.97602 -2.26279,4.56387 1.25507,16.34812 2.12059,19.79551"
+         id="path7567"
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4801);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4803);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 93.350804,284.9902 c -5.653759,-4.89562 -8.144891,-4.93628 -7.047474,-17.18999 0.937143,-10.46429 24.28729,-9.92434 24.83067,-0.45506 0.68136,11.87359 -3.26639,12.76278 -6.01133,18.51181"
+         id="path7569"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4798);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 61.93411,389.78267 -14.622904,-44.8555 107.710454,-0.47261 -17.11771,46.70276 -75.96984,-1.37465 z"
+         id="path7571"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path7573"
+         d="m 147.07567,363.9107 c -21.41174,-10.9747 -70.203183,-11.49032 -93.167044,0.42868 3.216853,10.16522 4.503609,21.47962 4.503609,21.47962 20.952382,-6.50601 63.513955,-6.76564 84.085385,0.94692 0,0 2.12105,-15.24105 4.57805,-22.85522 z"
+         style="fill:url(#linearGradient4793);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4795);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4788);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4790);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 126.52143,331.20715 c -8.28366,-3.50017 -17.5324,-13.44604 -27.880719,-13.765 -9.959907,0.23071 -17.955642,8.81457 -23.633568,13.35071 -26.348092,-11.99244 -26.033255,-34.94663 -7.6,-39.15714 3.002269,-0.68578 11.938672,0.10596 17.842857,-0.16428 -1.880069,-5.19215 -3.929534,-8.87401 -1.985715,-15.78572 -4.166449,-2.68158 -9.71151,-4.60443 -16.028571,-4.97857 -1.886108,-0.11171 -3.801403,-0.15935 -5.721428,-0.13571 -18.560243,0.22852 -37.817434,6.97963 -40.55,24.05714 -3.988286,24.9253 18.078258,39.6149 26.021429,65.97857 25.213151,-14.37905 83.351925,-13.46347 107.507145,-1.03572 6.41093,-20.3799 31.9659,-44.1967 26.25,-64.97142 -5.29335,-19.23889 -31.02682,-24.86888 -48.00715,-23.90714 -6.88197,0.38977 -13.48859,2.61766 -18.45,5.67856 0.96046,5.47913 -0.98626,9.95872 -2.59999,14.69286 7.85031,0.003 21.62321,-1.82213 27.02857,1.23571 11.93817,6.75349 12.84843,31.06209 -12.19286,38.90715 z"
+         id="path7575"
+         sodipodi:nodetypes="cccsccscsccssccsc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssc"
+         id="path7577"
+         d="m 75.082964,330.86356 c 8.684595,-6.09788 12.799612,-18.20825 12.45232,-27.98509 -0.500777,-14.0974 -8.041005,-16.55466 -3.734857,-28.89465 2.919886,-8.36742 27.237323,-8.79748 29.983703,0.28108 3.25783,10.76936 -5.10677,17.47409 -3.8029,28.37613 1.521,12.71774 1.61532,21.14791 16.52448,28.93081"
+         style="fill:url(#linearGradient4783);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4785);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient4778);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4780);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 63.015198,390.32636 c 20.083218,2.39645 52.162572,2.78986 74.826582,0.53929 -15.67932,-6.39544 -58.641204,-6.32588 -74.826582,-0.53929 z"
+         id="path7579"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5316);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5318);stroke-width:16.55992508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7581"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         transform="matrix(0.22084302,0,0,0.22084298,-76.302058,166.39376)" />
+      <path
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path7583"
+         style="fill:url(#linearGradient5312);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5314);stroke-width:18.08697128;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc"
+         transform="matrix(0.24288439,-0.0439872,0.02951635,0.16298102,-143.5593,257.03975)" />
+      <path
+         transform="matrix(0.23748182,0.03854011,-0.02653303,0.16349302,-43.120388,190.75541)"
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient5308);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5310);stroke-width:18.32027817;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7585"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/fantasy_alt.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/fantasy_alt.svg
@@ -1,0 +1,3798 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="fantasy_alt.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title6383">Fantasy Alt Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7935" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop7937" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop7929"
+         offset="0"
+         style="stop-color:#ede3de;stop-opacity:1;" />
+      <stop
+         id="stop7931"
+         offset="1"
+         style="stop-color:#8a6737;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7192" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="1"
+         id="stop7194" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         id="stop2268"
+         offset="0"
+         style="stop-color:#000e1c;stop-opacity:1;" />
+      <stop
+         id="stop2270"
+         offset="1"
+         style="stop-color:#50506f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14964"
+       gradientUnits="userSpaceOnUse"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient14967"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14969"
+       gradientUnits="userSpaceOnUse"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14972"
+       gradientUnits="userSpaceOnUse"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14975"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14978"
+       gradientUnits="userSpaceOnUse"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14981"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14984"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14987"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14990"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14993"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14996"
+       gradientUnits="userSpaceOnUse"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient14999"
+       gradientUnits="userSpaceOnUse"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15002"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15004"
+       gradientUnits="userSpaceOnUse"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15007"
+       gradientUnits="userSpaceOnUse"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15010"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15012"
+       gradientUnits="userSpaceOnUse"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,197.29485)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15017"
+       gradientUnits="userSpaceOnUse"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15022"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15024"
+       gradientUnits="userSpaceOnUse"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15030"
+       gradientUnits="userSpaceOnUse"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15034"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15036"
+       gradientUnits="userSpaceOnUse"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15040"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15042"
+       gradientUnits="userSpaceOnUse"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15046"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15048"
+       gradientUnits="userSpaceOnUse"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15051"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15053"
+       gradientUnits="userSpaceOnUse"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15056"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15058"
+       gradientUnits="userSpaceOnUse"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15061"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15063"
+       gradientUnits="userSpaceOnUse"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15066"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15068"
+       gradientUnits="userSpaceOnUse"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15071"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15078"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15080"
+       gradientUnits="userSpaceOnUse"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15083"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15085"
+       gradientUnits="userSpaceOnUse"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15088"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15090"
+       gradientUnits="userSpaceOnUse"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74068"
+       y2="115.58561"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15095"
+       gradientUnits="userSpaceOnUse"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15101"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15103"
+       gradientUnits="userSpaceOnUse"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15106"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15108"
+       gradientUnits="userSpaceOnUse"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15113"
+       gradientUnits="userSpaceOnUse"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15116"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,199.99999)"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15118"
+       gradientUnits="userSpaceOnUse"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21114126,0,0,0.210392,1011.288,212.82424)"
+       x1="213.78165"
+       y1="696.46155"
+       x2="414.65732"
+       y2="864.22052" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15165"
+       gradientUnits="userSpaceOnUse"
+       x1="1046.1874"
+       y1="366.56808"
+       x2="1098.8392"
+       y2="366.56808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16437029,1.1302757e-4,-0.00204311,0.16893829,1102.9193,220.4518)"
+       x1="241.75385"
+       y1="401.27609"
+       x2="522.97559"
+       y2="519.06158" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15170"
+       gradientUnits="userSpaceOnUse"
+       x1="1159.5165"
+       y1="297.8815"
+       x2="1178.6918"
+       y2="297.8815" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15173"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22387292,0.04610674,-0.04610674,0.22387292,1027.3988,235.02322)"
+       x1="456.672"
+       y1="496.70807"
+       x2="790.85327"
+       y2="285.25974" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15175"
+       gradientUnits="userSpaceOnUse"
+       x1="1116.9076"
+       y1="346.82153"
+       x2="1171.1093"
+       y2="346.82153" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15178"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21114126,0,0,0.210392,1185.1025,212.58006)"
+       x1="409.6666"
+       y1="725.85468"
+       x2="101.73616"
+       y2="844.86835" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15180"
+       gradientUnits="userSpaceOnUse"
+       x1="1098.4655"
+       y1="366.03885"
+       x2="1149.8408"
+       y2="366.03885" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15183"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17051017,0.01574006,-0.01481026,0.16043794,1043.8798,216.46919)"
+       x1="411.38654"
+       y1="269.9574"
+       x2="606.08582"
+       y2="442.53754" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15185"
+       gradientUnits="userSpaceOnUse"
+       x1="1073.6456"
+       y1="289.08289"
+       x2="1123.5177"
+       y2="289.08289" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15188"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07483657,-0.03798697,0.02784731,0.06327954,1091.6156,273.77449)"
+       x1="307.02979"
+       y1="442.26321"
+       x2="576.54529"
+       y2="444.9863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15190"
+       gradientUnits="userSpaceOnUse"
+       x1="1120.0306"
+       y1="282.81598"
+       x2="1140.408"
+       y2="282.81598" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20193623,0.01864103,-0.01673386,0.18127612,1018.779,214.60765)"
+       x1="275.24356"
+       y1="458.6561"
+       x2="771.40265"
+       y2="497.96924" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15195"
+       gradientUnits="userSpaceOnUse"
+       x1="1051.5103"
+       y1="303.85892"
+       x2="1148.3424"
+       y2="303.85892" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15199"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,998.986,217.12585)"
+       x1="211.03732"
+       y1="567.21368"
+       x2="502.98859"
+       y2="755.47064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15201"
+       gradientUnits="userSpaceOnUse"
+       x1="1050.9943"
+       y1="351.74463"
+       x2="1148.2543"
+       y2="351.74463" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15249"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,-0.49906422,1.8412176)"
+       x1="837.08344"
+       y1="316.11407"
+       x2="864.74457"
+       y2="316.98907" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15251"
+       gradientUnits="userSpaceOnUse"
+       x1="846.29999"
+       y1="319.5596"
+       x2="860.89307"
+       y2="319.5596" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,-0.49906422,2.3705552)"
+       x1="904.49695"
+       y1="279.93512"
+       x2="893.70923"
+       y2="340.68512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15256"
+       gradientUnits="userSpaceOnUse"
+       x1="828.73456"
+       y1="318.66046"
+       x2="974.46411"
+       y2="318.66046" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="892.60011"
+       y1="174.09663"
+       x2="902.16768"
+       y2="174.09663" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15262"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="960.82851"
+       y1="96.396319"
+       x2="984.5351"
+       y2="96.396319" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15267"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,200.91429)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="949.18222"
+       y1="72.811045"
+       x2="972.39326"
+       y2="72.811045" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15272"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15274"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="930.78402"
+       y1="51.229487"
+       x2="961.56683"
+       y2="51.229487" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15277"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,199.54286)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="901.95467"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15282"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="885.02086"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15285"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="870.47832"
+       y1="37.851393"
+       x2="876.45823"
+       y2="37.851393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="919.25245"
+       y1="81.701929"
+       x2="922.98304"
+       y2="81.701929" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15291"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="870.73263"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="828.48736"
+       y1="120.72367"
+       x2="836.35859"
+       y2="120.72367" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15297"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98633187,-0.15300317,0.15300317,0.98633187,2.9194419,334.01125)"
+       x1="866.44156"
+       y1="74.656575"
+       x2="876.04205"
+       y2="74.656575" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98633187,-0.15300317,0.15300317,0.98633187,2.9194419,334.01125)"
+       x1="859.85814"
+       y1="69.920009"
+       x2="880.83843"
+       y2="69.920009" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,200.91429)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,200)"
+       x1="822.23922"
+       y1="101.81162"
+       x2="972.98854"
+       y2="101.81162" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,631.83922,199.11026)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15311"
+       gradientUnits="userSpaceOnUse"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15314"
+       gradientUnits="userSpaceOnUse"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15316"
+       gradientUnits="userSpaceOnUse"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,199.99999)"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15321"
+       gradientUnits="userSpaceOnUse"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15324"
+       gradientUnits="userSpaceOnUse"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15326"
+       gradientUnits="userSpaceOnUse"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15329"
+       gradientUnits="userSpaceOnUse"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15332"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,199.99999)"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15334"
+       gradientUnits="userSpaceOnUse"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,199.99999)"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15339"
+       gradientUnits="userSpaceOnUse"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,199.99999)"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15344"
+       gradientUnits="userSpaceOnUse"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,199.99999)"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15349"
+       gradientUnits="userSpaceOnUse"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,199.99999)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15352"
+       gradientUnits="userSpaceOnUse"
+       x1="368.66669"
+       y1="673.33331"
+       x2="460.38913"
+       y2="707.0246" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15354"
+       gradientUnits="userSpaceOnUse"
+       x1="367.99088"
+       y1="673.33331"
+       x2="442.00919"
+       y2="673.33331" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15356"
+       gradientUnits="userSpaceOnUse"
+       x1="331.08029"
+       y1="435"
+       x2="572.87866"
+       y2="529.0235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15358"
+       gradientUnits="userSpaceOnUse"
+       x1="296.55371"
+       y1="435"
+       x2="550.11298"
+       y2="435" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15360"
+       gradientUnits="userSpaceOnUse"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15362"
+       gradientUnits="userSpaceOnUse"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15364"
+       gradientUnits="userSpaceOnUse"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15366"
+       gradientUnits="userSpaceOnUse"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15368"
+       gradientUnits="userSpaceOnUse"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15370"
+       gradientUnits="userSpaceOnUse"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15372"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15374"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15376"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15378"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15380"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15382"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15384"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15386"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15388"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15390"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15393"
+       gradientUnits="userSpaceOnUse"
+       x1="441.38952"
+       y1="59.207708"
+       x2="558.65944"
+       y2="59.207708"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051453)"
+       x1="153.41434"
+       y1="229.06763"
+       x2="712.03802"
+       y2="369.52274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15398"
+       gradientUnits="userSpaceOnUse"
+       x1="428.33821"
+       y1="50.506413"
+       x2="573.18176"
+       y2="50.506413"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15401"
+       gradientUnits="userSpaceOnUse"
+       x1="464.99454"
+       y1="87.334999"
+       x2="483.7212"
+       y2="87.334999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15404"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="152.40469"
+       x2="491.40409"
+       y2="152.40469"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15407"
+       gradientUnits="userSpaceOnUse"
+       x1="501.57386"
+       y1="136.66474"
+       x2="505.39889"
+       y2="136.66474"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15410"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="136.89706"
+       x2="478.65328"
+       y2="136.89706"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15413"
+       gradientUnits="userSpaceOnUse"
+       x1="487.57906"
+       y1="122.17737"
+       x2="491.40409"
+       y2="122.17737"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15416"
+       gradientUnits="userSpaceOnUse"
+       x1="474.82825"
+       y1="107.62534"
+       x2="478.65328"
+       y2="107.62534"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15419"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="100.54747"
+       x2="491.76443"
+       y2="100.54747"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15422"
+       gradientUnits="userSpaceOnUse"
+       x1="464.70573"
+       y1="114.99314"
+       x2="503.29605"
+       y2="114.99314"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15425"
+       gradientUnits="userSpaceOnUse"
+       x1="464.58317"
+       y1="129.88547"
+       x2="507.47516"
+       y2="129.88547"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15428"
+       gradientUnits="userSpaceOnUse"
+       x1="464.89416"
+       y1="144.86723"
+       x2="517.89351"
+       y2="144.86723"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15431"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051453)"
+       x1="218.50157"
+       y1="521.53015"
+       x2="676.30902"
+       y2="660.41461" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15433"
+       gradientUnits="userSpaceOnUse"
+       x1="455.08686"
+       y1="116.35999"
+       x2="543.14518"
+       y2="116.35999"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15436"
+       gradientUnits="userSpaceOnUse"
+       x1="443.51943"
+       y1="175.82125"
+       x2="555.15972"
+       y2="175.82125"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051453)"
+       x1="193.1496"
+       y1="715.4057"
+       x2="742.91541"
+       y2="730.41913" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15441"
+       gradientUnits="userSpaceOnUse"
+       x1="429.07269"
+       y1="173.94605"
+       x2="570.07235"
+       y2="173.94605"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15444"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23890515,0,0,0.23188362,392.26775,-2.7051453)"
+       x1="7.337575"
+       y1="207.66478"
+       x2="689.74506"
+       y2="274.33145" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15446"
+       gradientUnits="userSpaceOnUse"
+       x1="444.03736"
+       y1="57.924455"
+       x2="557.98109"
+       y2="57.924455"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.748596,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15451"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="23.458433"
+       y1="337.85495"
+       x2="87.371216"
+       y2="315.46323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15453"
+       gradientUnits="userSpaceOnUse"
+       x1="205.37198"
+       y1="77.368786"
+       x2="220.00801"
+       y2="77.368786"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="167.87183"
+       y1="174.99733"
+       x2="234.62003"
+       y2="174.99733" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15459"
+       gradientUnits="userSpaceOnUse"
+       x1="238.44265"
+       y1="40.074389"
+       x2="253.72799"
+       y2="40.074389"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15463"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="785.14124"
+       y1="294.75864"
+       x2="840.91125"
+       y2="363.08893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15465"
+       gradientUnits="userSpaceOnUse"
+       x1="372.24073"
+       y1="76.675623"
+       x2="395.53735"
+       y2="76.675623"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15469"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="649.86255"
+       y1="171.18027"
+       x2="711.11725"
+       y2="227.74881" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15471"
+       gradientUnits="userSpaceOnUse"
+       x1="341.53179"
+       y1="45.67738"
+       x2="365.54463"
+       y2="45.67738"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15475"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="406.01202"
+       y1="103.53159"
+       x2="470.8349"
+       y2="132.99438" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15477"
+       gradientUnits="userSpaceOnUse"
+       x1="294.59603"
+       y1="29.106316"
+       x2="310.51999"
+       y2="29.106316"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15480"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="175.43776"
+       y1="454.77576"
+       x2="687.12817"
+       y2="677.83978" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15482"
+       gradientUnits="userSpaceOnUse"
+       x1="254.17529"
+       y1="188.43194"
+       x2="334.08665"
+       y2="188.43194"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15485"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15487"
+       gradientUnits="userSpaceOnUse"
+       x1="282.06701"
+       y1="168.87478"
+       x2="304.46984"
+       y2="168.87478"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="724.24603"
+       y2="618.98932" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15492"
+       gradientUnits="userSpaceOnUse"
+       x1="215.32858"
+       y1="100.44596"
+       x2="374.35234"
+       y2="100.44596"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15495"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="822.49933"
+       y2="675.41992" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15497"
+       gradientUnits="userSpaceOnUse"
+       x1="246.33115"
+       y1="171.3815"
+       x2="342.14333"
+       y2="171.3815"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,0.374298,-1.9125002e-7)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15500"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,-1.9125002e-7)"
+       x1="153.6037"
+       y1="380.53995"
+       x2="761.36395"
+       y2="682.2066" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15507"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="221.55104"
+       y1="774.93707"
+       x2="611.05023"
+       y2="849.56549" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15509"
+       gradientUnits="userSpaceOnUse"
+       x1="61.303072"
+       y1="189.18989"
+       x2="139.93051"
+       y2="189.18989"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="701.01483"
+       y2="740.06274" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15514"
+       gradientUnits="userSpaceOnUse"
+       x1="73.393466"
+       y1="99.576291"
+       x2="128.57319"
+       y2="99.576291"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15517"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="698.83136"
+       y2="740.06268" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15519"
+       gradientUnits="userSpaceOnUse"
+       x1="18.694719"
+       y1="115.58561"
+       x2="183.74067"
+       y2="115.58561"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="197.64774"
+       y1="629.91022"
+       x2="664.98859"
+       y2="790.37555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15524"
+       gradientUnits="userSpaceOnUse"
+       x1="52.179426"
+       y1="171.15182"
+       x2="149.18172"
+       y2="171.15182"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15527"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="129.96214"
+       y1="428.65894"
+       x2="812.36853"
+       y2="836.31329" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15530"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="368.47662"
+       y1="273.33771"
+       x2="494.5513"
+       y2="319.27548" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15532"
+       gradientUnits="userSpaceOnUse"
+       x1="84.38115"
+       y1="72.976797"
+       x2="113.25052"
+       y2="72.976797"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="313.69473"
+       y1="101.18996"
+       x2="536.18018"
+       y2="251.91928" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15537"
+       gradientUnits="userSpaceOnUse"
+       x1="68.517819"
+       y1="40.057539"
+       x2="130.49355"
+       y2="40.057539"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="495.29623"
+       y1="448.54721"
+       x2="595.97144"
+       y2="528.54724" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15542"
+       gradientUnits="userSpaceOnUse"
+       x1="106.05839"
+       y1="111.66723"
+       x2="136.47574"
+       y2="111.66723"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857144,0,-8.7714142e-6)"
+       x1="297.55386"
+       y1="427.04959"
+       x2="368.56238"
+       y2="521.21625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15547"
+       gradientUnits="userSpaceOnUse"
+       x1="64.019555"
+       y1="110.56303"
+       x2="94.436889"
+       y2="110.56303"
+       gradientTransform="matrix(0.99812851,0,0,1.0000063,0,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15551"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,631.83922,-0.88973588)"
+       x1="321.15759"
+       y1="90.161285"
+       x2="395.43152"
+       y2="128.46291" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15553"
+       gradientUnits="userSpaceOnUse"
+       x1="708.30733"
+       y1="24.432458"
+       x2="721.72052"
+       y2="24.432458"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15556"
+       gradientUnits="userSpaceOnUse"
+       x1="729.02667"
+       y1="125.66114"
+       x2="739.4967"
+       y2="133.16115"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15558"
+       gradientUnits="userSpaceOnUse"
+       x1="667.0267"
+       y1="106.16114"
+       x2="759.99669"
+       y2="106.16114"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15561"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,-8.7714142e-6)"
+       x1="155.78476"
+       y1="666.80823"
+       x2="733.56958"
+       y2="841.04077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15563"
+       gradientUnits="userSpaceOnUse"
+       x1="630.42201"
+       y1="177.31452"
+       x2="767.67199"
+       y2="177.31452"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15566"
+       gradientUnits="userSpaceOnUse"
+       x1="667.23889"
+       y1="115.81965"
+       x2="659.72015"
+       y2="118.31965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15568"
+       gradientUnits="userSpaceOnUse"
+       x1="667.2389"
+       y1="105.81965"
+       x2="706.72016"
+       y2="105.81965"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15571"
+       gradientUnits="userSpaceOnUse"
+       x1="692.22753"
+       y1="160.05825"
+       x2="705.01598"
+       y2="160.05825"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15574"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,-8.7714142e-6)"
+       x1="334.55096"
+       y1="110.78522"
+       x2="393.23401"
+       y2="127.35208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15576"
+       gradientUnits="userSpaceOnUse"
+       x1="676.46831"
+       y1="25.322179"
+       x2="689.8815"
+       y2="25.322179"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15579"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,-8.7714142e-6)"
+       x1="192.30013"
+       y1="446.01318"
+       x2="613.59027"
+       y2="649.5235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15581"
+       gradientUnits="userSpaceOnUse"
+       x1="643.26833"
+       y1="95.33782"
+       x2="735.92003"
+       y2="95.33782"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15584"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,-8.7714142e-6)"
+       x1="229.48785"
+       y1="640.76947"
+       x2="615.77783"
+       y2="730.46149" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15586"
+       gradientUnits="userSpaceOnUse"
+       x1="662.91519"
+       y1="158.72688"
+       x2="731.09846"
+       y2="158.72688"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15589"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857144,0,0,0.22857144,600,-8.7714142e-6)"
+       x1="706.30969"
+       y1="193.79158"
+       x2="602.51648"
+       y2="612.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15591"
+       gradientUnits="userSpaceOnUse"
+       x1="697.80657"
+       y1="89.994812"
+       x2="747.74203"
+       y2="89.994812"
+       gradientTransform="matrix(1.0000063,0,0,1.0000063,-0.00378,-8.7714142e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15636"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21114126,0,0,0.210392,1011.288,12.82424)"
+       x1="213.78165"
+       y1="696.46155"
+       x2="414.65732"
+       y2="864.22052" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15638"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1046.1874"
+       y1="366.56808"
+       x2="1098.8392"
+       y2="366.56808" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16437029,1.1302757e-4,-0.00204311,0.16893829,1102.9193,20.4518)"
+       x1="241.75385"
+       y1="401.27609"
+       x2="522.97559"
+       y2="519.06158" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15643"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1159.5165"
+       y1="297.8815"
+       x2="1178.6918"
+       y2="297.8815" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22387292,0.04610674,-0.04610674,0.22387292,1027.3988,35.02322)"
+       x1="456.672"
+       y1="496.70807"
+       x2="790.85327"
+       y2="285.25974" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15648"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1116.9076"
+       y1="346.82153"
+       x2="1171.1093"
+       y2="346.82153" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21114126,0,0,0.210392,1185.1025,12.58006)"
+       x1="409.6666"
+       y1="725.85468"
+       x2="101.73616"
+       y2="844.86835" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1098.4655"
+       y1="366.03885"
+       x2="1149.8408"
+       y2="366.03885" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15656"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17051017,0.01574006,-0.01481026,0.16043794,1043.8798,16.46919)"
+       x1="411.38654"
+       y1="269.9574"
+       x2="606.08582"
+       y2="442.53754" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1073.6456"
+       y1="289.08289"
+       x2="1123.5177"
+       y2="289.08289" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15661"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07483657,-0.03798697,0.02784731,0.06327954,1091.6156,73.77449)"
+       x1="307.02979"
+       y1="442.26321"
+       x2="576.54529"
+       y2="444.9863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15663"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1120.0306"
+       y1="282.81598"
+       x2="1140.408"
+       y2="282.81598" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15666"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20193623,0.01864103,-0.01673386,0.18127612,1018.779,14.60765)"
+       x1="275.24356"
+       y1="458.6561"
+       x2="771.40265"
+       y2="497.96924" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1051.5103"
+       y1="303.85892"
+       x2="1148.3424"
+       y2="303.85892" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15672"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,998.986,17.12585)"
+       x1="211.03732"
+       y1="567.21368"
+       x2="502.98859"
+       y2="755.47064" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-200)"
+       x1="1050.9943"
+       y1="351.74463"
+       x2="1148.2543"
+       y2="351.74463" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15722"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,-0.49906422,-198.15878)"
+       x1="837.08344"
+       y1="316.11407"
+       x2="864.74457"
+       y2="316.98907" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15724"
+       gradientUnits="userSpaceOnUse"
+       x1="846.29999"
+       y1="119.55961"
+       x2="860.89307"
+       y2="119.55961" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,-0.49906422,-197.62944)"
+       x1="904.49695"
+       y1="279.93512"
+       x2="893.70923"
+       y2="340.68512" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15729"
+       gradientUnits="userSpaceOnUse"
+       x1="828.73456"
+       y1="118.66047"
+       x2="974.46411"
+       y2="118.66047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="892.6001"
+       y1="174.09663"
+       x2="902.16766"
+       y2="174.09663" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15735"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.91429)"
+       x1="705.29126"
+       y1="378.28769"
+       x2="787.12555"
+       y2="465.62366" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="960.82849"
+       y1="96.396317"
+       x2="984.5351"
+       y2="96.396317" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,0.91429)"
+       x1="667.0329"
+       y1="299.32745"
+       x2="739.15356"
+       y2="348.42047" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="949.18219"
+       y1="72.811043"
+       x2="972.39325"
+       y2="72.811043" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.91429)"
+       x1="598.67926"
+       y1="209.76059"
+       x2="705.53198"
+       y2="232.28799" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="930.784"
+       y1="51.229488"
+       x2="961.56683"
+       y2="51.229488" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15750"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.91429,-0.45714)"
+       x1="493.79175"
+       y1="157.9061"
+       x2="609.8985"
+       y2="148.71771" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15752"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="901.95465"
+       y1="33.598358"
+       x2="940.58276"
+       y2="33.598358" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="885.02087"
+       y1="30.237432"
+       x2="895.02954"
+       y2="30.237432" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="870.47833"
+       y1="37.851395"
+       x2="876.45825"
+       y2="37.851395" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15761"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="919.25244"
+       y1="81.701927"
+       x2="922.98303"
+       y2="81.701927" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="870.7326"
+       y1="109.9657"
+       x2="876.56927"
+       y2="109.9657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15767"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="828.48737"
+       y1="120.72367"
+       x2="836.35858"
+       y2="120.72367" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98633187,-0.15300317,0.15300317,0.98633187,2.9194419,134.01125)"
+       x1="866.44159"
+       y1="74.656578"
+       x2="876.04205"
+       y2="74.656578" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15773"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98633187,-0.15300317,0.15300317,0.98633187,2.9194419,134.01125)"
+       x1="859.85815"
+       y1="69.920006"
+       x2="880.83844"
+       y2="69.920006" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.91429)"
+       x1="58.222321"
+       y1="511.39841"
+       x2="775.05908"
+       y2="762.62531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99812851,0,0,0.99812851,1.4971928,0)"
+       x1="822.2392"
+       y1="101.81162"
+       x2="972.98853"
+       y2="101.81162" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15781"
+       gradientUnits="userSpaceOnUse"
+       x1="368.66669"
+       y1="673.33331"
+       x2="460.38913"
+       y2="707.0246" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15783"
+       gradientUnits="userSpaceOnUse"
+       x1="367.99088"
+       y1="673.33331"
+       x2="442.00919"
+       y2="673.33331" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15785"
+       gradientUnits="userSpaceOnUse"
+       x1="331.08029"
+       y1="435"
+       x2="572.87866"
+       y2="529.0235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15787"
+       gradientUnits="userSpaceOnUse"
+       x1="296.55371"
+       y1="435"
+       x2="550.11298"
+       y2="435" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15789"
+       gradientUnits="userSpaceOnUse"
+       x1="822.14368"
+       y1="909.1908"
+       x2="844.99213"
+       y2="932.17261" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15791"
+       gradientUnits="userSpaceOnUse"
+       x1="770.83986"
+       y1="915"
+       x2="824.16014"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15793"
+       gradientUnits="userSpaceOnUse"
+       x1="804.05585"
+       y1="930.06891"
+       x2="809.85663"
+       y2="955.65509" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15795"
+       gradientUnits="userSpaceOnUse"
+       x1="770.95651"
+       y1="915"
+       x2="824.04349"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15797"
+       gradientUnits="userSpaceOnUse"
+       x1="797.5"
+       y1="931.98047"
+       x2="797.5"
+       y2="947.82898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15799"
+       gradientUnits="userSpaceOnUse"
+       x1="771.72004"
+       y1="915"
+       x2="823.27996"
+       y2="915" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15801"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="479.95377"
+       y2="569.41608" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15803"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15805"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="473.62973"
+       y2="563.92206" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15807"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15809"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="463.12936"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15811"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15813"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="436.0773"
+       y2="584.75751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15815"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15817"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47086"
+       y1="530.60559"
+       x2="450.13174"
+       y2="571.97302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15819"
+       gradientUnits="userSpaceOnUse"
+       x1="339.47087"
+       y1="530.60559"
+       x2="450.13173"
+       y2="530.60559" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="360.77941"
+     inkscape:cy="213.82747"
+     inkscape:document-units="px"
+     inkscape:current-layer="BlackPieces"
+     showgrid="false"
+     inkscape:window-width="1236"
+     inkscape:window-height="873"
+     inkscape:window-x="518"
+     inkscape:window-y="395"
+     showguides="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Fantasy Alt Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2017-10-29</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:description>Chess piece set &quot;Fantasy Alt&quot; by Maurizio Monge.</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect14709"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssccscsssscc"
+         id="path14711"
+         d="m 920.82051,91.84195 c 0.049,17.48391 -20.16603,32.60628 -40.10424,24.99054 -3.05344,-1.16631 -32.75468,25.95129 -37.19477,22.51417 -3.50284,-2.71159 3.8808,-13.88996 3.34401,-12.46223 -2.55582,6.79794 -13.83928,14.36437 -22.90058,4.59713 -3.54361,-3.81967 -2.216,-16.57043 7.18118,-23.75614 9.73123,-7.44115 16.02018,-25.67101 19.14441,-33.9496 6.28395,-16.65129 3.81839,-17.015 15.8609,-32.11561 2.26233,-2.83684 -3.67739,-13.85043 -1.51858,-21.03944 8.52749,1.52073 11.81478,10.09428 15.7361,13.69223 2.28585,-5.2918 0.74991,-19.51109 4.81348,-18.84851 4.06357,0.66257 8.73775,12.98093 15.4412,18.39137 80.28857,24.70762 79.63225,153.18942 57.19346,153.60568 -27.69634,0.51379 -60.85496,0.39751 -88.70968,-0.0463 -6.74913,-0.10754 -9.87345,-8.83917 -8.57203,-14.05723 6.20686,-24.88641 32.41901,-42.30551 45.25898,-50.93791 13.18793,-8.86633 15.60252,-17.57942 15.02616,-30.57817 z"
+         style="fill:url(#linearGradient15776);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15778);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path14713"
+         d="m 880.21604,65.94855 c -6.75466,-0.19322 -12.21666,2.60708 -16.23762,8.0773"
+         style="fill:none;stroke:url(#linearGradient15773);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path14715"
+         d="m 870.7407,74.75167 c 2.73159,2.03747 5.74913,1.67201 5.61021,-2.48862"
+         style="fill:none;stroke:url(#linearGradient15770);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path14717"
+         d="m 834.46197,118.46619 c -3.1668,-1.09378 -5.45786,4.00845 -3.4373,4.21661"
+         style="fill:none;stroke:url(#linearGradient15767);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path14719"
+         d="m 872.42883,108.41242 2.16857,2.69497"
+         style="fill:none;stroke:url(#linearGradient15764);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path14721"
+         d="m 920.85784,84.39679 0.0665,-5.69552"
+         style="fill:none;stroke:url(#linearGradient15761);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path14723"
+         d="m 874.48657,37.17701 -2.31158,1.20709"
+         style="fill:none;stroke:url(#linearGradient15758);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path14725"
+         d="m 886.69032,24.88539 c 6.89193,9.62746 9.38036,11.57494 1.18547,10.1936"
+         style="fill:none;stroke:url(#linearGradient15755);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssss"
+         id="path14727"
+         d="m 903.87285,29.97164 c 19.78804,5.80204 16.45047,1.61424 20.62382,8.41048 2.33812,3.80761 5.57796,-1.29778 13.29052,-0.81481 4.16519,0.26083 -11.42877,-6.22198 -13.46256,-8.81433 -2.8235,-3.59896 -23.35496,0.36742 -20.45178,1.21866 z"
+         style="fill:url(#linearGradient15750);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15752);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssss"
+         id="path14729"
+         d="m 932.46887,45.65085 c 6.21536,4.72518 10.76795,-0.0742 10.52243,8.12477 -0.16858,5.62961 7.42995,1.8683 11.12002,4.21661 3.39955,2.16343 6.80931,-6.56348 4.64701,-6.56348 -3.25317,0 -8.77717,1.52621 -7.77769,-2.14735 2.19387,-8.06354 -20.29693,-4.9877 -18.51177,-3.63055 z"
+         style="fill:url(#linearGradient15745);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15747);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssss"
+         id="path14731"
+         d="m 950.75005,63.47787 c 1.20981,0.42324 7.79901,4.8845 7.49392,7.00599 -1.57365,10.94237 6.49501,10.23309 9.96743,11.38982 4.86586,1.62091 -0.22674,-4.18829 -2.68195,-7.17506 -2.45521,-2.98676 1.67773,-4.32408 1.38837,-6.21855 -1.01786,-6.66421 -16.79938,-5.22317 -16.16777,-5.0022 z"
+         style="fill:url(#linearGradient15740);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15742);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssss"
+         id="path14733"
+         d="m 962.3748,86.54793 c 1.15613,2.01595 3.867,4.29922 4.72632,7.46168 0.85933,3.16246 1.18283,5.98193 2.90148,9.37864 1.71865,3.39671 8.63367,2.95394 11.61554,1.95703 4.0178,-1.34325 -9.71342,-5.51474 -6.61953,-11.87464 1.9582,-4.02531 -13.24774,-8.01066 -12.62381,-6.92271 z"
+         style="fill:url(#linearGradient15735);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15737);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path14735"
+         d="m 900.1479,166.74312 -5.89252,14.05538"
+         style="fill:none;stroke:url(#linearGradient15732);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         style="fill:url(#linearGradient15727);fill-opacity:1;stroke:url(#linearGradient15729);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 903.76482,127.08285 c 20.46274,0.67006 43.40859,0.40112 64.17841,-6.3017 7.34028,-2.36885 5.14467,5.9227 -0.26791,6.15977 -47.76912,13.0376 -97.24962,4.0943 -111.91307,-4.39714 3.57818,0.49536 5.56646,8.97506 4.38923,11.75551 -1.70649,4.03046 -4.24913,3.19022 -4.91849,-1.66797 -0.69139,-5.01798 -1.36764,-10.83586 -6.06511,-14.22084 -4.76858,-3.43622 -7.75628,-5.37513 -12.20901,-9.63808 -3.88102,-3.71561 -8.36262,-3.44372 -5.4749,-7.95648 4.80102,-2.87446 17.87493,12.31305 22.95111,16.13705 12.30945,5.48275 32.08199,9.5651 49.32974,10.12988 z"
+         id="path14737"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssccssssccs" />
+      <path
+         style="fill:url(#linearGradient15722);fill-opacity:1;stroke:url(#linearGradient15724);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 853.71179,114.59855 c -4.08727,0.0993 -6.86835,2.99333 -4.97811,7.21502 2.02871,4.53093 7.89366,2.58984 9.46969,-0.10336 2.12175,-3.62578 0.20935,-7.22589 -4.49158,-7.11166 z"
+         id="path14739"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssss" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect14451"
+         width="200"
+         height="200"
+         x="1000"
+         y="0" />
+      <path
+         style="fill:url(#linearGradient15672);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15674);stroke-width:3.65714287999999987;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 1099.25 92.75 C 1088.5405 92.75 1079.8438 103.01337 1079.8438 115.6875 C 1079.8438 124.00489 1083.5903 131.28762 1089.1875 135.3125 C 1085.7079 160.58519 1068.9143 153.06495 1060.5625 158.96875 C 1052.7472 164.49335 1048.6613 183.88382 1059.0312 184.5625 C 1065.457 184.98305 1132.1753 185.26378 1138.8125 184.53125 C 1150.5567 183.23515 1147.0791 163.02381 1139.5 158.3125 C 1128.8373 151.68434 1112.5951 161.66299 1108.6875 135.71875 C 1114.6098 131.7909 1118.625 124.29323 1118.625 115.6875 C 1118.625 103.01337 1109.9595 92.75 1099.25 92.75 z "
+         id="path14453" />
+      <path
+         style="fill:url(#linearGradient15666);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15668);stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1081.5541,92.81195 c -22.7723,4.05282 -24.2153,18.60609 -24.2153,18.60609 20.4738,-0.36153 34.7728,7.77429 55.295,4.76036 23.2878,-3.42011 21.0371,-9.19037 29.88,-16.57337 -16.0551,-7.99444 -36.7627,-11.09944 -60.9597,-6.79308 z"
+         id="path14457"
+         sodipodi:nodetypes="scscs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15656);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15658);stroke-width:3.65714264;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1095.162,77.46381 c -17.6378,-0.0934 -18.9427,19.83488 -19.6878,22.48467 14.0396,-0.68991 30.8797,6.35566 45.9319,-1.7902 1.2902,-11.00692 -2.0379,-17.87775 -5.7945,-20.59067 -4.6991,-3.39362 -11.1316,-0.0544 -20.4496,-0.1038 z"
+         id="path14461"
+         sodipodi:nodetypes="cccss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccscc"
+         id="path14463"
+         d="m 1100.2941,153.7531 c 7.2098,8.65556 12.3667,21.23448 13.7071,34.21434 8.836,0.89021 24.641,0.3882 33.422,0.4642 0.8831,-7.88027 2.456,-29.08669 -9.8008,-33.02905 -12.985,-4.17661 -13.9095,-5.85507 -20.8668,-11.82995 -4.5142,4.66077 -12.8619,8.52942 -16.4615,10.18046 z"
+         style="fill:url(#linearGradient15651);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15653);stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15636);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15638);stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1097.0106,153.99726 c -7.2097,8.65556 -13.2809,21.69164 -14.6213,34.6715 -8.836,0.89021 -24.1077,0.0834 -32.8887,0.15944 -3.1688,-5.59455 -1.9135,-28.07259 10.1817,-33.18144 12.367,-5.22362 14.5953,-5.6265 21.9336,-11.60138 3.3713,3.89886 11.7952,8.30085 15.3947,9.95188 z"
+         id="path14469"
+         sodipodi:nodetypes="cccscc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient15781);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15783);stroke-width:17.35164642;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path14471"
+         sodipodi:cx="405.00003"
+         sodipodi:cy="673.33331"
+         sodipodi:rx="28.333334"
+         sodipodi:ry="25.000002"
+         d="m 433.33336,673.33331 a 28.333334,25.000002 0 1 1 -56.66666,0 28.333334,25.000002 0 1 1 56.66666,0 z"
+         transform="matrix(0.21114126,0,0,0.210392,1013.1685,12.2294)" />
+    </g>
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="-8.7714143e-06"
+         x="600"
+         height="200.00002"
+         width="200.00002"
+         id="rect3532"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccsss"
+         id="path9790"
+         d="m 699.63576,49.570115 c 2.47308,-4.17302 8.95019,-11.540435 15.62922,-15.371943 8.28185,7.784208 19.57487,25.913335 25.16109,43.334027 4.3538,13.57739 5.25671,19.678129 5.48338,34.182521 0.22668,14.50438 -7.40135,28.79221 -12.08341,34.07785"
+         style="fill:url(#linearGradient15589);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15591);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccscc"
+         id="path9792"
+         d="m 729.25016,157.04188 c 1.38027,-12.22151 -67.22774,-11.31942 -64.42223,0.6871 2.26677,5.00281 0.47896,11.4366 0.47896,11.4366 0,0 15.83487,-2.24695 33.45899,-1.96695 17.62412,0.28002 29.55199,1.6774 29.55199,1.6774 0,0 -0.44798,-8.23262 0.93229,-11.83415 z"
+         style="fill:url(#linearGradient15584);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15586);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csscscc"
+         id="path9786"
+         d="m 663.87068,155.95066 c -5.20925,-1.84795 -9.00165,-9.24249 -12.28799,-13.95878 -5.24562,-7.52812 -8.33831,-23.18378 -5.26619,-40.73935 3.07213,-17.555567 19.76846,-51.478735 36.86548,-66.52637 20.83702,15.047635 34.27476,37.797126 44.87973,68.11034 5.67522,16.22203 8.49209,33.97462 3.28283,52.58617 -12.15493,-2.50794 -53.31428,-4.88687 -67.47386,0.52799 z"
+         style="fill:url(#linearGradient15579);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15581);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path12426"
+         d="m 680.09809,31.707124 c 2.85251,-4.844739 -4.50992,-7.935602 -0.65876,-11.31926 2.16269,-1.900157 5.86256,-2.090257 7.93989,0.374469 2.99515,3.553696 -5.19882,6.63662 -1.16731,10.897601"
+         style="fill:url(#linearGradient15574);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15576);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssss"
+         id="path13305"
+         d="m 699.74397,162.82256 c -2.17892,-0.58828 -4.13767,0.44725 -4.93659,-0.21476 -0.98036,-0.81235 -0.92296,-4.19213 -0.2739,-5.05008 0.55496,-0.73356 7.68718,-0.82513 8.38705,-0.14934 0.65242,0.62893 -0.0189,4.7234 -0.62337,5.75943"
+         style="fill:none;stroke:url(#linearGradient15571);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path18555"
+         d="m 687.15715,79.671424 c -2.61208,0.414251 -3.91212,3.278245 -3.58511,5.707013 -0.045,2.076336 0.86451,4.751529 -0.84347,6.378701 -2.31052,0.768723 -4.81096,-0.193961 -7.16527,-0.395208 -1.93832,-0.1771 -4.27577,-0.909831 -5.99901,0.338066 -1.31897,1.562455 0.22173,3.923461 1.92143,4.45 3.41781,1.486779 7.47558,0.711268 10.76429,2.471429 1.13526,1.047316 0.9031,2.871425 1.25,4.264285 1.06913,8.29763 1.01265,16.82705 3.52142,24.86429 0.65668,1.76462 1.68241,4.21295 3.87857,4.22857 1.69536,-0.58013 1.48132,-2.83199 1.57143,-4.28571 -0.20534,-9.11358 -2.73457,-17.99682 -3.13571,-27.09286 -0.0451,-0.895481 0.035,-2.019286 1.19286,-2.114289 4.10561,-1.181656 8.90265,0.132752 12.63571,-2.364286 1.53308,-0.830759 2.81271,-3.93038 0.32857,-4.335715 -4.37871,-0.644439 -8.80472,1.242763 -13.15714,0.421429 -1.3474,-0.477036 -1.2294,-2.342197 -1.38572,-3.514286 -0.25509,-2.761218 0.58401,-5.700293 -0.46428,-8.335715 -0.26287,-0.459659 -0.79112,-0.752151 -1.32857,-0.685714 z"
+         style="fill:url(#linearGradient15566);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15568);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssssssss"
+         id="path5000"
+         d="m 672.65542,183.60888 c 12.75959,-0.14292 18.9024,-7.40146 24.55023,-7.41003 5.64784,-0.009 10.8007,7.2328 24.53757,7.25691 7.37046,0.0129 46.17117,0.78733 44.01473,-5.09378 -2.15638,-5.88111 -26.66058,2.01679 -34.86539,-2.16602 -4.29474,-2.18945 -5.55472,-2.70835 -11.11038,-3.55005 -14.98719,-2.27064 -30.31065,-2.18012 -43.86266,-0.0859 -6.03322,0.93234 -8.48726,1.97054 -11.88523,4.25765 -5.71575,3.84714 -29.79279,-4.15201 -31.68783,1.46771 -1.89502,5.61974 24.8043,5.49712 40.30896,5.32346 z"
+         style="fill:url(#linearGradient15561);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15563);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path5875"
+         d="m 745.30001,20.835706 c -4.70532,0.0451 -8.21547,3.906819 -10.16705,7.832047 -1.29109,2.492668 -3.56778,4.307326 -4.83295,6.796526 -0.26622,1.499325 1.87191,1.987869 3,1.664285 2.75386,-0.582731 4.93531,-2.759885 5.86528,-5.376478 1.10356,-2.694302 3.59551,-4.813961 6.54901,-5.009236 2.90063,-0.509955 5.58003,1.770158 6.16428,4.542857 0.84429,2.906627 0.46231,6.332846 -1.87858,8.442858 -3.65372,3.832471 -9.19591,5.547494 -12.27142,9.992857 -16.87919,33.309355 -33.73271,66.640308 -50.38525,100.064468 -5.91165,12.12292 -12.15817,24.10908 -17.33618,36.56412 -0.40285,1.55401 -1.61197,3.27714 -0.96429,4.89285 1.02162,0.79382 2.30836,-0.43381 3.19286,-0.97143 3.64051,-3.32308 5.65874,-8.01742 8.07143,-12.25 10.16578,-19.72331 19.69309,-39.77213 29.58769,-59.63428 10.74342,-21.690553 21.48757,-43.388078 32.46231,-64.958584 3.10474,-4.595265 8.99767,-6.134712 12.47878,-10.379435 2.21678,-2.433147 3.63519,-5.654388 3.27837,-8.991995 -0.22871,-5.553797 -3.44458,-11.564379 -9.19286,-12.885715 -1.17966,-0.298962 -2.40003,-0.390238 -3.62143,-0.335715 z"
+         style="fill:url(#linearGradient15556);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15558);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15551);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15553);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 711.93732,30.817396 c 2.8525,-4.844738 -4.50993,-7.935603 -0.65878,-11.31926 2.16269,-1.900156 5.86257,-2.090256 7.9399,0.37447 2.99515,3.553695 -5.19883,6.636618 -1.16731,10.897599"
+         id="path3155"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         y="-8.7714143e-06"
+         x="0"
+         height="200.00002"
+         width="200"
+         id="rect5257"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="csssc"
+         id="path3299"
+         d="m 65.973661,139.99661 c 5.301121,-7.65948 -1.61168,-28.76318 0.0042,-38.41182 2.622423,-15.658995 23.197554,-26.169234 25.943908,-17.090675 3.257851,10.769371 -9.968434,11.785943 -13.648343,20.775695 -3.380091,8.25732 -2.65696,22.05308 3.923681,30.35652"
+         style="fill:url(#linearGradient15545);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15547);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15540);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15542);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 134.1464,141.10081 c -5.30112,-7.65947 1.61167,-28.76317 -0.004,-38.41181 -2.62245,-15.658977 -23.19758,-26.169229 -25.94393,-17.09068 -3.25785,10.769372 9.96844,11.785944 13.64834,20.77573 3.38009,8.2573 2.65699,22.05307 -3.92368,30.3565"
+         id="path3303"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         id="path24710"
+         d="m 91.706667,65.854911 c 1.201738,-3.428681 4.320983,-16.211443 3.180846,-19.977313 -5.10032,-0.403604 -15.756639,4.27477 -22.663337,2.776012 -1.945257,-3.51675 -3.159817,-11.084184 -0.365554,-15.238216 6.252639,-1.902638 20.052731,1.432798 23.867154,1.9439 1.352229,-3.852085 -3.312983,-15.459995 -2.409234,-19.663205 4.285829,-2.048761 14.929028,-1.846206 18.092208,0.23633 -0.1611,4.414548 -6.60458,15.137098 -6.76098,18.803167 4.29349,-0.220128 17.6671,-3.857177 22.23266,-2.968901 1.96944,3.819529 2.39676,10.643422 -0.78042,15.00476 -4.86738,1.621319 -17.75428,-2.041109 -23.1237,-0.976014 -2.26279,4.563872 1.25507,16.348118 2.12059,19.795516"
+         style="fill:url(#linearGradient15535);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15537);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path3297"
+         d="M 93.350804,84.990183 C 87.697045,80.094571 85.205913,80.053909 86.30333,67.8002 c 0.937143,-10.464289 24.28729,-9.924343 24.83067,-0.45506 0.68136,11.873589 -3.26639,12.76278 -6.01133,18.511809"
+         style="fill:url(#linearGradient15530);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15532);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path25586"
+         d="M 61.93411,189.78267 47.311207,144.92716 155.02166,144.45455 137.90395,191.15732 61.93411,189.78267 z"
+         style="fill:url(#linearGradient15527);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15522);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15524);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 147.07567,163.91069 c -21.41174,-10.9747 -70.203183,-11.49032 -93.167044,0.42869 3.216853,10.16521 4.503609,21.47961 4.503609,21.47961 20.952382,-6.50601 63.513955,-6.76563 84.085385,0.94693 0,0 2.12105,-15.24106 4.57805,-22.85523 z"
+         id="path5264"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccsccscsccssccsc"
+         id="path23833"
+         d="m 126.52143,131.20714 c -8.28366,-3.50016 -17.5324,-13.44604 -27.880719,-13.765 -9.959906,0.23071 -17.955641,8.81458 -23.633568,13.35072 -26.348092,-11.99245 -26.033255,-34.946631 -7.6,-39.157149 3.002269,-0.685779 11.938672,0.10596 17.842857,-0.164287 -1.880069,-5.192135 -3.929534,-8.874 -1.985714,-15.785715 -4.16645,-2.681577 -9.711511,-4.604432 -16.028572,-4.978571 -1.886107,-0.111708 -3.801403,-0.159355 -5.721428,-0.135714 -18.560243,0.228527 -37.817434,6.979632 -40.55,24.057143 -3.988286,24.925303 18.078258,39.614913 26.021429,65.978573 25.213151,-14.37905 83.351925,-13.46346 107.507145,-1.03571 6.41093,-20.37991 31.9659,-44.19671 26.25,-64.971434 -5.29335,-19.238892 -31.02682,-24.868876 -48.00715,-23.907144 -6.88197,0.38978 -13.48859,2.617669 -18.45,5.678571 0.96046,5.479119 -0.98626,9.958726 -2.59999,14.692859 7.85031,0.0034 21.62321,-1.822129 27.02857,1.235714 11.93817,6.753486 12.84843,31.062084 -12.19286,38.907144 z"
+         style="fill:url(#linearGradient15517);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15519);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15512);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15514);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 75.082965,130.86356 c 8.684594,-6.09788 12.799611,-18.20826 12.452319,-27.9851 -0.500777,-14.097396 -8.041005,-16.554654 -3.734857,-28.894655 2.919886,-8.367415 27.237323,-8.79747 29.983703,0.281084 3.25783,10.769363 -5.10677,17.474094 -3.8029,28.376131 1.521,12.71774 1.61532,21.14791 16.52448,28.93081"
+         id="path2408"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path8563"
+         d="m 63.015198,190.32635 c 20.083219,2.39646 52.162572,2.78987 74.826582,0.53929 -15.67932,-6.39544 -58.641204,-6.32588 -74.826582,-0.53929 z"
+         style="fill:url(#linearGradient15507);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15509);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.22084302,0,0,0.22084299,-76.302058,-33.60625)"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path21809"
+         style="fill:url(#linearGradient15797);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15799);stroke-width:16.55992508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.24288439,-0.0439872,0.02951635,0.16298103,-143.5593,57.039743)"
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15793);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15795);stroke-width:18.08697128;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path21811"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z" />
+      <path
+         d="m 815,915 a 17.5,16.666666 0 1 1 -35,0 17.5,16.666666 0 1 1 35,0 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path21815"
+         style="fill:url(#linearGradient15789);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15791);stroke-width:18.32027817;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc"
+         transform="matrix(0.23748182,0.03854011,-0.02653303,0.16349303,-43.120388,-9.2446104)" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="-1.9125002e-07"
+         x="200"
+         height="200"
+         width="200"
+         id="rect5420"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path5422"
+         d="m 255.7566,188.54634 -11.51501,-37.99134 99.14697,0.30124 -11.31854,38.78422 -76.31342,-1.09412 z"
+         style="fill:url(#linearGradient15500);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path5424"
+         d="m 340.04874,163.72108 c -27.93136,-9.98142 -64.77863,-10.03939 -91.97573,-0.0238 2.87639,6.9782 3.63842,21.2567 3.63842,21.2567 23.02155,-6.4396 62.16105,-6.24382 85.00231,0.95725 0,0 0.52796,-15.24721 3.335,-22.19017 z"
+         style="fill:url(#linearGradient15495);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15497);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccc"
+         id="path28221"
+         d="m 244.59516,159.52352 c 27.85155,-12.04272 71.44711,-12.23302 99.56053,0.0937 2.7717,-24.0083 11.50797,-53.64495 28.04178,-74.902734 -12.53664,4.905644 -30.73811,36.311554 -41.32007,42.230354 -8.29808,-17.4316 8.12443,-62.675195 14.50944,-72.258029 -10.71977,6.450011 -33.40524,46.403659 -40.10731,65.093699 -9.66079,-21.587315 -7.39948,-61.961528 -7.63058,-78.881893 -7.26764,15.897915 -16.80412,52.42813 -17.78025,78.243313 -18.55827,-13.91178 -25.1076,-51.490537 -30.05734,-66.378457 -2.72535,21.439477 2.03068,58.782217 5.17107,73.880327 -12.06681,-8.13546 -26.15763,-26.03872 -37.85397,-41.212562 14.8707,35.559682 20.25328,46.329812 27.4667,74.092222 z"
+         style="fill:url(#linearGradient15490);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15492);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscscscs"
+         id="path7672"
+         d="m 293.20307,159.95009 c -4.34242,-0.0223 -1.96238,3.3453 -2.81575,4.82632 -1.95143,1.13118 -8.28466,-0.87581 -6.24601,3.27771 1.4443,2.94263 3.60368,1.5574 6.02905,2.50551 1.20576,1.66093 -0.83269,6.71218 3.43692,6.6062 3.52628,-0.0875 1.60418,-5.12706 2.3579,-6.48491 2.1317,-1.39293 4.92849,0.49481 6.33928,-3.07474 1.07104,-2.70994 -4.23143,-1.70479 -6.32528,-2.87179 -0.87707,-1.31001 1.74188,-4.76063 -2.77611,-4.7843 z"
+         style="fill:url(#linearGradient15485);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15487);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path5428"
+         d="m 255.90247,188.63381 c 20.30223,2.42259 53.19352,3.28242 76.10467,1.00729 -12.92995,-5.77856 -59.40347,-5.7297 -76.10467,-1.00729 z"
+         style="fill:url(#linearGradient15480);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15482);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path1323"
+         d="m 308.48458,18.861369 c -1.95657,0.04289 -7.98708,1.055847 -11.61107,2.863445 -1.09938,2.768007 -0.52829,10.881355 0.0301,17.517505 3.47071,-5.570278 11.13967,-15.143592 11.58093,-20.38095 z"
+         style="fill:url(#linearGradient15475);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15477);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,219.9395,-62.058583)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path29102"
+         style="fill:url(#linearGradient15817);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15819);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient15469);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15471);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 363.40624,47.086749 c -1.0783,-1.292098 -0.39089,-3.657122 -9.14369,-8.469503 l -11.16706,13.949298 c 6.26539,-1.954215 16.17474,-4.905131 20.31075,-5.479795 z"
+         id="path2211"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15813);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15815);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path2203"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,267.48235,-48.344298)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path2213"
+         d="m 393.27089,80.432313 c 0.61126,-3.160512 -2.78183,-4.175618 -6.03682,-8.531246 -4.53406,1.856475 -9.78677,4.070773 -13.48712,9.262115 9.34106,-1.926412 13.58725,0.927561 19.52394,-0.730869 z"
+         style="fill:url(#linearGradient15463);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15465);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,295.50864,-19.599749)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path2205"
+         style="fill:url(#linearGradient15809);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15811);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient15457);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15459);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 251.79887,35.318512 c -2.41372,-2.699971 -5.23276,-2.312505 -11.59959,-3.247765 0.2223,7.708942 4.82388,9.859582 7.56151,15.857287 3.47071,-5.570279 2.9111,-5.772164 4.03808,-12.609522 z"
+         id="path2215"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15805);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15807);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path2207"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,171.71088,-50.172869)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path2217"
+         d="m 211.48865,66.235947 c -3.0736,0.639985 -3.33367,6.928343 -4.29815,10.154396 3.44153,3.793177 6.94093,5.954215 9.94755,11.821691 3.21471,-5.721856 -2.0022,-17.58522 -5.6494,-21.976087 z"
+         style="fill:url(#linearGradient15451);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15453);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,143.06101,-15.753258)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path2209"
+         style="fill:url(#linearGradient15801);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15803);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="-1.9125002e-07"
+         x="400"
+         height="200"
+         width="200"
+         id="rect5557"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         id="path5877"
+         d="m 445.78352,73.909629 c 0,0 0.74294,-26.795976 4.03537,-35.704134 6.87967,-1.485205 20.42276,-2.185836 28.83567,-0.958005 0.0941,5.449697 -1.24165,16.911936 -0.36368,22.15203 7.64469,-0.362183 23.13148,0.566139 32.98671,-0.541993 0.2195,-6.392917 -1.66181,-15.444709 0.2039,-22.571239 6.25561,-0.470065 20.39748,-0.967262 26.98233,1.862388 -0.87797,9.11776 0.12858,21.652599 0.12858,21.652599 l 17.26446,0.597419 -2.57076,13.714369 c -21.55516,8.079339 -94.01815,6.879755 -107.50258,-0.203434 z"
+         style="fill:url(#linearGradient15444);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15446);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path30874"
+         d="m 457.30676,160.56585 c -5.48294,5.47516 -16.9404,10.98428 -25.1102,12.71378 -1.18486,3.91126 -2.35068,8.4338 0.0549,13.29682 29.11926,0.2639 106.00895,-0.0742 133.83217,-0.17069 1.50133,-5.42439 2.63666,-9.34807 1.1353,-13.61155 -8.56656,-1.69588 -18.91267,-4.25676 -26.57123,-12.22767"
+         style="fill:url(#linearGradient15439);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15441);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15436);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 445.26656,175.6852 c 34.16186,0.0166 71.23736,-1.26013 107.77421,0.13268"
+         id="path28104"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path29124"
+         d="m 457.76994,71.056158 c -0.86145,10.251586 -1.10949,81.665672 -0.8726,90.172142 12.61195,-1.06648 71.22563,-1.13348 84.15137,-0.12963 -0.7319,-16.00677 -0.5294,-89.817639 -0.5294,-89.817639"
+         style="fill:url(#linearGradient15431);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15433);stroke-width:3.6571424;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path34378"
+         d="m 466.60128,145.10477 c 9.11731,-0.67214 28.2216,-1.42914 49.24302,-0.75316"
+         style="fill:none;stroke:url(#linearGradient15428);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15425);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.29087,130.31945 c 11.60061,-1.1168 22.82244,-1.48459 39.15458,-1.31463"
+         id="path2302"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15422);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.41321,115.4173 c 16.51853,-1.14223 16.98386,-1.02096 34.86095,-1.27874"
+         id="path2304"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2306"
+         d="m 466.41321,100.8027 c 8.38523,-0.69331 13.31611,-1.053493 23.35091,-0.811573"
+         style="fill:none;stroke:url(#linearGradient15419);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15416);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 476.51678,104.61814 c 0.20091,6.8416 -0.0402,-0.30543 0.16073,5.61156"
+         id="path28065"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2309"
+         d="m 489.24373,119.14294 c 0.20091,6.84159 -0.0402,-0.30544 0.16073,5.61157"
+         style="fill:none;stroke:url(#linearGradient15413);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15410);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 476.51678,133.83509 c 0.20091,6.84158 -0.0402,-0.30544 0.16073,5.61154"
+         id="path2311"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path2313"
+         d="m 503.21234,133.37132 c 0.2009,6.84159 -0.0402,0.15833 0.16073,6.07531"
+         style="fill:none;stroke:url(#linearGradient15407);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15404);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 489.24373,149.08181 c 0.20091,6.84158 -0.0402,0.15832 0.16073,6.0753"
+         id="path2315"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15401);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.70147,87.589543 c 6.36738,-0.693308 9.61192,-0.915861 15.03448,-0.811584"
+         id="path5035"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccc"
+         id="path29999"
+         d="m 430.11375,36.863589 c 1.17855,6.450932 2.0691,12.57112 3.2111,21.837835 7.33191,5.112121 11.43607,6.897506 12.22117,15.464228 22.0234,-3.968271 88.44983,-3.053457 108.42368,-0.08037 1.39189,-7.721737 3.6692,-9.04106 14.42942,-15.52219 1.35941,-10.139883 2.55301,-15.028594 2.62996,-21.091168 -3.22448,-0.784064 -26.3927,-7.722038 -29.25458,-6.725392 -1.01791,6.03259 0.42138,11.21536 -0.91776,16.888691 -8.67267,0.43472 -16.39895,0.104555 -25.37453,-2.231486 0.0446,-7.583552 0.0334,-11.742521 0.40606,-17.611874 -3.79049,-1.349987 -26.3333,-1.589964 -30.58647,-0.197854 -0.73305,7.309339 0.19362,11.291138 -0.39386,17.789961 -7.69911,2.177811 -15.00049,1.612908 -24.19151,2.129139 -0.7405,-7.726821 0.62683,-10.438154 0.45301,-15.861982 -3.79211,-1.036796 -27.47526,4.111421 -31.05569,5.212462 z"
+         style="fill:url(#linearGradient15396);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15398);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path27172"
+         d="m 443.14063,59.942256 c 33.97809,-3.359008 84.23139,-3.567879 113.39331,0.810011"
+         style="fill:none;stroke:url(#linearGradient15393);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7539"
+         width="200.00002"
+         height="200.00002"
+         x="600"
+         y="199.99998" />
+      <path
+         style="fill:url(#linearGradient15347);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15349);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 699.63576,249.57011 c 2.47308,-4.17302 8.95019,-11.54043 15.62922,-15.37194 8.28185,7.78421 19.57487,25.91334 25.16109,43.33403 4.3538,13.57739 5.25671,19.67813 5.48338,34.18251 0.22668,14.50439 -7.40135,28.79222 -12.08341,34.07786"
+         id="path7541"
+         sodipodi:nodetypes="ccsss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15342);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15344);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 729.25016,357.04188 c 1.38027,-12.22151 -67.22774,-11.31942 -64.42223,0.6871 2.26677,5.00281 0.47896,11.4366 0.47896,11.4366 0,0 15.83487,-2.24695 33.45899,-1.96695 17.62412,0.28002 29.55199,1.67739 29.55199,1.67739 0,0 -0.44798,-8.23261 0.93229,-11.83414 z"
+         id="path7543"
+         sodipodi:nodetypes="cccscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15337);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15339);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 663.87068,355.95066 c -5.20925,-1.84795 -9.00165,-9.2425 -12.28799,-13.95879 -5.24562,-7.52811 -8.33831,-23.18377 -5.26619,-40.73934 3.07213,-17.55557 19.76846,-51.47874 36.86548,-66.52637 20.83702,15.04763 34.27476,37.79712 44.87973,68.11034 5.67522,16.22203 8.49209,33.97462 3.28283,52.58617 -12.15493,-2.50794 -53.31428,-4.88687 -67.47386,0.52799 z"
+         id="path7545"
+         sodipodi:nodetypes="csscscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15332);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15334);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 680.09809,231.70712 c 2.85251,-4.84474 -4.50992,-7.9356 -0.65876,-11.31926 2.16269,-1.90015 5.86256,-2.09025 7.93989,0.37447 2.99515,3.5537 -5.19882,6.63662 -1.16731,10.8976"
+         id="path7547"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15329);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 699.74397,362.82256 c -2.17892,-0.58828 -4.13767,0.44725 -4.93659,-0.21477 -0.98036,-0.81234 -0.92296,-4.19212 -0.2739,-5.05007 0.55496,-0.73356 7.68718,-0.82513 8.38705,-0.14934 0.65242,0.62893 -0.0189,4.7234 -0.62337,5.75943"
+         id="path7549"
+         sodipodi:nodetypes="cssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15324);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15326);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 687.15715,279.67142 c -2.61208,0.41425 -3.91212,3.27825 -3.58511,5.70702 -0.045,2.07633 0.86451,4.75152 -0.84347,6.3787 -2.31052,0.76872 -4.81096,-0.19396 -7.16527,-0.39521 -1.93832,-0.1771 -4.27577,-0.90983 -5.99901,0.33806 -1.31897,1.56246 0.22173,3.92347 1.92143,4.45 3.41781,1.48678 7.47558,0.71127 10.76429,2.47143 1.13526,1.04732 0.9031,2.87143 1.25,4.26429 1.06913,8.29763 1.01265,16.82704 3.52142,24.86428 0.65668,1.76463 1.68241,4.21296 3.87857,4.22858 1.69536,-0.58013 1.48132,-2.83199 1.57143,-4.28572 -0.20534,-9.11357 -2.73457,-17.99681 -3.13571,-27.09286 -0.0451,-0.89547 0.035,-2.01928 1.19286,-2.11428 4.10561,-1.18166 8.90265,0.13275 12.63571,-2.36429 1.53308,-0.83076 2.81271,-3.93038 0.32857,-4.33571 -4.37871,-0.64444 -8.80472,1.24276 -13.15714,0.42143 -1.3474,-0.47704 -1.2294,-2.3422 -1.38572,-3.51429 -0.25509,-2.76122 0.58401,-5.70029 -0.46428,-8.33571 -0.26287,-0.45966 -0.79112,-0.75215 -1.32857,-0.68572 z"
+         id="path7551"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15319);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15321);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 672.65542,383.60888 c 12.75959,-0.14292 18.9024,-7.40146 24.55023,-7.41003 5.64784,-0.009 10.8007,7.2328 24.53757,7.25691 7.37046,0.0129 46.17117,0.78733 44.01473,-5.09378 -2.15638,-5.88111 -26.66058,2.01679 -34.86539,-2.16602 -4.29474,-2.18945 -5.55472,-2.70835 -11.11038,-3.55005 -14.98719,-2.27064 -30.31065,-2.18013 -43.86266,-0.0859 -6.03322,0.93234 -8.48726,1.97054 -11.88523,4.25764 -5.71575,3.84715 -29.79279,-4.152 -31.68783,1.46772 -1.89502,5.61974 24.8043,5.49712 40.30896,5.32346 z"
+         id="path7553"
+         sodipodi:nodetypes="csssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15314);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15316);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 745.30001,220.83571 c -4.70532,0.0451 -8.21547,3.90681 -10.16705,7.83204 -1.29109,2.49267 -3.56778,4.30733 -4.83295,6.79653 -0.26622,1.49932 1.87191,1.98787 3,1.66428 2.75386,-0.58273 4.93531,-2.75988 5.86528,-5.37647 1.10356,-2.69431 3.59551,-4.81397 6.54901,-5.00924 2.90063,-0.50996 5.58003,1.77016 6.16428,4.54286 0.84429,2.90662 0.46231,6.33284 -1.87858,8.44285 -3.65372,3.83247 -9.19591,5.5475 -12.27142,9.99286 -16.87919,33.30936 -33.73271,66.64031 -50.38525,100.06447 -5.91165,12.12292 -12.15817,24.10908 -17.33618,36.56411 -0.40285,1.55401 -1.61197,3.27714 -0.96429,4.89285 1.02162,0.79383 2.30836,-0.4338 3.19286,-0.97142 3.64051,-3.32308 5.65874,-8.01742 8.07143,-12.25 10.16578,-19.72331 19.69309,-39.77213 29.58769,-59.63428 10.74342,-21.69055 21.48757,-43.38808 32.46231,-64.95859 3.10474,-4.59526 8.99767,-6.13471 12.47878,-10.37943 2.21678,-2.43315 3.63519,-5.65439 3.27837,-8.992 -0.22871,-5.55379 -3.44458,-11.56437 -9.19286,-12.88571 -1.17966,-0.29896 -2.40003,-0.39024 -3.62143,-0.33571 z"
+         id="path7555"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path7557"
+         d="m 711.93732,230.8174 c 2.8525,-4.84474 -4.50993,-7.93561 -0.65878,-11.31927 2.16269,-1.90015 5.86257,-2.09025 7.9399,0.37448 2.99515,3.55369 -5.19883,6.63661 -1.16731,10.89759"
+         style="fill:url(#linearGradient15309);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15311);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7623"
+         width="200"
+         height="200"
+         x="400"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient15015);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15017);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 445.78352,273.90963 c 0,0 0.74294,-26.79598 4.03537,-35.70414 6.87967,-1.4852 20.42276,-2.18583 28.83567,-0.958 0.0941,5.4497 -1.24165,16.91194 -0.36368,22.15203 7.64469,-0.36218 23.13148,0.56614 32.98671,-0.54199 0.2195,-6.39292 -1.66181,-15.44471 0.2039,-22.57124 6.25561,-0.47007 20.39748,-0.96726 26.98233,1.86239 -0.87797,9.11776 0.12858,21.6526 0.12858,21.6526 l 17.26446,0.59741 -2.57076,13.71437 c -21.55516,8.07934 -94.01815,6.87976 -107.50258,-0.20343 z"
+         id="path7625"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15010);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15012);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 457.30676,360.56585 c -5.48294,5.47516 -16.9404,10.98428 -25.1102,12.71378 -1.18486,3.91126 -2.35068,8.4338 0.0549,13.29682 29.11926,0.2639 106.00895,-0.0742 133.83217,-0.17069 1.50133,-5.42439 2.63666,-9.34807 1.1353,-13.61155 -8.56656,-1.69588 -18.91267,-4.25676 -26.57123,-12.22767"
+         id="path7627"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path7629"
+         d="m 445.26656,375.6852 c 34.16186,0.0166 71.23736,-1.26013 107.77421,0.13268"
+         style="fill:none;stroke:url(#linearGradient15007);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15002);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15004);stroke-width:3.6571424;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 457.76994,271.05616 c -0.86145,10.25158 -1.10949,81.66567 -0.8726,90.17214 12.61195,-1.06648 71.22563,-1.13348 84.15137,-0.12963 -0.7319,-16.00677 -0.5294,-89.81764 -0.5294,-89.81764"
+         id="path7631"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient14999);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.60128,345.10477 c 9.11731,-0.67214 28.2216,-1.42914 49.24302,-0.75316"
+         id="path7633"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7635"
+         d="m 466.29087,330.31945 c 11.60061,-1.11679 22.82244,-1.48459 39.15458,-1.31463"
+         style="fill:none;stroke:url(#linearGradient14996);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7637"
+         d="m 466.41321,315.4173 c 16.51853,-1.14223 16.98386,-1.02096 34.86095,-1.27874"
+         style="fill:none;stroke:url(#linearGradient14993);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient14990);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 466.41321,300.80271 c 8.38523,-0.69332 13.31611,-1.0535 23.35091,-0.81158"
+         id="path7639"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7641"
+         d="m 476.51678,304.61814 c 0.20091,6.8416 -0.0402,-0.30543 0.16073,5.61156"
+         style="fill:none;stroke:url(#linearGradient14987);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient14984);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 489.24373,319.14294 c 0.20091,6.84159 -0.0402,-0.30544 0.16073,5.61157"
+         id="path7643"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7645"
+         d="m 476.51678,333.83509 c 0.20091,6.84158 -0.0402,-0.30544 0.16073,5.61154"
+         style="fill:none;stroke:url(#linearGradient14981);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient14978);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 503.21234,333.37132 c 0.2009,6.84159 -0.0402,0.15833 0.16073,6.07531"
+         id="path7647"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7649"
+         d="m 489.24373,349.08181 c 0.20091,6.84158 -0.0402,0.15832 0.16073,6.0753"
+         style="fill:none;stroke:url(#linearGradient14975);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cs"
+         id="path7651"
+         d="m 466.70147,287.58954 c 6.36738,-0.6933 9.61192,-0.91586 15.03448,-0.81158"
+         style="fill:none;stroke:url(#linearGradient14972);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient14967);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient14969);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 430.11375,236.86359 c 1.17855,6.45093 2.0691,12.57112 3.2111,21.83783 7.33191,5.11213 11.43607,6.89751 12.22117,15.46423 22.0234,-3.96827 88.44983,-3.05346 108.42368,-0.0804 1.39189,-7.72173 3.6692,-9.04106 14.42942,-15.52219 1.35941,-10.13988 2.55301,-15.02859 2.62996,-21.09116 -3.22448,-0.78407 -26.3927,-7.72204 -29.25458,-6.7254 -1.01791,6.03259 0.42138,11.21536 -0.91776,16.88869 -8.67267,0.43472 -16.39895,0.10456 -25.37453,-2.23148 0.0446,-7.58355 0.0334,-11.74252 0.40606,-17.61188 -3.79049,-1.34998 -26.3333,-1.58996 -30.58647,-0.19785 -0.73305,7.30934 0.19362,11.29114 -0.39386,17.78996 -7.69911,2.17781 -15.00049,1.61291 -24.19151,2.12914 -0.7405,-7.72682 0.62683,-10.43815 0.45301,-15.86198 -3.79211,-1.0368 -27.47526,4.11142 -31.05569,5.21246 z"
+         id="path7653"
+         sodipodi:nodetypes="ccccccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient14964);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 443.14063,259.94226 c 33.97809,-3.35901 84.23139,-3.56788 113.39331,0.81001"
+         id="path7655"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7589"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient15071);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 255.7566,388.54634 -11.51501,-37.99134 99.14697,0.30124 -11.31854,38.78422 -76.31342,-1.09412 z"
+         id="path7591"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15066);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15068);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 340.04874,363.72108 c -27.93136,-9.98142 -64.77863,-10.03939 -91.97573,-0.0237 2.87639,6.9782 3.63842,21.2567 3.63842,21.2567 23.02155,-6.4396 62.16105,-6.24382 85.00231,0.95725 0,0 0.52796,-15.2472 3.335,-22.19017 z"
+         id="path7593"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15061);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15063);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 244.59516,359.52352 c 27.85155,-12.04272 71.44711,-12.23302 99.56053,0.0937 2.7717,-24.0083 11.50797,-53.64495 28.04178,-74.90273 -12.53664,4.90564 -30.73811,36.31155 -41.32007,42.23035 -8.29808,-17.4316 8.12443,-62.67519 14.50944,-72.25803 -10.71977,6.45001 -33.40524,46.40366 -40.10731,65.0937 -9.66079,-21.58732 -7.39948,-61.96153 -7.63058,-78.88189 -7.26764,15.89791 -16.80412,52.42813 -17.78025,78.24331 -18.55827,-13.91178 -25.1076,-51.49054 -30.05734,-66.37846 -2.72535,21.43948 2.03068,58.78222 5.17107,73.88033 -12.06681,-8.13546 -26.15763,-26.03872 -37.85397,-41.21256 14.8707,35.55968 20.25328,46.32981 27.4667,74.09222 z"
+         id="path7595"
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15056);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15058);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 293.20307,359.95009 c -4.34242,-0.0224 -1.96238,3.3453 -2.81575,4.82632 -1.95143,1.13118 -8.28466,-0.87581 -6.24601,3.27771 1.4443,2.94263 3.60368,1.5574 6.02905,2.50551 1.20576,1.66093 -0.83269,6.71218 3.43692,6.6062 3.52628,-0.0875 1.60418,-5.12706 2.3579,-6.48491 2.1317,-1.39292 4.92849,0.49481 6.33928,-3.07474 1.07104,-2.70994 -4.23143,-1.70478 -6.32528,-2.87179 -0.87707,-1.31001 1.74188,-4.76063 -2.77611,-4.7843 z"
+         id="path7597"
+         sodipodi:nodetypes="ccscscscs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15051);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15053);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 255.90247,388.63381 c 20.30223,2.42259 53.19352,3.28242 76.10467,1.00729 -12.92995,-5.77856 -59.40347,-5.7297 -76.10467,-1.00729 z"
+         id="path7599"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15046);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15048);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 308.48458,218.86137 c -1.95657,0.0429 -7.98708,1.05585 -11.61107,2.86344 -1.09938,2.76801 -0.52829,10.88136 0.0301,17.51751 3.47071,-5.57028 11.13967,-15.14359 11.58093,-20.38095 z"
+         id="path7601"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15388);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15390);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7603"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,219.9395,137.94142)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path7605"
+         d="m 363.40624,247.08675 c -1.0783,-1.2921 -0.39089,-3.65712 -9.14369,-8.4695 l -11.16706,13.94929 c 6.26539,-1.95421 16.17474,-4.90513 20.31075,-5.47979 z"
+         style="fill:url(#linearGradient15040);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15042);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,267.48235,151.6557)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path7607"
+         style="fill:url(#linearGradient15384);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15386);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient15034);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15036);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 393.27089,280.43231 c 0.61126,-3.16051 -2.78183,-4.17562 -6.03682,-8.53124 -4.53406,1.85647 -9.78677,4.07077 -13.48712,9.26211 9.34106,-1.92641 13.58725,0.92756 19.52394,-0.73087 z"
+         id="path7609"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15380);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15382);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7611"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,295.50864,180.40025)" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path7613"
+         d="m 251.79887,235.31851 c -2.41372,-2.69997 -5.23276,-2.3125 -11.59959,-3.24776 0.2223,7.70894 4.82388,9.85958 7.56151,15.85728 3.47071,-5.57027 2.9111,-5.77216 4.03808,-12.60952 z"
+         style="fill:url(#linearGradient15028);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15030);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         transform="matrix(0.19518313,0,0,0.19518313,171.71088,149.82713)"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         sodipodi:ry="44.783428"
+         sodipodi:rx="45.961941"
+         sodipodi:cy="530.60559"
+         sodipodi:cx="394.8013"
+         id="path7615"
+         style="fill:url(#linearGradient15376);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15378);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         style="fill:url(#linearGradient15022);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15024);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 211.48865,266.23595 c -3.0736,0.63998 -3.33367,6.92834 -4.29815,10.15439 3.44153,3.79318 6.94093,5.95422 9.94755,11.82169 3.21471,-5.72185 -2.0022,-17.58522 -5.6494,-21.97608 z"
+         id="path7617"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15372);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15374);stroke-width:18.73698616;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7619"
+         sodipodi:cx="394.8013"
+         sodipodi:cy="530.60559"
+         sodipodi:rx="45.961941"
+         sodipodi:ry="44.783428"
+         d="m 440.76324,530.60559 a 45.961941,44.783428 0 1 1 -91.92388,0 45.961941,44.783428 0 1 1 91.92388,0 z"
+         transform="matrix(0.19518313,0,0,0.19518313,143.06101,184.24674)" />
+    </g>
+    <g
+       id="K"
+       transform="translate(-0.70710676,-1.4142135)"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7561"
+         width="200"
+         height="200.00002"
+         x="0"
+         y="199.99998" />
+      <path
+         style="fill:url(#linearGradient15116);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15118);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 65.973661,339.99661 c 5.301121,-7.65948 -1.61168,-28.76318 0.0042,-38.41182 2.622423,-15.659 23.197554,-26.16923 25.943908,-17.09068 3.257851,10.76938 -9.968434,11.78595 -13.648343,20.7757 -3.380091,8.25732 -2.65696,22.05308 3.923681,30.35651"
+         id="path7563"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csssc"
+         id="path7565"
+         d="m 134.1464,341.10081 c -5.30112,-7.65947 1.61167,-28.76317 -0.004,-38.41181 -2.62245,-15.65898 -23.19758,-26.16923 -25.94393,-17.09068 -3.25785,10.76937 9.96844,11.78594 13.64834,20.77573 3.38009,8.2573 2.65699,22.05307 -3.92368,30.3565"
+         style="fill:url(#linearGradient15111);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15113);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15106);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15108);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 91.706667,265.85491 c 1.201738,-3.42868 4.320983,-16.21144 3.180846,-19.97731 -5.10032,-0.40361 -15.756639,4.27477 -22.663337,2.77601 -1.945257,-3.51675 -3.159817,-11.08419 -0.365554,-15.23822 6.252639,-1.90264 20.052731,1.4328 23.867154,1.9439 1.352229,-3.85208 -3.312983,-15.45999 -2.409234,-19.6632 4.285829,-2.04876 14.929028,-1.84621 18.092208,0.23633 -0.1611,4.41455 -6.60458,15.1371 -6.76098,18.80316 4.29349,-0.22012 17.6671,-3.85717 22.23266,-2.9689 1.96944,3.81953 2.39676,10.64343 -0.78042,15.00476 -4.86738,1.62132 -17.75428,-2.04111 -23.1237,-0.97601 -2.26279,4.56387 1.25507,16.34812 2.12059,19.79552"
+         id="path7567"
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15101);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15103);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 93.350804,284.99018 c -5.653759,-4.89561 -8.144891,-4.93627 -7.047474,-17.18998 0.937143,-10.46429 24.28729,-9.92434 24.83067,-0.45506 0.68136,11.87359 -3.26639,12.76278 -6.01133,18.51181"
+         id="path7569"
+         sodipodi:nodetypes="csss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15098);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="M 61.93411,389.78267 47.311207,344.92716 155.02166,344.45455 137.90395,391.15731 61.93411,389.78267 z"
+         id="path7571"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path7573"
+         d="m 147.07567,363.91069 c -21.41174,-10.9747 -70.203183,-11.49032 -93.167044,0.42869 3.216853,10.16521 4.503609,21.47961 4.503609,21.47961 20.952382,-6.50601 63.513955,-6.76563 84.085385,0.94693 0,0 2.12105,-15.24106 4.57805,-22.85523 z"
+         style="fill:url(#linearGradient15093);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15095);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15088);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15090);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 126.52143,331.20714 c -8.28366,-3.50017 -17.5324,-13.44604 -27.880719,-13.765 -9.959906,0.23071 -17.955641,8.81458 -23.633568,13.35071 -26.348092,-11.99244 -26.033255,-34.94662 -7.6,-39.15714 3.002269,-0.68578 11.938672,0.10596 17.842857,-0.16429 -1.880069,-5.19213 -3.929534,-8.874 -1.985714,-15.78571 -4.16645,-2.68158 -9.711511,-4.60443 -16.028572,-4.97857 -1.886107,-0.11171 -3.801403,-0.15936 -5.721428,-0.13572 -18.560243,0.22853 -37.817434,6.97963 -40.55,24.05715 -3.988286,24.9253 18.078258,39.61491 26.021429,65.97857 25.213151,-14.37905 83.351925,-13.46346 107.507145,-1.03571 6.41093,-20.37991 31.9659,-44.19671 26.25,-64.97144 -5.29335,-19.23889 -31.02682,-24.86887 -48.00715,-23.90714 -6.88197,0.38978 -13.48859,2.61767 -18.45,5.67857 0.96046,5.47912 -0.98626,9.95873 -2.59999,14.69286 7.85031,0.003 21.62321,-1.82213 27.02857,1.23571 11.93817,6.75349 12.84843,31.06209 -12.19286,38.90715 z"
+         id="path7575"
+         sodipodi:nodetypes="cccsccscsccssccsc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssc"
+         id="path7577"
+         d="m 75.082965,330.86355 c 8.684594,-6.09787 12.799611,-18.20825 12.452319,-27.98509 -0.500777,-14.0974 -8.041005,-16.55466 -3.734857,-28.89466 2.919886,-8.36741 27.237323,-8.79747 29.983703,0.28109 3.25783,10.76936 -5.10677,17.47409 -3.8029,28.37613 1.521,12.71774 1.61532,21.14791 16.52448,28.93081"
+         style="fill:url(#linearGradient15083);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15085);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15078);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15080);stroke-width:3.65714312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 63.015198,390.32635 c 20.083219,2.39645 52.162572,2.78987 74.826582,0.53929 -15.67932,-6.39544 -58.641204,-6.32588 -74.826582,-0.53929 z"
+         id="path7579"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15368);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15370);stroke-width:16.55992508;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7581"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 c 0,9.20475 -7.83502,16.66667 -17.5,16.66667 -9.66498,0 -17.5,-7.46192 -17.5,-16.66667 0,-9.20475 7.83502,-16.66667 17.5,-16.66667 9.66498,0 17.5,7.46192 17.5,16.66667 z"
+         transform="matrix(0.22084302,0,0,0.22084299,-76.302058,166.39375)" />
+      <path
+         d="m 815,915 c 0,9.20475 -7.83502,16.66667 -17.5,16.66667 -9.66498,0 -17.5,-7.46192 -17.5,-16.66667 0,-9.20475 7.83502,-16.66667 17.5,-16.66667 9.66498,0 17.5,7.46192 17.5,16.66667 z"
+         sodipodi:ry="16.666666"
+         sodipodi:rx="17.5"
+         sodipodi:cy="915"
+         sodipodi:cx="797.5"
+         id="path7583"
+         style="fill:url(#linearGradient15364);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15366);stroke-width:18.08697128;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc"
+         transform="matrix(0.24288439,-0.0439872,0.02951635,0.16298103,-143.5593,257.03974)" />
+      <path
+         transform="matrix(0.23748182,0.03854011,-0.02653303,0.16349303,-43.120388,190.75539)"
+         sodipodi:type="arc"
+         style="fill:url(#linearGradient15360);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15362);stroke-width:18.32027817;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path7585"
+         sodipodi:cx="797.5"
+         sodipodi:cy="915"
+         sodipodi:rx="17.5"
+         sodipodi:ry="16.666666"
+         d="m 815,915 c 0,9.20475 -7.83502,16.66667 -17.5,16.66667 -9.66498,0 -17.5,-7.46192 -17.5,-16.66667 0,-9.20475 7.83502,-16.66667 17.5,-16.66667 9.66498,0 17.5,7.46192 17.5,16.66667 z" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         y="200"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect13193"
+         style="fill:none;stroke:none" />
+      <path
+         style="fill:url(#linearGradient15199);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15201);stroke-width:3.65714287999999987;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 1099.25 292.75 C 1088.5405 292.75 1079.8438 303.01337 1079.8438 315.6875 C 1079.8438 324.00489 1083.5903 331.28762 1089.1875 335.3125 C 1085.7079 360.58519 1068.9143 353.06495 1060.5625 358.96875 C 1052.7472 364.49335 1048.6613 383.88382 1059.0312 384.5625 C 1065.457 384.98305 1132.1753 385.26378 1138.8125 384.53125 C 1150.5567 383.23515 1147.0791 363.02381 1139.5 358.3125 C 1128.8373 351.68434 1112.5951 361.66299 1108.6875 335.71875 C 1114.6098 331.7909 1118.625 324.29323 1118.625 315.6875 C 1118.625 303.01337 1109.9595 292.75 1099.25 292.75 z "
+         id="path35274-3" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scscs"
+         id="path34396-9"
+         d="m 1081.5541,292.81195 c -22.7723,4.05282 -24.2153,18.60609 -24.2153,18.60609 20.4738,-0.36153 34.7728,7.77429 55.295,4.76036 23.2878,-3.42011 21.0371,-9.19037 29.88,-16.57337 -16.0551,-7.99444 -36.7627,-11.09944 -60.9597,-6.79308 z"
+         style="fill:url(#linearGradient15193);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15195);stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccss"
+         id="path3363"
+         d="m 1095.162,277.46381 c -17.6378,-0.0934 -18.9427,19.83488 -19.6878,22.48467 14.0396,-0.68991 30.8797,6.35566 45.9319,-1.7902 1.2902,-11.00692 -2.0379,-17.87775 -5.7945,-20.59067 -4.6991,-3.39362 -11.1316,-0.0544 -20.4496,-0.1038 z"
+         style="fill:url(#linearGradient15183);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15185);stroke-width:3.65714264;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient15178);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15180);stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1100.2941,353.7531 c 7.2098,8.65556 12.3667,21.23448 13.7071,34.21434 8.836,0.89021 24.641,0.3882 33.422,0.4642 0.8831,-7.88027 2.456,-29.08669 -9.8008,-33.02905 -12.985,-4.17661 -13.9095,-5.85507 -20.8668,-11.82995 -4.5142,4.66077 -12.8619,8.52942 -16.4615,10.18046 z"
+         id="path4628"
+         sodipodi:nodetypes="cccscc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscc"
+         id="path4642"
+         d="m 1097.0106,353.99726 c -7.2097,8.65556 -13.2809,21.69164 -14.6213,34.6715 -8.836,0.89021 -24.1077,0.0834 -32.8887,0.15944 -3.1688,-5.59455 -1.9135,-28.07259 10.1817,-33.18144 12.367,-5.22362 14.5953,-5.6265 21.9336,-11.60138 3.3713,3.89886 11.7952,8.30085 15.3947,9.95188 z"
+         style="fill:url(#linearGradient15163);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15165);stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.21114126,0,0,0.210392,1013.1685,212.2294)"
+         d="m 433.33336,673.33331 a 28.333334,25.000002 0 1 1 -56.66666,0 28.333334,25.000002 0 1 1 56.66666,0 z"
+         sodipodi:ry="25.000002"
+         sodipodi:rx="28.333334"
+         sodipodi:cy="673.33331"
+         sodipodi:cx="405.00003"
+         id="path4632"
+         style="opacity:0.98999999;fill:url(#linearGradient15352);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15354);stroke-width:17.35164642;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7659"
+         width="200"
+         height="200"
+         x="800"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient15303);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15305);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 920.82051,291.84195 c 0.049,17.48391 -20.16603,32.60628 -40.10424,24.99054 -3.05344,-1.16631 -32.75468,25.95129 -37.19477,22.51417 -3.50284,-2.71159 3.8808,-13.88996 3.34401,-12.46223 -2.55582,6.79794 -13.83928,14.36437 -22.90058,4.59713 -3.54361,-3.81967 -2.216,-16.57043 7.18118,-23.75614 9.73123,-7.44115 16.02018,-25.67101 19.14441,-33.9496 6.28395,-16.65129 3.81839,-17.015 15.8609,-32.11561 2.26233,-2.83684 -3.67739,-13.85043 -1.51858,-21.03944 8.52749,1.52073 11.81478,10.09428 15.7361,13.69223 2.28585,-5.2918 0.74991,-19.51109 4.81348,-18.84851 4.06357,0.66257 8.73775,12.98093 15.4412,18.39137 80.28857,24.70762 79.63225,153.18942 57.19346,153.60568 -27.69634,0.51379 -60.85496,0.39751 -88.70968,-0.0463 -6.74913,-0.10754 -9.87345,-8.83917 -8.57203,-14.05723 6.20686,-24.88641 32.41901,-42.30551 45.25898,-50.93791 13.18793,-8.86633 15.60252,-17.57942 15.02616,-30.57817 z"
+         id="path7661"
+         sodipodi:nodetypes="csssssssccscsssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15300);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 880.21604,265.94855 c -6.75466,-0.19322 -12.21666,2.60708 -16.23762,8.0773"
+         id="path7663"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15297);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 870.7407,274.75167 c 2.73159,2.03747 5.74913,1.67201 5.61021,-2.48862"
+         id="path7665"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15294);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 834.46197,318.46619 c -3.1668,-1.09378 -5.45786,4.00845 -3.4373,4.21661"
+         id="path7667"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15291);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 872.42883,308.41242 2.16857,2.69497"
+         id="path7669"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15288);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 920.85784,284.39679 0.0665,-5.69552"
+         id="path7671"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15285);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 874.48657,237.17701 -2.31158,1.20709"
+         id="path7673"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15282);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 886.69032,224.88539 c 6.89193,9.62746 9.38036,11.57494 1.18547,10.1936"
+         id="path7675"
+         sodipodi:nodetypes="cs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15277);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15279);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 903.87285,229.97164 c 19.78804,5.80204 16.45047,1.61424 20.62382,8.41048 2.33812,3.80761 5.57796,-1.29778 13.29052,-0.81481 4.16519,0.26083 -11.42877,-6.22198 -13.46256,-8.81433 -2.8235,-3.59896 -23.35496,0.36742 -20.45178,1.21866 z"
+         id="path7677"
+         sodipodi:nodetypes="cssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15272);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15274);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 932.46887,245.65085 c 6.21536,4.72518 10.76795,-0.0742 10.52243,8.12477 -0.16858,5.62961 7.42995,1.8683 11.12002,4.21661 3.39955,2.16343 6.80931,-6.56348 4.64701,-6.56348 -3.25317,0 -8.77717,1.52621 -7.77769,-2.14735 2.19387,-8.06354 -20.29693,-4.9877 -18.51177,-3.63055 z"
+         id="path7679"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15267);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15269);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 950.75005,263.47787 c 1.20981,0.42324 7.79901,4.8845 7.49392,7.00599 -1.57365,10.94237 6.49501,10.23309 9.96743,11.38982 4.86586,1.62091 -0.22674,-4.18829 -2.68195,-7.17506 -2.45521,-2.98676 1.67773,-4.32408 1.38837,-6.21855 -1.01786,-6.66421 -16.79938,-5.22317 -16.16777,-5.0022 z"
+         id="path7681"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15262);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15264);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 962.3748,286.54793 c 1.15613,2.01595 3.867,4.29922 4.72632,7.46168 0.85933,3.16246 1.18283,5.98193 2.90148,9.37864 1.71865,3.39671 8.63367,2.95394 11.61554,1.95703 4.0178,-1.34325 -9.71342,-5.51474 -6.61953,-11.87464 1.9582,-4.02531 -13.24774,-8.01066 -12.62381,-6.92271 z"
+         id="path7683"
+         sodipodi:nodetypes="csssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15259);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 900.1479,366.74312 -5.89252,14.05538"
+         id="path7685"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ssccssssccs"
+         inkscape:connector-curvature="0"
+         id="path14541"
+         d="m 903.76482,327.08285 c 20.46274,0.67006 43.40859,0.40112 64.17841,-6.3017 7.34028,-2.36885 5.14467,5.9227 -0.26791,6.15977 -47.76912,13.0376 -97.24962,4.0943 -111.91307,-4.39714 3.57818,0.49536 5.56646,8.97506 4.38923,11.75551 -1.70649,4.03046 -4.24913,3.19022 -4.91849,-1.66797 -0.69139,-5.01798 -1.36764,-10.83586 -6.06511,-14.22084 -4.76858,-3.43622 -7.75628,-5.37513 -12.20901,-9.63808 -3.88102,-3.71561 -8.36262,-3.44372 -5.4749,-7.95648 4.80102,-2.87446 17.87493,12.31305 22.95111,16.13705 12.30945,5.48275 32.08199,9.5651 49.32974,10.12988 z"
+         style="fill:url(#linearGradient15254);fill-opacity:1;stroke:url(#linearGradient15256);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path14543"
+         d="m 853.71179,314.59855 c -4.08727,0.0993 -6.86835,2.99333 -4.97811,7.21502 2.02871,4.53093 7.89366,2.58984 9.46969,-0.10336 2.12175,-3.62578 0.20935,-7.22589 -4.49158,-7.11166 z"
+         style="fill:url(#linearGradient15249);fill-opacity:1;stroke:url(#linearGradient15251);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/freak.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/freak.svg
@@ -1,0 +1,3522 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="freak.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title12605">Freak Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2816"
+       id="linearGradient2822"
+       x1="708.40527"
+       y1="708.24023"
+       x2="726.89935"
+       y2="767.16583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,11.74344,200.38093)" />
+    <linearGradient
+       id="linearGradient2816">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0"
+         id="stop2818" />
+      <stop
+         style="stop-color:#ff7000;stop-opacity:1;"
+         offset="1"
+         id="stop2820" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804"
+       id="linearGradient2810"
+       x1="508.33115"
+       y1="392.78183"
+       x2="477.68985"
+       y2="467.27161"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,0.68005975,199.99998)" />
+    <linearGradient
+       id="linearGradient2804">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2806" />
+      <stop
+         style="stop-color:#ff0000;stop-opacity:0;"
+         offset="1"
+         id="stop2808" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804"
+       id="linearGradient2812"
+       x1="354.75922"
+       y1="397.64706"
+       x2="386.78885"
+       y2="451.85861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,0.68005975,199.99998)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2266"
+       id="linearGradient2695"
+       x1="313.33334"
+       y1="558.33331"
+       x2="726.66669"
+       y2="558.33331"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient2266">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2268-0" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop2270-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508"
+       id="linearGradient2895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.23514766,0,0,0.23515269,410.38926,197.28955)"
+       x1="247.19395"
+       y1="571.16028"
+       x2="408.68234"
+       y2="606.51562" />
+    <linearGradient
+       id="linearGradient2508">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2510" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop2512" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508"
+       id="linearGradient2891"
+       x1="247.19395"
+       y1="571.16028"
+       x2="408.68234"
+       y2="606.51562"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,195.4562,195.62677)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2930"
+       id="linearGradient2936"
+       x1="410.92975"
+       y1="131.56165"
+       x2="899.82593"
+       y2="1051.2655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,197.11895,194.51824)" />
+    <linearGradient
+       id="linearGradient2930">
+      <stop
+         style="stop-color:#ff80ff;stop-opacity:1;"
+         offset="0"
+         id="stop2932" />
+      <stop
+         style="stop-color:#8080ff;stop-opacity:1;"
+         offset="1"
+         id="stop2934" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508"
+       id="linearGradient2382"
+       x1="252"
+       y1="523.33331"
+       x2="751.33331"
+       y2="686.66663"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29064823,0,0,0.29032343,184.62491,155.61232)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2930"
+       id="linearGradient2944"
+       x1="396.74344"
+       y1="487.85074"
+       x2="465.33133"
+       y2="867.33136"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,197.11895,194.51824)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3392"
+       id="linearGradient3398"
+       x1="458.6149"
+       y1="105.43819"
+       x2="464.21469"
+       y2="248.97305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)" />
+    <linearGradient
+       id="linearGradient3392">
+      <stop
+         style="stop-color:#ff4040;stop-opacity:1;"
+         offset="0"
+         id="stop3394" />
+      <stop
+         style="stop-color:#4040ff;stop-opacity:1;"
+         offset="1"
+         id="stop3396" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3390"
+       x1="385.03464"
+       y1="184.11929"
+       x2="499.04916"
+       y2="184.11929"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)" />
+    <linearGradient
+       id="linearGradient3037">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3039" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop3041" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3388"
+       x1="259.42661"
+       y1="345.1275"
+       x2="642.65881"
+       y2="345.1275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3331"
+       gradientUnits="userSpaceOnUse"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3323"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3404"
+       id="linearGradient3298"
+       x1="303.73691"
+       y1="691.15222"
+       x2="679.99005"
+       y2="788.88568"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3404">
+      <stop
+         id="stop3406"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3408"
+         offset="1"
+         style="stop-color:#80ff00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3321"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17692252,0,0,0.18069943,430.13607,240.65019)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3329"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15368023,0,0,0.14162492,464.49737,238.93879)"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3404"
+       id="linearGradient3306"
+       x1="602.73309"
+       y1="849.21295"
+       x2="363.14337"
+       y2="533.09149"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3352"
+       x1="8.6666679"
+       y1="251.29697"
+       x2="282.04749"
+       y2="251.29697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,409.15872,219.93368)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3354"
+       x1="6.0974813"
+       y1="295.18372"
+       x2="279.49164"
+       y2="295.18372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,410.77496,225.32114)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3362"
+       gradientUnits="userSpaceOnUse"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037"
+       id="linearGradient3360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15368023,0,0,0.17242857,332.51026,242.91979)"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25" />
+    <linearGradient
+       id="linearGradient4087">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop4089" />
+      <stop
+         style="stop-color:#ffff40;stop-opacity:1;"
+         offset="1"
+         id="stop4091" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3099">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3101" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop3103" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4071">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop4073" />
+      <stop
+         style="stop-color:#ff4040;stop-opacity:1;"
+         offset="1"
+         id="stop4075" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2908">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop2910" />
+      <stop
+         style="stop-color:#4040ff;stop-opacity:1;"
+         offset="1"
+         id="stop2912" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2908"
+       id="linearGradient7002"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1366192,0,0,0.17563497,635.47577,189.5527)"
+       x1="439.21051"
+       y1="778.75781"
+       x2="358.42087"
+       y2="144.51556" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4071"
+       id="linearGradient7004"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20913212,0,0,0.2044384,610.07365,196.89456)"
+       x1="313.56229"
+       y1="578.41479"
+       x2="153.28476"
+       y2="785.55286" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099"
+       id="linearGradient7006"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20913212,0,0,0.2044384,612.04534,200.74947)"
+       x1="192.93016"
+       y1="788.82587"
+       x2="404.99326"
+       y2="835.96631" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4087"
+       id="linearGradient7008"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20834537,-0.01771845,0.01812527,0.20366903,619.48745,204.21896)"
+       x1="563.04547"
+       y1="790.1297"
+       x2="393.39581"
+       y2="883.63776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099"
+       id="linearGradient7010"
+       gradientUnits="userSpaceOnUse"
+       x1="156.27754"
+       y1="889.14215"
+       x2="588.54163"
+       y2="889.14215" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2816-6"
+       id="linearGradient2822-2"
+       x1="708.40527"
+       y1="708.24023"
+       x2="726.89935"
+       y2="767.16583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12834949,0,0,0.13258606,781.30313,248.05566)" />
+    <linearGradient
+       id="linearGradient2816-6">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0"
+         id="stop2818-0" />
+      <stop
+         style="stop-color:#ff7000;stop-opacity:1;"
+         offset="1"
+         id="stop2820-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2856"
+       id="linearGradient2862"
+       x1="333.5834"
+       y1="655.8938"
+       x2="122.61045"
+       y2="615.47394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.07814514,0.2147984,0.2147984,0.07814514,740.0721,237.77147)" />
+    <linearGradient
+       id="linearGradient2856">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop2858" />
+      <stop
+         style="stop-color:#ff8040;stop-opacity:1;"
+         offset="1"
+         id="stop2860" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2820"
+       id="linearGradient2826"
+       x1="482.26068"
+       y1="828.54749"
+       x2="661.53931"
+       y2="110.39577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,799.99999,205.33333)" />
+    <linearGradient
+       id="linearGradient2820">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop2822" />
+      <stop
+         style="stop-color:#ff4040;stop-opacity:1;"
+         offset="1"
+         id="stop2824" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804-3"
+       id="linearGradient2802"
+       x1="330.99365"
+       y1="329.03958"
+       x2="244.44389"
+       y2="252.75464"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,799.99999,200)" />
+    <linearGradient
+       id="linearGradient2804-3">
+      <stop
+         id="stop2806-7"
+         offset="0"
+         style="stop-color:#808080;stop-opacity:1;" />
+      <stop
+         id="stop2808-1"
+         offset="1"
+         style="stop-color:#40ff80;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2672"
+       id="linearGradient2319"
+       gradientUnits="userSpaceOnUse"
+       x1="97.114487"
+       y1="55.559166"
+       x2="755.40845"
+       y2="825.62524"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,799.99999,200.91429)" />
+    <linearGradient
+       id="linearGradient2672">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2674" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop2676" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2977"
+       id="linearGradient2993"
+       x1="86.188515"
+       y1="245.65826"
+       x2="192.44601"
+       y2="150.66571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.17852457,-0.05376615,-0.05921966,0.18238952,1205.3719,271.75522)" />
+    <linearGradient
+       id="linearGradient2977">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop2979" />
+      <stop
+         style="stop-color:#40ff40;stop-opacity:1;"
+         offset="1"
+         id="stop2981" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099-6"
+       id="linearGradient2292"
+       gradientUnits="userSpaceOnUse"
+       x1="118.5958"
+       y1="579.19678"
+       x2="232.82404"
+       y2="831.39819"
+       gradientTransform="matrix(0.21569052,0,0,0.21556763,1010.2916,211.39172)" />
+    <linearGradient
+       id="linearGradient3099-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3101-9" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop3103-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099-6"
+       id="linearGradient2975"
+       x1="432.66666"
+       y1="411.33334"
+       x2="634.66669"
+       y2="478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04270766,-0.14903139,-0.1493728,0.04835369,1198.3143,408.36197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2977"
+       id="linearGradient2983"
+       x1="266.05432"
+       y1="588.67303"
+       x2="548.09802"
+       y2="789.98169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04270766,-0.14903139,-0.1493728,0.04835369,1198.3143,408.36197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3224"
+       id="linearGradient3230"
+       x1="458.86057"
+       y1="854.13947"
+       x2="314.90103"
+       y2="408.66223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22590286,0,0,0.22574012,991.14533,166.43085)" />
+    <linearGradient
+       id="linearGradient3224">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop3226" />
+      <stop
+         style="stop-color:yellow;stop-opacity:1;"
+         offset="1"
+         id="stop3228" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3237"
+       id="linearGradient2294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.20867612,0,0,0.20778578,1121.3735,184.09523)"
+       x1="368.841"
+       y1="636.23065"
+       x2="25.697485"
+       y2="818.42755" />
+    <linearGradient
+       id="linearGradient3237">
+      <stop
+         id="stop3239"
+         offset="0"
+         style="stop-color:#408040;stop-opacity:1;" />
+      <stop
+         id="stop3241"
+         offset="1"
+         style="stop-color:#ff80ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070"
+       id="linearGradient3243"
+       gradientUnits="userSpaceOnUse"
+       x1="298.66666"
+       y1="435"
+       x2="550.18915"
+       y2="468.76749" />
+    <linearGradient
+       id="linearGradient3070">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3072" />
+      <stop
+         style="stop-color:#d0b090;stop-opacity:1"
+         offset="1"
+         id="stop3074" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070"
+       id="linearGradient2296"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22590286,0,0,0.22574012,989.07824,183.87663)"
+       x1="300.27295"
+       y1="623.78223"
+       x2="774.0462"
+       y2="764.89874" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2816-0"
+       id="linearGradient2822-1"
+       x1="708.40527"
+       y1="708.24023"
+       x2="726.89935"
+       y2="767.16583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,11.743453,0.38094777)" />
+    <linearGradient
+       id="linearGradient2816-0">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0"
+         id="stop2818-9" />
+      <stop
+         style="stop-color:#ff7000;stop-opacity:1;"
+         offset="1"
+         id="stop2820-73" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804-1"
+       id="linearGradient2810-9"
+       x1="508.33115"
+       y1="392.78183"
+       x2="477.68985"
+       y2="467.27161"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,0.68007341,-2.2285156e-6)" />
+    <linearGradient
+       id="linearGradient2804-1">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop2806-2" />
+      <stop
+         style="stop-color:#ff0000;stop-opacity:0;"
+         offset="1"
+         id="stop2808-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804-1"
+       id="linearGradient2812-2"
+       x1="354.75922"
+       y1="397.64706"
+       x2="386.78885"
+       y2="451.85861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22126766,0,0,0.22857143,0.68007341,-2.2285156e-6)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2266-6"
+       id="linearGradient2695-6"
+       x1="313.33334"
+       y1="558.33331"
+       x2="726.66669"
+       y2="558.33331"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient2266-6">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2268-5" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop2270-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508-5"
+       id="linearGradient2895-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.23514766,0,0,0.23515269,410.38925,-2.710449)"
+       x1="247.19395"
+       y1="571.16028"
+       x2="408.68234"
+       y2="606.51562" />
+    <linearGradient
+       id="linearGradient2508-5">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop2510-2" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop2512-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508-5"
+       id="linearGradient2891-1"
+       x1="247.19395"
+       y1="571.16028"
+       x2="408.68234"
+       y2="606.51562"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,195.45619,-4.373229)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2930-2"
+       id="linearGradient2936-4"
+       x1="410.92975"
+       y1="131.56165"
+       x2="899.82593"
+       y2="1051.2655"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,197.11894,-5.481759)" />
+    <linearGradient
+       id="linearGradient2930-2">
+      <stop
+         style="stop-color:#a000a0;stop-opacity:1;"
+         offset="0"
+         id="stop2932-0" />
+      <stop
+         style="stop-color:#0000a0;stop-opacity:1;"
+         offset="1"
+         id="stop2934-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2508-5"
+       id="linearGradient2382-0"
+       x1="252"
+       y1="523.33331"
+       x2="751.33331"
+       y2="686.66663"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29064823,0,0,0.29032343,184.6249,-44.387679)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2930-2"
+       id="linearGradient2944-3"
+       x1="396.74344"
+       y1="487.85074"
+       x2="465.33133"
+       y2="867.33136"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23514766,0,0,0.23515269,197.11894,-5.481759)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3392-0"
+       id="linearGradient3398-1"
+       x1="458.6149"
+       y1="105.43819"
+       x2="464.21469"
+       y2="248.97305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400.00001,2.1269531e-5)" />
+    <linearGradient
+       id="linearGradient3392-0">
+      <stop
+         style="stop-color:#c00000;stop-opacity:1;"
+         offset="0"
+         id="stop3394-2" />
+      <stop
+         style="stop-color:#0000c0;stop-opacity:1;"
+         offset="1"
+         id="stop3396-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3390-8"
+       x1="385.03464"
+       y1="184.11929"
+       x2="499.04916"
+       y2="184.11929"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400.00001,2.1269531e-5)" />
+    <linearGradient
+       id="linearGradient3037-6">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop3039-3" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop3041-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3388-0"
+       x1="259.42661"
+       y1="345.1275"
+       x2="642.65881"
+       y2="345.1275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400.00001,2.1269531e-5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3331-3"
+       gradientUnits="userSpaceOnUse"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3323-1"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3404-2"
+       id="linearGradient3298-9"
+       x1="303.73691"
+       y1="691.15222"
+       x2="679.99005"
+       y2="788.88568"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3404-2">
+      <stop
+         id="stop3406-6"
+         offset="0"
+         style="stop-color:#808080;stop-opacity:1;" />
+      <stop
+         id="stop3408-6"
+         offset="1"
+         style="stop-color:#408000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3321-7"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17692252,0,0,0.18069943,430.13601,40.650211)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3329-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15368023,0,0,0.14162492,464.49731,38.938811)"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3404-2"
+       id="linearGradient3306-1"
+       x1="602.73309"
+       y1="849.21295"
+       x2="363.14337"
+       y2="533.09149"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3352-3"
+       x1="8.6666679"
+       y1="251.29697"
+       x2="282.04749"
+       y2="251.29697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,409.15871,19.933701)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3354-1"
+       x1="6.0974813"
+       y1="295.18372"
+       x2="279.49164"
+       y2="295.18372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,410.77491,25.321161)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3362-4"
+       gradientUnits="userSpaceOnUse"
+       x1="425.69217"
+       y1="321.0997"
+       x2="733.96295"
+       y2="321.0997" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3037-6"
+       id="linearGradient3360-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15368023,0,0,0.17242857,332.51021,42.919811)"
+       x1="486.96875"
+       y1="528.25"
+       x2="798"
+       y2="528.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4087-0"
+       id="linearGradient4098"
+       gradientUnits="userSpaceOnUse"
+       x1="563.04547"
+       y1="790.1297"
+       x2="393.39581"
+       y2="883.63776"
+       gradientTransform="matrix(0.20834537,-0.01771845,0.01812527,0.20366903,619.48739,4.2189583)" />
+    <linearGradient
+       id="linearGradient4087-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4089-3" />
+      <stop
+         style="stop-color:#c0c000;stop-opacity:1;"
+         offset="1"
+         id="stop4091-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099-7"
+       id="linearGradient4106"
+       x1="192.93016"
+       y1="788.82587"
+       x2="404.99326"
+       y2="835.96631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20913212,0,0,0.2044384,612.04529,0.74946835)" />
+    <linearGradient
+       id="linearGradient3099-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3101-8" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop3103-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4071-7"
+       id="linearGradient4077"
+       x1="313.56229"
+       y1="578.41479"
+       x2="153.28476"
+       y2="785.55286"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20913212,0,0,0.2044384,610.07359,-3.1054417)" />
+    <linearGradient
+       id="linearGradient4071-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4073-4" />
+      <stop
+         style="stop-color:#c00000;stop-opacity:1;"
+         offset="1"
+         id="stop4075-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2908-1"
+       id="linearGradient2914"
+       x1="439.21051"
+       y1="778.75781"
+       x2="358.42087"
+       y2="144.51556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1366192,0,0,0.17563497,635.47569,-10.447302)" />
+    <linearGradient
+       id="linearGradient2908-1">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2910-3" />
+      <stop
+         style="stop-color:#0000c0;stop-opacity:1;"
+         offset="1"
+         id="stop2912-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3099-7"
+       id="linearGradient4056"
+       x1="156.27754"
+       y1="889.14215"
+       x2="588.54163"
+       y2="889.14215"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2816-8"
+       id="linearGradient2822-3"
+       x1="708.40527"
+       y1="708.24023"
+       x2="726.89935"
+       y2="767.16583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12834949,0,0,0.13258606,781.58888,48.159912)" />
+    <linearGradient
+       id="linearGradient2816-8">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0"
+         id="stop2818-7" />
+      <stop
+         style="stop-color:#ff7000;stop-opacity:1;"
+         offset="1"
+         id="stop2820-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2856-4"
+       id="linearGradient2862-4"
+       x1="333.5834"
+       y1="655.8938"
+       x2="122.61045"
+       y2="615.47394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.07814514,0.2147984,0.2147984,0.07814514,740.07211,37.771472)" />
+    <linearGradient
+       id="linearGradient2856-4">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2858-9" />
+      <stop
+         style="stop-color:#804000;stop-opacity:1;"
+         offset="1"
+         id="stop2860-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2820-8"
+       id="linearGradient2826-8"
+       x1="482.26068"
+       y1="828.54749"
+       x2="661.53931"
+       y2="110.39577"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,5.3333316)" />
+    <linearGradient
+       id="linearGradient2820-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2822-8" />
+      <stop
+         style="stop-color:#c00000;stop-opacity:1;"
+         offset="1"
+         id="stop2824-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2804-16"
+       id="linearGradient2802-9"
+       x1="330.99365"
+       y1="329.03958"
+       x2="244.44389"
+       y2="252.75464"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,1.572998e-6)" />
+    <linearGradient
+       id="linearGradient2804-16">
+      <stop
+         id="stop2806-9"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop2808-8"
+         offset="1"
+         style="stop-color:#008040;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2672-9"
+       id="linearGradient2319-0"
+       gradientUnits="userSpaceOnUse"
+       x1="97.114487"
+       y1="55.559166"
+       x2="755.40845"
+       y2="825.62524"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800,0.91429157)" />
+    <linearGradient
+       id="linearGradient2672-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2674-2" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop2676-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2977-3"
+       id="linearGradient2993-9"
+       x1="86.188515"
+       y1="245.65826"
+       x2="192.44601"
+       y2="150.66571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.17852457,-0.05376615,-0.05921966,0.18238951,1205.3719,71.755222)" />
+    <linearGradient
+       id="linearGradient2977-3">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2979-0" />
+      <stop
+         style="stop-color:#00c000;stop-opacity:1;"
+         offset="1"
+         id="stop2981-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070-6"
+       id="linearGradient2292-2"
+       gradientUnits="userSpaceOnUse"
+       x1="118.5958"
+       y1="579.19678"
+       x2="232.82404"
+       y2="831.39819"
+       gradientTransform="matrix(0.21569052,0,0,0.21556762,1010.2916,11.391722)" />
+    <linearGradient
+       id="linearGradient3070-6">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3072-5" />
+      <stop
+         style="stop-color:#907050;stop-opacity:1;"
+         offset="1"
+         id="stop3074-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070-6"
+       id="linearGradient2975-2"
+       x1="432.66666"
+       y1="411.33334"
+       x2="634.66669"
+       y2="478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04270766,-0.14903138,-0.1493728,0.04835369,1198.3142,208.36197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2977-3"
+       id="linearGradient2983-3"
+       x1="266.05432"
+       y1="588.67303"
+       x2="548.09802"
+       y2="789.98169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04270766,-0.14903138,-0.1493728,0.04835369,1198.3142,208.36197)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3224-8"
+       id="linearGradient3230-7"
+       x1="458.86057"
+       y1="854.13947"
+       x2="314.90103"
+       y2="408.66223"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22590286,0,0,0.22574011,991.14535,-33.569148)" />
+    <linearGradient
+       id="linearGradient3224-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3226-4" />
+      <stop
+         style="stop-color:#c0c000;stop-opacity:1;"
+         offset="1"
+         id="stop3228-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3237-6"
+       id="linearGradient2294-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.20867612,0,0,0.20778578,1121.3734,-15.904768)"
+       x1="368.841"
+       y1="636.23065"
+       x2="25.697485"
+       y2="818.42755" />
+    <linearGradient
+       id="linearGradient3237-6">
+      <stop
+         id="stop3239-3"
+         offset="0"
+         style="stop-color:#008000;stop-opacity:1;" />
+      <stop
+         id="stop3241-6"
+         offset="1"
+         style="stop-color:#800080;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070-6"
+       id="linearGradient3243-9"
+       gradientUnits="userSpaceOnUse"
+       x1="298.66666"
+       y1="435"
+       x2="550.18915"
+       y2="468.76749" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3070-6"
+       id="linearGradient2296-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22590286,0,0,0.22574011,989.07826,-16.123368)"
+       x1="300.27295"
+       y1="623.78223"
+       x2="774.0462"
+       y2="764.89874" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.5"
+     inkscape:cx="39.59969"
+     inkscape:cy="287.76502"
+     inkscape:document-units="px"
+     inkscape:current-layer="svg2722"
+     showgrid="false"
+     inkscape:window-width="1566"
+     inkscape:window-height="828"
+     inkscape:window-x="193"
+     inkscape:window-y="311"
+     showguides="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Freak Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:description>Chess piece set &quot;Freak&quot; by Maurizio Monge.</dc:description>
+        <dc:date>2017-10-29</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="k">
+      <rect
+         y="0"
+         x="0"
+         height="200"
+         width="200"
+         id="rect5056-5"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.21236206,-0.01003656,0.00971585,0.21937189,-18.21666,-10.576362)"
+         d="m 716.66667,558.33331 a 196.66667,293.33334 0 1 1 -393.33334,0 196.66667,293.33334 0 1 1 393.33334,0 z"
+         sodipodi:ry="293.33334"
+         sodipodi:rx="196.66667"
+         sodipodi:cy="558.33331"
+         sodipodi:cx="520"
+         id="path4289-4"
+         style="fill:url(#linearGradient2695-6);fill-opacity:1;stroke:#000000;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2569-3"
+         d="m 76.371313,58.087787 c -0.50817,-0.74198 -4.68974,-1.34054 -7.1759,-1.85917 -1.65376,-0.34498 -3.97427,0.18783 -5.66299,0.26764 -2.52629,0.1194 -5.18771,1.16436 -7.35172,2.17939 -4.25762,1.99703 -7.28314,5.17336 -10.59961,8.92781 -2.04673,2.31704 -3.04436,4.748831 -4.64744,7.180961 -1.5061,2.28498 -2.11237,3.78998 -4.35829,5.70176 -2.36797,2.01569 -4.07573,3.97245 -5.74165,6.49991 -1.00726,1.52818 -0.98299,3.89971 -1.54298,5.20232 -0.71242,1.65717 -1.24173,2.76434 -1.57537,4.47108"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2573-1"
+         d="m 70.969723,72.265718 c 0.0826,1.8643 -3.50699,0.89852 -5.26048,1.34777 -4.84076,1.24024 -7.18224,5.34856 -8.07347,9.90758 -0.78554,4.01838 -1.77183,8.15253 -3.72907,11.90057 -1.80182,3.45044 -4.07478,6.832392 -6.28759,10.189572 -1.85112,2.80844 -2.52378,6.67721 -3.82622,9.70685 -1.93338,4.49727 -3.21825,9.8531 -4.67753,14.51009 -1.16738,3.72548 -2.65291,8.18941 -3.37512,11.88384 -0.72313,3.6991 -2.10541,7.31718 -3.43991,10.42137 -0.83724,1.94754 -1.88435,4.25783 -2.21847,5.96701"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2577-9"
+         d="m 62.588563,131.28347 c -2.40744,3.65247 -2.95708,7.15832 -3.71287,12.26619 -0.55013,3.71795 0.33887,7.68603 -0.20589,11.36767 -0.66446,4.49063 -3.1847,8.66743 -4.03442,13.01416 -0.45996,2.35287 -0.95163,4.04501 -2.21847,5.96702 -1.16262,1.76386 -2.63674,4.11695 -3.29648,5.65157 -0.73684,1.714 -1.26458,2.89253 -3.03969,3.44113"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2579-8"
+         d="m 79.330043,52.818557 c -0.56914,1.32389 -7.35406,-1.923189 -8.97797,-2.506769 -2.93524,-1.05482 -5.78601,-1.56923 -8.60784,-2.15787 -3.47025,-0.72391 -8.15423,0.38538 -11.67993,0.55201 -3.7625,0.17782 -5.08348,-0.004 -6.99777,2.16265 -2.0132,2.279069 -4.629,4.088459 -6.46572,6.167739 -0.11258,0.12745 -0.22516,0.2549 -0.33774,0.38235"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2581-7"
+         d="m 87.792143,51.685858 c -0.0405,0.0459 -8.59686,-7.40287 -8.85074,-7.64218 -1.60836,-1.51607 -17.91692,-7.21369 -19.46885,-7.14035 -0.87347,0.0413 -8.44425,-12.05801 -9.39898,-12.01289"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2585-7"
+         d="m 91.671563,51.188208 c -0.0695,-0.23991 3.40608,-12.42141 3.66429,-13.36306 2.19368,-7.99997 -2.53256,-14.2733 0.47655,-21.27287"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2591-6"
+         d="m 97.742623,52.126157 c -2.4862,1.43445 3.061947,-7.769009 5.015267,-14.892439 1.40913,-5.13886 9.59196,-10.0908 12.86666,-13.79797 1.01516,-1.14923 2.69286,-1.81799 3.77996,-2.74335"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2593-8"
+         d="m 101.88485,49.554278 c 1.07137,-1.21286 3.95312,-6.39494 6.33617,-9.09271 3.58723,-4.06098 8.94088,-10.083 14.02563,-11.65443 2.92174,-0.90296 6.44669,-0.67107 9.54011,-0.81727 1.06181,-0.0502 2.12362,-0.10036 3.18543,-0.15054"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2597-7"
+         d="m 116.25284,53.638227 c 0.66509,0.37062 10.49463,-1.25207 13.44962,-0.63565 3.4238,0.71422 6.2823,2.48781 9.71823,3.20456 4.27015,0.89077 8.50215,-3.44257 12.33921,-1.68233 2.32339,1.06586 10.45078,5.20815 13.01702,5.61335"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2599-3"
+         d="m 119.77833,61.165707 c 2.10834,0.96719 19.61756,-0.0338 26.69102,2.036 2.86878,0.83944 5.39982,3.19354 8.72119,4.71722 3.35699,1.54001 5.14643,4.715941 7.08106,7.725821 2.1929,3.41168 3.91291,6.56567 5.76246,9.98644 0.0814,0.15063 0.24675,0.2326 0.37013,0.34889"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2601-2"
+         d="m 125.58706,64.188637 c 1.90834,3.5295 13.25449,7.52866 18.55278,10.481111 3.80338,2.11942 6.5545,5.83088 7.53215,9.90281 1.32974,5.53838 2.88288,12.45266 6.07013,16.933222 1.97792,2.78052 1.61005,5.99886 3.23632,9.00668 0.39897,0.73789 0.47306,2.67276 0.51587,3.63948"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2605-5"
+         d="m 135.5852,89.729468 c 1.66939,2.09276 5.93813,4.30368 7.43499,7.70909 1.03294,2.34999 1.08135,5.282292 1.7558,7.611112 0.97706,3.37365 2.00097,5.94996 3.9442,8.97322 2.81676,4.38227 8.01056,7.2188 9.39899,12.01289 0.90659,3.13033 1.17637,6.25208 1.83677,9.43921 0.65493,3.16071 1.30657,6.36966 2.19071,9.42248 0.83493,2.88291 1.72326,5.3308 2.47987,7.94327 0.267,0.92192 0.64343,1.91197 0.82122,2.52589"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2607-4"
+         d="m 141.10939,110.35235 c 0.81023,2.79764 1.35126,6.48531 1.48283,9.45593 0.23896,5.39545 1.21164,10.96042 4.21948,15.18877 2.86953,4.03392 4.78612,9.22292 7.66169,12.82777 1.01819,1.2764 1.83696,3.55541 2.36652,5.38393 1.00616,3.47413 2.64413,6.65217 3.63884,10.08681 0.82127,2.83572 1.14818,5.81595 2.49606,8.30889 0.17277,0.31955 0.0324,0.73125 0.0486,1.09686"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2611-3"
+         d="m 69.331893,83.334678 c -3.89308,-0.21646 -10.39517,2.14945 -15.07356,4.00987 -0.9417,0.37448 -1.85528,0.82045 -2.78292,1.23068 -2.02643,0.89614 -1.77803,4.9425 -2.54002,6.71498 -1.74432,4.05752 -7.24847,9.357582 -10.08374,12.567292 -0.5629,0.63724 -1.12581,1.27449 -1.68872,1.91174 -1.83273,2.07477 -3.47928,4.49823 -5.01758,6.83207 -1.21143,1.83793 -2.53842,3.56761 -2.94254,5.63485"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2613-5"
+         d="m 66.262123,94.104938 c -0.53412,2.73224 -4.93116,2.28266 -7.28694,3.64186 -4.76815,2.751042 -5.99325,9.088442 -9.35968,12.899452 -3.93091,4.45004 -3.61134,8.95946 -10.11612,11.83605 -2.87094,1.2696 -6.28953,6.0305 -8.12205,8.81072 -1.24767,1.8929 -1.99005,3.27933 -3.31267,5.28595 -1.15906,1.75847 -1.82869,4.42157 -2.20228,6.33263"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2615-7"
+         d="m 63.534713,120.61358 c -0.53971,2.76087 -5.49596,0.30867 -8.10817,1.11597 -4.27842,1.32225 -5.89958,2.93394 -5.70926,7.23115 0.25961,5.86164 -6.79631,12.3554 -9.90561,16.58911 -4.4399,6.04549 -9.54381,11.92996 -13.01009,18.56776 -1.12286,2.15024 -2.16479,4.79551 -2.54002,6.71497 -0.0523,0.26741 -0.21437,0.49865 -0.32155,0.74797"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2621-5"
+         d="m 81.224163,57.568987 c -0.45179,0.51146 -7.7627,-0.62317 -9.62107,-1.01084 -2.96365,-0.61823 -7.27493,-0.38895 -10.29656,-0.24614 -2.66791,0.12609 -5.04613,-0.1279 -7.80281,0.002 -2.82662,0.13359 -6.07846,2.88832 -8.31636,4.42328 -3.56603,2.44592 -6.06999,6.98209 -9.13528,9.95777 -1.28368,1.24615 -5.19981,3.750021 -6.88443,4.721991 -1.27316,0.73456 -3.29262,2.51821 -4.45544,3.50804"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2627-6"
+         d="m 90.445513,47.530218 c -0.48003,-0.45249 -0.32244,-7.28032 -0.40482,-9.1405 -0.12955,-2.92496 -0.25909,-5.84992 -0.38864,-8.77488 -0.12375,-2.7942 -0.35145,-5.23973 -1.04793,-7.64456 -0.31042,-1.07186 -0.32743,-1.61261 -0.82122,-2.52589"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2631-5"
+         d="m 98.907624,46.397518 c 1.530986,-2.32275 6.952186,-7.17953 10.567216,-9.65906 2.26008,-1.55018 5.37023,-0.62019 8.12436,-0.75035 4.00132,-0.18911 7.3647,1.11747 11.39076,0.92719 3.73856,-0.17669 7.14579,-1.43687 10.92347,-1.61541 0.16685,-0.008 0.22516,-0.2549 0.33774,-0.38235"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2633-9"
+         d="m 105.08648,49.769348 c 3.11247,-0.1471 8.67652,-1.50922 13.04709,-1.71578 3.42914,-0.16207 6.98668,1.44291 10.39372,2.43985 3.18182,0.93105 6.24749,0.7599 9.28333,1.39319 5.04451,1.052309 12.8919,1.222629 17.77782,0.991719 2.23441,-0.1056 4.20301,0.7862 6.0817,1.17811"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2635-5"
+         d="m 116.43097,57.660047 c 5.73019,-0.27082 12.98268,1.23437 19.66085,3.46742 0.46328,0.15492 0.95463,0.19914 1.43195,0.29872 1.38415,0.28873 3.8797,3.36724 4.81169,4.53559 2.01259,2.52301 7.1693,5.61715 9.88016,6.860761 1.97149,0.90442 2.9834,3.49956 3.78227,5.31702 0.98711,2.24572 2.28426,4.12975 3.81465,6.04826 1.20531,1.511 1.44282,2.76146 2.65568,3.90473"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2639-8"
+         d="m 138.01418,88.515518 c 5.95976,7.47122 12.459,18.050512 19.53824,24.723562 2.38991,2.25278 2.42481,6.7 2.56084,9.77137 0.11506,2.598 3.33505,4.8715 4.53872,6.38043 1.82712,2.2905 2.9712,4.82394 4.21717,7.1284 0.53305,0.98589 1.21028,2.5741 1.56149,3.22367"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2643-3"
+         d="m 142.55057,142.89253 c 0.0872,0.0822 0.0108,0.24374 0.0162,0.36562 0.11677,2.63652 4.67789,2.30733 6.56519,4.08634 0.61689,0.58149 1.23377,1.16298 1.85065,1.74446 1.81447,1.71036 3.52325,4.5023 4.53872,6.38043 1.11618,2.06439 1.6593,4.41158 2.76904,6.46406 1.0272,1.89984 1.83725,4.48559 2.41509,6.4808 0.0677,0.23376 0.0216,0.48749 0.0324,0.73124 0.0818,1.8466 1.36732,4.79242 2.38271,5.74955"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2659-3"
+         d="m 77.143963,59.516817 c -3.1666,1.82702 -8.03437,2.69757 -13.52827,6.86791 -3.92843,2.98202 -6.44169,7.840451 -8.68418,12.134751 -0.25076,0.4802 -0.42873,0.9973 -0.6431,1.49594 -2.10853,4.9047 -2.53867,10.10744 -3.93727,15.20787 -2.60218,9.489732 -6.02141,17.404182 -10.91654,25.796522 -2.21205,3.79241 -5.98806,6.6698 -7.68714,10.6221 -0.0267,0.0622 -0.89748,1.36162 -0.99704,1.51267"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2619-1"
+         d="m 72.674633,70.719597 c -0.35761,1.829331 -3.5529,-0.93124 -5.35764,-0.84595 -3.74141,0.17683 -6.1309,0.96531 -9.08901,2.994261 -2.056,1.4102 -3.07756,4.2519 -4.69603,6.08411 -3.37873,3.82494 -7.50787,6.8977 -11.24271,10.42375 -3.00075,2.83299 -4.42152,6.8382 -6.64153,10.20629 -1.30951,1.986732 -3.30542,4.125902 -4.37447,5.336142 -1.28874,1.45893 -2.13081,3.56406 -3.32886,4.92033 -0.44471,0.50344 -0.66263,0.50299 -1.02943,0.78143"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2661-9"
+         d="m 68.621703,75.307778 c -0.33002,0.76766 -4.34961,2.96665 -5.03377,6.46644 -0.0964,0.49307 -0.19278,0.98613 -0.28917,1.47922 -0.71298,3.64723 -0.83212,6.37178 -2.39428,10.00556 -1.37441,3.19704 -2.69888,7.186682 -3.79384,10.438072 -1.39494,4.14217 -4.17368,7.75552 -5.49875,11.98423 -0.31076,0.9917 -0.62151,1.98343 -0.93226,2.97513 -1.22638,3.91373 -2.1587,7.85804 -3.39133,11.51823 -1.68132,4.99254 -6.09551,11.12396 -9.61645,15.10989 -1.13296,1.2826 -2.71205,2.68626 -3.73138,3.8402"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2663-9"
+         d="m 65.137853,100.75301 c 0.34161,1.21727 -2.54021,5.68126 -3.52088,8.59326 -1.09016,3.23716 -1.43381,5.98925 -2.07272,9.2576 -0.19278,0.98613 -0.38556,1.97228 -0.57834,2.95841 -0.0935,0.47835 0.0432,0.97497 0.0648,1.46249 0.15212,3.43464 -1.55711,8.73542 -3.39132,11.5182 -2.01399,3.05554 -1.88038,5.59259 -1.7188,9.24087 0.12793,2.8885 0.55937,6.10766 0.0347,8.7916 -0.80058,4.0954 -3.84079,5.92521 -6.72249,8.3782 -1.48819,1.26679 -2.57899,4.0428 -3.65041,5.66831 -0.61347,0.93072 -0.90923,2.69987 -1.25382,3.72309"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2665-6"
+         d="m 69.205403,127.5046 c -2.08985,3.17063 -2.10714,7.63977 -3.005,12.23274 -0.7721,3.94966 -0.87884,7.63487 -1.62164,11.43456 -0.57634,2.94829 -0.76825,6.6782 -0.64078,9.55632 0.13393,3.02404 -0.19538,5.36885 -1.78357,7.77838 -2.88419,4.37576 -6.23007,8.94458 -10.47007,11.85276 -0.84758,0.58137 -0.95112,1.07673 -1.35097,1.5294"
+         style="fill:none;stroke:#37260f;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2617-1"
+         d="m 62.847653,137.13339 c -0.42915,2.19532 -4.05587,1.90383 -5.51725,3.55822 -3.47389,3.93266 -4.66317,6.8262 -4.43695,11.93402 0.17175,3.87777 -1.03021,8.38773 -1.58924,12.16583 -0.36712,2.48106 -0.99144,5.42619 -1.78357,7.77838 -0.57783,1.71581 -0.38482,4.21079 -0.78653,6.26573 -0.0523,0.2674 -0.21437,0.49864 -0.32155,0.74797"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2667-7"
+         d="m 75.115183,53.750527 c -2.20005,1.50901 -5.2573,0.85043 -7.72184,1.8305 -7.07529,2.81355 -13.15569,2.99057 -18.06467,8.54785 -2.54232,2.87805 -3.80504,5.1139 -4.56649,9.009071 -1.07492,5.4987 -8.46179,13.07248 -11.64292,17.40397 -1.48031,2.01564 -3.03738,3.43576 -4.00434,5.68503 -0.43642,1.01518 -0.86705,2.01686 -1.2862,2.99188"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2571-1"
+         d="m 73.091033,64.104987 c -0.28109,0.65384 -10.50435,0.47666 -12.72554,0.96781 -2.18114,0.48228 -5.57372,6.51257 -6.36856,8.361461 -2.26629,5.27167 -7.97751,12.87057 -11.65911,17.03837 -2.66517,3.01714 -2.90306,4.73645 -4.26112,7.89548 -1.43075,3.328082 -3.05089,6.370262 -4.18017,9.723572 -1.92331,5.71113 -3.48955,10.99712 -5.28824,16.73727 -0.75516,2.40996 -0.88157,4.11964 -0.77033,6.63134 0.008,0.17236 -0.22516,0.2549 -0.33775,0.38235"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2575-4"
+         d="m 61.582283,100.55466 c -0.32916,1.6838 -2.62718,6.91772 -3.82622,9.70685 -2.92728,6.80922 -4.18742,15.27079 -6.10716,22.27176 -1.26464,4.61192 -1.53922,9.45238 -2.21616,14.02737 -0.57019,3.85352 -2.59096,9.1923 -4.40455,12.66527 -1.21154,2.32006 -1.69164,4.82593 -2.87777,7.09733 -1.28904,2.46847 -2.77415,4.46894 -4.30971,6.79861 -1.41255,2.14307 -3.02921,4.07554 -4.34209,6.06738 -0.84045,1.2751 -1.53473,1.97036 -2.36421,2.67644"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2669-0"
+         d="m 85.282203,51.071708 c -1.18388,2.753859 -4.97733,-3.17883 -7.64319,-4.40179 -4.55743,-2.0907 -10.22127,-4.93957 -14.8029,-5.89532 -3.29256,-0.68685 -20.39514,10.0947 -24.65993,11.790649 -1.69222,0.67293 -2.47324,0.8801 -3.4584,1.99537"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2671-2"
+         d="m 89.497063,50.139748 c -2.03232,0.80817 -0.0986,-4.99793 -1.70723,-6.51425 -3.06093,-2.88531 -5.10521,-7.08644 -9.52622,-6.8775 -2.46178,0.11635 -3.80715,-1.42811 -6.11409,-1.90935 -0.49319,-0.10287 -1.24987,0.0591 -1.76969,0.0836"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2623-5"
+         d="m 84.694263,52.439317 c -1.98461,1.14505 -6.3114,-3.374369 -8.72119,-4.717219 -2.40021,-1.33751 -4.78345,-2.80906 -7.24067,-3.32165 -3.63645,-0.75858 -7.35684,-1.31064 -11.10159,-2.4064 -2.25049,-0.65852 -3.6566,-1.12503 -5.74397,-1.56046 -0.96268,-0.20082 -1.86592,-0.60396 -2.89626,-1.32866"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2673-8"
+         d="m 99.326334,47.843258 c -0.0412,-0.009 -2.158691,-7.08021 -3.960391,-9.33883 -1.2827,-1.60801 -1.9698,-4.43451 -2.07736,-6.86315 -0.0727,-1.64056 -0.51459,-3.6108 -0.59683,-5.46757"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="css"
+         id="path2583-0"
+         d="m 91.843963,53.137707 c -2.31792,0.10954 -0.74376,-4.901649 -2.07736,-6.863149 -7.07374,-10.40427 -16.64543,-19.38344 -16.32273,-32.20324"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2675-1"
+         d="m 107.90178,49.269908 c -0.0418,-0.94459 -0.28077,-6.33941 -0.42102,-9.50613 -0.11343,-2.56119 0.49181,-4.25783 1.84834,-6.3159 0.77261,-1.17216 2.36734,-1.92512 2.3966,-1.94519"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2677-6"
+         d="m 111.55566,51.687958 c 1.05589,-1.60198 4.85696,-2.89089 7.28694,-3.64186 0.22629,-0.0699 0.47191,-0.0223 0.70787,-0.0335 2.37474,-0.11223 4.94864,-0.60027 7.41649,-0.7169 4.64575,-0.21957 8.01039,4.38443 12.5983,4.1676 0.5899,-0.0279 1.17979,-0.0558 1.76969,-0.0836"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2629-9"
+         d="m 91.329203,43.458218 c -0.36615,-1.26428 2.48178,-1.18284 3.08828,-2.34427 1.77855,-3.40585 3.887011,-6.67757 5.949837,-9.80722 1.57776,-2.3937 3.01358,-5.09231 4.63126,-7.54659 1.12825,-1.71172 3.1498,-3.31717 4.777,-4.256"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2625-7"
+         d="m 86.841373,46.235018 c -1.8348,-0.38275 -6.6368,-8.00777 -9.33422,-10.55041 -1.96345,-1.8508 -2.74266,-3.286 -4.84408,-5.26685 -2.12205,-2.00029 -3.57183,-3.90215 -5.23039,-5.98135"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2595-0"
+         d="m 105.71339,47.907788 c 0.38835,-0.0183 5.20996,-2.99997 7.28694,-3.64186 4.246,-1.31222 8.54645,-1.50307 13.04709,-1.71578 4.16685,-0.19693 6.37586,0.0594 10.00739,1.72535 5.09312,2.33646 15.59472,-3.2335 16.18395,-2.96319"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2679-5"
+         d="m 117.34705,54.319297 c 2.30725,-0.10905 9.30288,2.21479 12.63069,4.89883 2.19338,1.76906 4.57703,3.26332 6.61376,5.1832 2.21981,2.09243 3.78715,4.62092 5.97066,6.67913 2.16132,2.037311 2.88328,7.011031 4.33052,9.687731 2.13984,3.95768 5.25606,7.23922 8.9479,9.8359 1.92658,1.35509 3.5234,1.93597 5.77634,2.29171"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2681-1"
+         d="m 119.98884,65.918757 c 3.68069,2.58886 8.23318,5.83202 11.05533,9.369911 1.78822,2.24174 3.16801,5.23764 4.94124,7.46056 1.8124,2.27206 3.1574,5.07839 5.27898,7.07821 1.63867,1.54464 2.91217,5.09811 4.21717,7.12841 2.23641,3.479382 3.9925,6.566262 7.16202,9.553912 2.89471,2.72861 5.18867,6.12512 8.54537,8.75576 0.39919,0.31285 0.74026,0.69779 1.11039,1.04667"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2683-3"
+         d="m 128.40016,83.777628 c 2.74885,2.15428 11.97093,5.95915 16.07522,10.59821 1.37497,1.55412 0.8428,5.07806 1.36948,6.896602 0.75762,2.61597 0.51244,5.63525 1.08031,8.3758 0.71794,3.46479 1.25586,6.50428 2.2069,9.7881 0.88961,3.07171 2.82792,6.86993 5.00601,8.92305 4.24084,3.99749 8.89273,8.03211 12.93836,11.8456 0.12338,0.1163 0.24675,0.23259 0.37013,0.3489"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86142826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2687-2"
+         d="m 129.38782,133.98861 c 2.15829,2.03444 4.93656,7.3398 6.84047,10.30187 1.44179,2.24312 2.69336,4.98143 3.86323,7.14511 1.26402,2.33785 2.4293,4.57381 3.84704,6.77951 1.03415,1.60894 1.79293,4.73656 2.3989,6.11517"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2641-9"
+         d="m 139.74222,111.51612 c 3.14655,5.81961 8.05879,10.60867 11.71693,16.29996 1.84322,2.86767 1.93243,6.45126 3.9442,8.97323 1.87534,2.35095 4.51021,6.99902 6.1164,9.96971 1.25432,2.3199 4.30246,4.7563 5.95447,6.31352 1.04432,0.9844 1.66933,2.09269 2.25316,2.82459"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2603-9"
+         d="m 126.95654,71.085237 c 2.92148,5.403331 9.26874,10.488681 13.77579,14.737111 2.86814,2.70358 5.91626,6.48104 7.86989,9.52046 1.11039,1.72754 0.44648,4.948442 1.01554,6.913332 1.28846,4.4489 2.21273,8.79188 4.47626,12.97831 1.69442,3.13388 4.77891,5.90613 7.09724,8.09144 1.56049,1.47094 2.38056,3.21449 3.76608,4.9514 0.82413,1.03314 1.35483,1.83445 1.89923,2.84132"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2685-9"
+         d="m 133.59625,106.94388 c 0.061,0.0575 1.11645,6.64231 1.82058,9.0736 1.33635,4.61423 2.04741,9.12381 3.0767,13.41085 0.56195,2.3405 0.72969,4.37775 1.35329,6.53098 1.12737,3.89264 2.78096,7.46266 5.42472,10.36878 0.63168,0.69436 1.24456,1.40673 1.86684,2.11008 3.1789,3.59309 6.86654,6.82289 10.37984,10.1346 1.9597,1.84726 3.92449,4.1286 6.25983,5.19993"
+         style="fill:none;stroke:#4f3100;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2637-6"
+         d="m 130.89843,71.998087 c 3.7824,4.741661 13.44395,9.869701 18.74709,14.868561 2.22324,2.09566 3.3689,4.92736 5.63292,7.06148 1.66669,1.57105 2.20842,3.34403 3.78227,5.31702 1.52902,1.916802 3.35252,3.397012 4.84408,5.266852 1.75524,2.20038 2.72854,5.15283 4.23336,7.49401"
+         style="fill:none;stroke:#37260f;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2609-0"
+         d="m 137.62553,135.79759 c 0.45948,0.84981 1.66931,6.77979 3.26871,9.73791 1.27883,2.36523 1.41,5.50929 2.47987,7.94328 1.21185,2.75701 2.72882,5.70578 3.57407,8.62433 0.56049,1.93532 1.58881,4.28121 2.38271,5.74955 1.05292,1.94739 1.7319,3.87452 2.73665,5.73283 0.10211,0.18886 0.68352,0.6443 0.74026,0.69778"
+         style="fill:none;stroke:#37260f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2701-6"
+         d="m 73.257563,139.93886 c 0.14204,1.65238 -1.67524,4.982 -2.15369,7.42951 -0.63674,3.25719 -0.80272,5.90026 -0.64079,9.55629 0.22346,5.04552 -0.62728,9.86155 -0.3979,15.0406 0.18518,4.18121 -1.14087,7.43477 -3.79384,10.4381 -0.77751,0.88019 -1.23133,1.61725 -2.02646,2.29408"
+         style="fill:none;stroke:#2f1e00;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2705-4"
+         d="m 87.514523,149.52385 c -0.44515,2.2771 -1.76711,8.14222 -2.31332,11.83365 -0.34404,2.32515 0.0652,5.04792 -0.38401,7.34587 -0.44018,2.2517 -3.09419,5.34468 -4.29352,7.16423 -1.44298,2.18923 -1.95843,3.83026 -1.84834,6.31592 0.0705,1.59145 0.42402,0.78421 0.77265,1.42901"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2707-3"
+         d="m 93.404213,154.37488 c 0.0833,1.88035 -2.79456,8.01709 -3.40751,11.15261 -0.46479,2.37756 0.24686,5.57402 0.35624,8.04364 0.128,2.89007 -0.57688,6.74909 -0.99472,9.57303 -0.32486,2.19546 0.34274,4.52507 -0.0625,6.59788"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2711-0"
+         d="m 103.41161,156.10023 c 0.0887,2.00298 1.53538,10.64245 1.72573,14.94025 0.22051,4.97889 -0.27467,11.32486 4.1709,14.0919 1.82711,1.13723 0.28814,4.57248 -0.11104,5.50103 -0.0678,0.15768 -0.22516,0.2549 -0.33775,0.38233"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2713-5"
+         d="m 109.37996,154.719 c -0.24687,0.57426 4.23584,7.54993 4.39529,11.15022 0.19265,4.34975 0.53033,7.35861 2.62561,11.23386 1.08753,2.01141 0.8948,4.187 0.99935,6.54771 0.0983,2.2198 0.0449,4.49092 0.64541,6.56443 0.44755,1.54532 0.21714,0.30524 0.75646,1.06341"
+         style="fill:none;stroke:#3c2600;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2717-4"
+         d="m 118.96633,146.93824 c 0.28767,6.49505 8.59868,13.27568 10.44693,19.65746 0.81946,2.82949 -0.0793,6.2178 0.0509,9.15721 0.0639,1.44222 0.24735,2.13584 0.85362,3.25712"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2719-1"
+         d="m 124.70798,140.43833 c 0.11083,2.5022 3.86357,11.82641 5.68381,16.21872 0.39712,0.95824 0.79424,1.91652 1.19135,2.87476 1.59705,3.85372 2.42337,7.87245 4.73304,10.76787"
+         style="fill:none;stroke:#3c2600;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2721-4"
+         d="m 81.217683,127.47194 c 0.0508,1.14769 0.20659,4.66446 0.30767,6.94679 0.0991,2.23671 0.15704,3.66362 -0.83511,5.16885"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2723-5"
+         d="m 86.205183,127.96901 c 0.0638,1.44061 0.23972,5.41256 0.35625,8.04362 0.0768,1.73471 -1.29931,3.67803 -1.91311,4.85344"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2727-8"
+         d="m 97.917503,128.14823 c 0.0784,1.76991 1.541651,6.71918 2.190697,9.42247 0.2719,1.13247 0.44507,2.04083 0.49968,3.27386"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2729-5"
+         d="m 104.35314,129.30962 c 0.17099,0.71217 0.9191,4.73596 1.04792,7.64457 0.0594,1.3406 0.11875,2.6812 0.17813,4.02181"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2733-1"
+         d="m 117.09487,128.70743 c 0.0545,0.22712 2.30578,4.58818 3.12297,6.44734 0.29431,0.66954 0.52694,1.1988 0.78884,1.79463"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2737-9"
+         d="m 89.069073,128.56642 c 0.12259,2.76806 -0.38718,5.47666 0.35625,8.04365"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2739-9"
+         d="m 95.761493,127.51736 c 0.0286,0.64575 -0.13142,5.04101 -0.0139,7.69475 0.055,1.24169 -0.99751,2.86039 -1.23763,4.08872"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2743-6"
+         d="m 109.96755,127.94512 c 0.0318,0.71772 -0.1241,5.20626 0.002,8.06035 0.0317,0.71522 -0.17397,1.17575 -0.27297,1.84485"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2747-7"
+         d="m 76.813133,140.13721 c 0.63869,2.20532 -2.37587,3.91341 -3.28029,6.01721 -0.67168,1.56242 0.25109,5.66921 0.32387,7.31239 0.1523,3.4389 -2.7087,12.51086 -3.51856,16.65363 -0.15791,0.80778 -2.49121,2.97185 -3.00731,4.17236"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2751-9"
+         d="m 87.917033,150.60398 c -3.08574,3.49325 -5.97336,17.28443 -5.70464,23.35189 0.16926,3.82154 0.69625,8.12107 0.16424,11.71656 -0.0399,0.26968 -0.21436,0.49866 -0.32155,0.74798"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2753-0"
+         d="m 92.423373,156.25318 c -0.44696,3.02063 0.0617,10.99148 1.01785,14.97368 0.74129,3.08749 0.30332,6.96907 -0.27066,9.9052 -0.37287,1.90742 -1.52188,3.94337 -2.23467,5.60139"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2759-5"
+         d="m 113.96494,154.13594 c 0.32811,7.40812 4.82509,18.82835 7.23142,27.13713 0.26123,0.90199 0.35281,2.76674 0.49967,3.27385"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2763-9"
+         d="m 122.66532,142.36679 c 0.55965,2.33093 10.92,11.90626 12.81113,16.98102 0.77607,2.08256 0.56109,4.66048 0.66161,6.93006 0.052,1.17456 0.83809,2.90672 0.91838,4.71959"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2767-7"
+         d="m 87.685713,129.36457 c -0.7385,1.12042 -0.49103,4.92957 -0.38402,7.34585 0.0956,2.15783 -0.82651,3.33111 -1.18904,5.1856"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2765-6"
+         d="m 81.957943,128.16973 c 0.69082,1.61864 0.97795,5.14949 -0.72176,7.7282 -0.9574,1.45252 -1.95567,2.7658 -2.26705,4.87015"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2735-6"
+         d="m 83.614283,125.52675 c 0.0596,1.34651 0.22944,5.18054 0.34005,7.67802 0.0324,0.73123 0.0648,1.46249 0.0972,2.19372"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2769-8"
+         d="m 94.764453,129.03002 c 0.0663,1.49699 0.23882,5.39233 0.35625,8.04364 0.0784,1.7706 0.0719,3.42098 -0.12724,5.13541"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2725-1"
+         d="m 92.238313,128.05024 c 0.0605,1.36632 0.25844,5.83517 0.37244,8.40928 0.053,1.19619 0.009,2.19832 -0.2082,3.30731"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2771-8"
+         d="m 101.21628,130.55702 c 0.12088,2.72923 0.5874,5.25468 0.71018,8.02691 0.0694,1.56664 0.0464,3.01164 -0.15961,4.40417"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2741-9"
+         d="m 102.92119,129.01091 c 0.0148,0.33386 -1.60437,3.8162 -1.4944,6.29917 0.0902,2.03708 -0.18714,3.78279 -0.0949,5.86665"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2773-2"
+         d="m 107.84393,128.04548 c 0.1338,3.02106 -0.5681,8.15688 2.1907,9.42248 4.1645,1.91046 9.04804,3.55364 7.4188,7.34347"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2775-9"
+         d="m 116.01687,128.39198 c 1.9844,0.91034 1.14894,4.58658 2.75284,6.09845 1.71731,1.61877 3.26819,1.7182 3.39594,4.60251 0.0305,0.68942 -0.90065,1.01959 -1.35097,1.52939"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2731-5"
+         d="m 110.01613,129.04198 c 0.11619,2.62338 2.24572,5.47714 2.8338,7.92653 0.26471,1.10248 0.2143,2.28847 0.49968,3.27385"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2745-4"
+         d="m 113.82847,127.02986 c 0.0109,0.24691 3.62017,3.82821 4.1524,5.66593 0.27255,0.94109 0.42226,1.52609 0.46728,2.54261"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2777-6"
+         d="m 78.279773,149.22753 c 0.046,1.03823 -2.06499,6.97568 -2.44287,8.9087 -1.24261,6.3565 -1.55815,9.64239 -5.70695,15.29151 -2.02527,2.75766 -3.99076,5.65344 -5.29055,8.6769 -0.34539,0.80343 -0.66651,1.5504 -0.96465,2.24391"
+         style="fill:none;stroke:#130500;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2779-2"
+         d="m 88.481483,155.34031 c -1.20405,2.80077 -4.05828,6.85783 -4.83946,10.8539 -0.56376,2.88391 -0.43402,6.21665 -0.30304,9.17395 0.13063,2.94957 -1.22744,4.8716 -2.1699,7.06387 -0.71431,1.66158 -1.59845,2.3469 -1.94549,4.12219"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2749-7"
+         d="m 83.298503,146.42563 c -0.44182,2.26011 -3.13113,7.04802 -3.79384,10.4381 -0.63334,3.23987 0.66535,7.01465 0.80735,10.22064 0.15964,3.60465 -0.81674,6.68385 -3.13455,9.30776 -1.50274,1.7012 -2.4588,3.93538 -4.00434,5.68503"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2703-6"
+         d="m 79.293003,148.08049 c -0.88078,0.99711 -1.40144,8.3981 -1.2677,11.41785 0.11305,2.55259 0.54676,5.18077 -0.38401,7.34587 -1.111,2.5843 -2.35429,3.97099 -2.89396,6.7317 -0.20516,1.04946 -0.3675,1.87993 -0.57833,2.95841"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2781-7"
+         d="m 96.106163,151.31611 c -1.5676,3.64645 -0.59651,10.55611 -0.41409,14.67498 0.13797,3.11499 0.28149,6.81768 -0.64078,9.5563 -0.74717,2.21864 -1.39638,4.45234 -1.83215,6.68153 -0.4265,2.18173 -0.87626,4.2397 -0.77034,6.63134"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2783-1"
+         d="m 106.09737,152.67584 c -0.94346,4.82619 0.61347,13.85151 0.89062,20.10909 0.13382,3.0217 0.61188,5.80725 0.74257,8.75816 0.11989,2.70694 0.58792,5.26643 0.71018,8.02691 0.0108,0.24374 0.0216,0.48749 0.0324,0.73124"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2785-7"
+         d="m 114.89721,151.16078 c 0.14339,3.23762 -3.15162,6.13847 1.16128,10.20391 3.53446,3.33165 4.75296,3.09395 6.00305,7.41038 0.94242,3.25404 -0.46285,5.56568 -0.31924,8.80833 0.0702,1.58436 0.14034,3.16871 0.21051,4.75306"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2757-1"
+         d="m 105.84059,154.88628 c 0.37478,8.46227 8.30827,19.41863 8.72812,28.89833 0.0918,2.07184 0.18352,4.14369 0.27529,6.21553 0.005,0.12189 0.23595,-0.0112 0.35393,-0.0167"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2755-8"
+         d="m 102.63896,154.67122 c -1.5646,8.00365 -2.43495,17.09547 -2.00334,26.84079 0.15835,3.57519 1.71898,6.77971 1.88535,10.53609"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2709-6"
+         d="m 99.180554,156.66659 c -0.63128,4.26644 -3.798341,10.3362 -3.534741,16.288 0.10202,2.30356 0.87822,3.81286 0.98315,6.1821 0.0915,2.06681 0.14127,3.89456 0.59684,5.46757"
+         style="fill:none;stroke:#2f1e00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2787-8"
+         d="m 122.21654,148.25017 c 0.14297,3.22817 2.4705,5.7445 5.00601,8.92304 2.37455,2.97676 3.1969,8.11657 3.36587,11.93163 0.15077,3.40426 1.05532,6.51066 2.17451,9.05687 0.28076,0.63874 0.54245,1.00326 0.77265,1.42902"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2761-0"
+         d="m 118.29084,147.70292 c 0.88549,3.05747 2.20171,5.24101 5.0384,9.65428 1.46086,2.2728 0.1908,8.84543 0.87212,11.68313 0.58812,2.44953 2.11418,4.20295 2.76903,6.46407"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2715-7"
+         d="m 116.28058,150.36264 c 0.74784,2.5822 1.06903,8.62698 1.96631,12.36417 0.73152,3.04678 2.65832,4.22355 3.50929,7.16185 0.91671,3.16526 2.00298,5.18368 2.15832,8.69124 0.10059,2.27115 0.55454,4.51249 0.66161,6.93006"
+         style="fill:none;stroke:#3c2600;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2789-8"
+         d="m 94.837183,107.78165 c -1.51463,3.12926 -2.81278,3.54944 -3.41036,6.01867 -0.54674,2.25913 -1.04307,3.93618 -1.04307,7.00372 0,1.50152 6.69478,1.61624 7.823001,1.61624 2.646086,0 5.567526,-2.69374 8.344526,-2.69374"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccssc"
+         id="path2791-6"
+         d="m 81.532803,83.849388 c -6.44249,1.00711 -10.87369,7.87225 -9.92437,15.45055 0.2371,1.892792 0.78719,3.653002 1.58112,5.219292 12.49996,4.19981 16.12593,-0.47437 21.96438,-2.93607 0.38183,-1.723452 0.48006,-3.570332 0.24296,-5.463122 -0.96058,-7.66815 -7.07116,-13.17869 -13.6378,-12.3009 -0.077,0.0103 -0.1499,0.0183 -0.22629,0.0303 z"
+         style="fill:url(#linearGradient2812-2);fill-opacity:1;stroke:#130500;stroke-width:3.42857146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccssc"
+         style="fill:url(#linearGradient2810-9);fill-opacity:1;stroke:#130500;stroke-width:3.42857146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 114.43999,84.901418 c -6.48929,-0.60696 -12.37582,4.97039 -13.2011,12.56417 -0.20613,1.89666 -0.0777,3.741562 0.33224,5.458102 6.76746,4.26454 14.2292,4.36342 22.00925,2.55244 0.76821,-1.57991 1.28944,-3.34947 1.49556,-5.24612 0.83507,-7.683822 -3.82915,-14.539202 -10.40919,-15.302302 -0.0771,-0.009 -0.14981,-0.0191 -0.22676,-0.0263 z"
+         id="path2796-6" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2798-9"
+         d="m 82.588833,102.41873 c -0.47776,-3.976372 -1.96716,-4.089122 2.01727,-5.118102 2.74693,-0.7094 2.31421,2.15859 3.09477,3.771232"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2800-6"
+         d="m 109.27036,102.2464 c 1.66176,-1.34379 1.35682,-5.605182 5.38914,-4.104742 0.43033,0.16013 -0.18668,4.901612 0.23992,5.571972"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2802-1"
+         d="m 105.13352,141.20076 c 2.93097,0.60636 12.40598,2.56658 18.40963,3.80863 5.57561,1.15349 9.83108,3.13276 15.13653,4.23037 5.18914,1.07354 10.71342,3.31531 16.15928,4.44196 4.69221,0.97074 10.05929,3.17998 15.13652,4.23037 8.10594,1.67698 7.30205,3.08386 2.86205,7.18546 -7.35901,6.79815 4.19521,5.31196 4.29447,5.28402 1.96003,-0.55163 3.38655,-6.49393 1.2262,4.64925 -1.25465,6.4715 -6.53967,3.04262 -12.06964,1.89857 -5.53098,-1.14426 -10.59462,-2.41096 -13.90894,-5.0753 -3.73215,-3.00021 -8.31769,-4.65116 -12.47652,-6.97674 -5.41648,-3.02883 -10.00394,-4.03082 -14.72687,-6.3434 -4.91091,-2.40463 -9.79851,-3.06263 -13.90894,-5.0753 -2.56803,-1.25744 -5.53919,-8.93638 -6.13377,-12.25789 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.49779892;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2814-8"
+         d="m 167.68183,164.28483 c -1.86327,1.47682 -3.87086,5.75833 -4.69379,9.15872 -0.79954,3.3037 3.04484,4.24463 5.21533,5.92623 1.82935,1.4173 6.98791,0.53875 9.38759,0.53875 2.47391,0 3.55043,-3.35678 4.17227,-5.92623 0.55943,-2.3116 0.52153,-4.92029 0.52153,-7.54247 0,-2.76288 -4.63052,-8.08123 -6.77993,-8.08123 -2.70774,0 -5.14599,5.37316 -7.823,5.92623 z"
+         style="fill:url(#linearGradient2822-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4063-5"
+         d="m 75.428583,78.476188 c 2.95914,-2.50427 9.73171,-4.03938 14.47619,-5.33333"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4065-9"
+         d="m 107.80953,74.666668 c 2.15864,-0.87008 7.90175,1.56069 10.66667,2.66666 0.91915,0.36766 1.91664,1.07379 2.66667,1.52381"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="q">
+      <rect
+         y="0"
+         x="200"
+         height="200"
+         width="200"
+         id="rect5056-4"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path2901-0"
+         d="m 236.05081,108.07946 c -3.63973,17.98871 -2.38687,34.80685 -16.20264,49.50303 -8.90333,9.28155 -4.18375,28.44858 8.26516,17.03677 13.54195,-10.23619 22.19631,-2.1647 36.79003,-4.96836 19.62014,4.5953 49.19054,9.49779 70.02323,6.96213 22.49327,-9.96108 39.58161,11.71025 50.09875,-7.52046 -5.16347,-13.36414 -20.35832,-19.76076 -18.99545,-38.32677 1.76301,-22.60476 -9.21524,-49.131249 -30.59752,-59.023409 -17.88217,-6.52548 -39.88302,-8.94871 -57.39638,-0.47055 -10.46246,1.40054 -34.3536,43.331849 -41.98518,36.807619 z"
+         style="fill:url(#linearGradient2944-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2950-4"
+         d="m 239.79606,129.8858 c 0.77619,2.20047 0.62378,7.8967 0,11.63946 -0.43375,2.60259 -2.2076,4.3965 -2.77124,6.65113 -0.59396,2.37588 -2.77294,4.06684 -3.87974,5.5426 -1.63366,2.17826 -2.89351,4.00209 -4.43399,5.5426 -2.10799,2.10804 -1.34117,4.37591 1.1085,4.98834 1.67177,0.41795 6.04622,-2.75867 8.31373,-3.32556 2.39723,-0.59932 3.87974,-5.76723 3.87974,-7.75964 0,-1.96445 2.28132,-4.00848 3.32549,-6.09686 1.33544,-2.67096 2.5272,2.0847 2.21699,3.32556 -0.7817,3.12685 1.42684,5.86096 2.77124,7.20538 2.99251,2.99258 6.09673,-4.26211 6.09673,-4.98834 0,-3.71474 2.54797,-1.55509 3.87974,1.10852 1.00335,2.00675 1.15498,4.48057 2.77124,6.09686 0.29211,0.29212 0.3695,0.73901 0.55425,1.10852"
+         style="fill:none;stroke:#000000;stroke-width:1.82857168;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2952-0"
+         d="m 358.95946,136.53692 c 2.3551,2.35516 -0.25355,6.74544 0.55424,9.97669 0.8985,3.59405 3.3665,6.13786 5.54249,8.3139 1.65654,1.65658 2.94812,4.0567 4.43398,5.5426 1.54586,1.54589 2.27857,3.57189 2.77124,5.5426 0.83037,3.32152 -1.37651,2.84286 -3.87974,2.21704 -3.10361,-0.77592 -8.05028,-4.46144 -9.42221,-7.20538 -1.17407,-2.34818 -2.3188,-4.63769 -3.3255,-6.65112 -2.09722,-4.19455 -4.30065,-2.35038 -6.09673,-0.55426 -2.90985,2.90991 -3.87974,2.1863 -3.87974,6.65112 0,2.74437 -1.10681,2.49333 -3.87973,3.87982 -2.97791,1.48899 -4.56659,2.56047 -7.20523,3.87982"
+         style="fill:none;stroke:#000000;stroke-width:1.82857168;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2374-6"
+         d="m 302.71887,43.943261 c -26.53598,0 -48.07501,31.32918 -48.07501,69.940749 0,38.61157 31.23891,69.28255 48.07501,69.94982 15.87379,0.62914 48.07503,-31.33824 48.07503,-69.94982 0,-38.611569 -21.53905,-69.940739 -48.07503,-69.940749 z"
+         style="fill:url(#linearGradient2382-0);fill-opacity:1;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3412-2"
+         d="m 299.51403,119.07221 c -0.82886,8.82491 -9.54159,19.20139 -3.12041,24.95407 3.66256,3.28127 9.82405,2.2602 11.86837,2.2602"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsscsssss"
+         id="path3433-2"
+         d="m 300.59355,42.791091 c -15.59707,-0.1484 -39.23599,3.18305 -47.61233,18.23197 -9.94854,19.95926 -18.31861,22.15947 -15.3567,46.082309 2.17762,17.58835 16.26241,30.92755 17.4349,17.39377 0.85559,-9.87586 3.50144,-26.939189 7.23376,-36.388109 6.33185,-19.91146 19.0705,-26.78053 40.00158,-27.48134 22.61469,-0.75718 35.17611,7.35495 42.77695,25.08427 6.76748,15.785499 1.73822,28.209219 8.03774,42.731089 1.90951,4.40186 13.6383,-13.9347 8.64203,-43.188899 -4.81965,-35.46703 -28.99587,-39.09721 -61.15793,-42.46506 z"
+         style="fill:#402000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2823-7"
+         d="m 346.64213,124.76919 c -2.07921,2.11711 -3.64218,10.95381 -3.64218,21.5293 0,12.15294 2.06469,22.01922 4.60496,22.01922 2.54026,0 4.60495,-9.86628 4.60495,-22.01922 0,-8.06065 -0.90957,-15.1074 -2.2616,-18.94361 3.03682,4.96979 5.16808,16.56906 5.16808,30.0757 0,18.02909 -3.80385,32.6614 -8.48329,32.66139 -4.67943,0 -8.47421,-14.6323 -8.47421,-32.66139 0,-18.02909 3.79478,-32.66139 8.47421,-32.66139 0.003,0 0.006,-2e-5 0.009,0 z"
+         style="opacity:0.98999999;fill:#a0a000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path4323-2"
+         d="m 322.75018,154.82239 c -0.89702,0.41978 -11.61548,4.4757 -19.67162,4.60909 -7.22428,0.11961 -17.08891,-3.36669 -18.23068,-3.65165"
+         style="fill:none;stroke:#000000;stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscsssc"
+         id="path1928-7"
+         d="m 236.40463,115.80002 c 11.22802,-23.917369 37.01504,-47.550289 68.52902,-45.631999 22.12646,1.34686 51.37881,13.04053 59.94488,44.495429 8.57058,-12.4026 2.32072,-23.679499 -2.28515,-41.915859 -6.14453,-24.3284 -28.57691,-46.17238 -60.31456,-45.39069 -31.75878,0.7822 -50.16583,18.89624 -57.50093,43.91292 -5.89126,20.09242 -12.2522,17.6582 -8.37326,44.530199 z"
+         style="fill:url(#linearGradient2936-4);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#a0a000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 255.10666,123.96558 c -2.07921,2.11712 -3.64219,10.95382 -3.64219,21.52931 0,12.15294 2.06469,22.01922 4.60496,22.01922 2.54026,0 4.60496,-9.86628 4.60496,-22.01922 0,-8.06065 -0.90958,-15.1074 -2.26161,-18.94361 3.03682,4.96979 5.16809,16.56906 5.16809,30.0757 0,18.02909 -3.80386,32.6614 -8.4833,32.66139 -4.67943,0 -8.47421,-14.6323 -8.47421,-32.66139 0,-18.02909 3.79478,-32.6614 8.47421,-32.6614 0.003,0 0.006,-1e-5 0.009,0 z"
+         id="path2828-5" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 297.49097,109.18643 c 1.57362,2.29269 -0.0639,4.46234 -1.7474,6.73509 -6.2051,2.79307 -18.40681,4.36645 -26.78441,-2.79722 -4.70777,-4.02561 6.46981,-10.33129 14.4572,-10.16799 9.08642,0.18011 11.56432,2.57277 14.07461,6.23012 z"
+         id="path2860-1"
+         sodipodi:nodetypes="ccsss" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:#713e01;stroke-width:13.15185261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path2862-9"
+         sodipodi:cx="361.66666"
+         sodipodi:cy="545"
+         sodipodi:rx="20"
+         sodipodi:ry="20"
+         d="m 381.66666,545 a 20,20 0 1 1 -40,0 20,20 0 1 1 40,0 z"
+         transform="matrix(-0.2368784,-0.00369816,-0.00419688,0.18354903,372.43798,12.735891)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 295.46948,104.52742 c -0.18142,-0.79881 1.16947,-3.19582 1.51283,-4.40123"
+         id="path2864-0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 289.28307,101.65096 c 0.22832,-1.16564 0.6858,-5.682919 0.58778,-7.491229"
+         id="path2866-0"
+         sodipodi:nodetypes="cs" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 282.75137,100.7352 c 0.0717,-0.25172 -1.47328,-6.169209 -0.77069,-11.296229"
+         id="path2868-6"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 276.05167,102.57566 c 0.0112,-0.34569 -2.63744,-4.336089 -2.90461,-5.571559 -0.38708,-1.78989 -0.5207,-3.97975 -0.85052,-5.50491"
+         id="path2870-2"
+         sodipodi:nodetypes="css" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 270.24658,105.02703 c -0.20228,-0.41123 -2.47714,-0.95812 -2.95217,-3.16619 -0.0759,-0.35259 -1.31743,-2.565409 -1.50101,-2.875919"
+         id="path2872-0"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2874-2"
+         d="m 256.54086,119.31652 c -1.26336,9.02521 -4.59832,26.21981 2.71071,21.2151 4.63503,-3.17374 -2.2364,-11.36317 2.12825,-24.76293"
+         style="fill:url(#linearGradient2891-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2895-6);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 349.30456,120.97931 c 1.26337,9.0252 4.59832,26.2198 -2.7107,21.21509 -4.63503,-3.17374 2.2364,-11.36317 -2.12825,-24.76293"
+         id="path2893-4"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2897-9"
+         d="m 271.13079,87.269441 c 7.11907,-2.38935 14.68666,-3.88166 23.27843,-3.32556"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsss"
+         id="path2908-9"
+         d="m 307.18857,109.57835 c -1.57362,2.29269 0.0639,4.46234 1.7474,6.73509 6.2051,2.79307 18.40681,4.36646 26.78441,-2.79722 4.70777,-4.0256 -6.46981,-10.33129 -14.4572,-10.16799 -9.08642,0.18011 -11.56432,2.57277 -14.07461,6.23012 z"
+         style="fill:#808080;fill-opacity:1;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.2368784,-0.00369816,0.00419688,0.18354903,232.24145,13.127811)"
+         d="m 381.66666,545 a 20,20 0 1 1 -40,0 20,20 0 1 1 40,0 z"
+         sodipodi:ry="20"
+         sodipodi:rx="20"
+         sodipodi:cy="545"
+         sodipodi:cx="361.66666"
+         id="path2910-9"
+         style="fill:#000000;fill-opacity:1;stroke:#713e01;stroke-width:13.15185261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2912-5"
+         d="m 309.21006,104.91935 c 0.18142,-0.79881 -1.16947,-3.19583 -1.51283,-4.40124"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path2914-0"
+         d="m 315.39647,102.04289 c -0.22833,-1.16565 -0.68581,-5.682929 -0.58779,-7.491239"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2916-3"
+         d="m 321.92817,101.12712 c -0.0717,-0.25172 1.47328,-6.169199 0.77069,-11.296229"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="css"
+         id="path2918-7"
+         d="m 328.62787,102.96758 c -0.0111,-0.34569 2.63743,-4.336089 2.90461,-5.571559 0.38707,-1.78989 0.52069,-3.97975 0.85052,-5.5049"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2920-0"
+         d="m 334.43296,105.41895 c 0.20228,-0.41123 2.47713,-0.95812 2.95217,-3.16619 0.0759,-0.35259 1.31742,-2.565409 1.50101,-2.875909"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 333.54875,87.661361 c -7.11908,-2.38935 -14.68666,-3.88165 -23.27843,-3.32556"
+         id="path2922-4"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2924-9"
+         d="m 247.72344,80.859041 c 10.87663,-11.26199 34.43608,-23.475 52.50631,-22.69611 27.46749,1.18395 44.84324,10.40555 59.28395,25.16501"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="r">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect5056-11"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:url(#linearGradient3360-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 408.83651,111.60555 0,38.71019 c -0.1705,0.26226 -0.2594,0.52945 -0.2594,0.80287 0,2.91645 10.0645,5.28601 22.4613,5.28601 11.3669,0 20.7659,-1.99046 22.25,-4.56935 l 0.6292,0 0,-40.22972 -45.0811,0 z"
+         id="path3356-1" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3362-4);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:19.3214283;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3358-0"
+         sodipodi:cx="579.82758"
+         sodipodi:cy="321.0997"
+         sodipodi:rx="146.13541"
+         sodipodi:ry="30.641294"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         transform="matrix(0.15368023,0,0,0.23312411,341.92811,37.424291)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path3333-2"
+         d="m 442.45931,97.282891 0,91.342699"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3354-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 472.83021,85.820301 c -19.2843,6.91923 -36.4764,9.82768 -58.833,0.1014 9.1018,4.72028 21.9032,9.07537 29.1727,13.84148 11.6225,-6.61275 16.0903,-8.63103 29.6603,-13.94288 z"
+         id="path3344-1"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3335-2"
+         d="m 412.96821,80.962271 c 18.5954,7.80874 35.5378,9.01883 58.8299,0.60847 -9.0442,-4.82975 -21.7921,-9.33899 -29.0035,-14.19246 -11.7015,6.47203 -16.1933,8.43625 -29.8264,13.58399 z"
+         style="fill:url(#linearGradient3352-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3306-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:14.78016663;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3279-5"
+         sodipodi:cx="478.47559"
+         sodipodi:cy="691.15222"
+         sodipodi:rx="167.3486"
+         sodipodi:ry="150.84944"
+         d="m 645.82419,691.15222 a 167.3486,150.84944 0 1 1 -334.69721,0 167.3486,150.84944 0 1 1 334.69721,0 z"
+         transform="matrix(0.24144869,0,0,0.25357143,365.93191,-30.932369)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:url(#linearGradient3329-4);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 540.82361,95.354171 0,31.794789 c -0.1705,0.21541 -0.2594,0.43487 -0.2594,0.65944 0,2.39544 10.0645,4.34169 22.4614,4.34169 11.3668,0 20.7658,-1.63487 22.25,-3.75306 l 0.6291,0 0,-33.042859 -45.0811,0 z"
+         id="path3325-7" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3310-3"
+         d="m 518.00571,112.63067 0,40.56701 c -0.1963,0.27484 -0.2986,0.55485 -0.2986,0.84139 0,3.05634 11.5866,5.53956 25.8584,5.53956 13.0859,0 23.9064,-2.08593 25.615,-4.78853 l 0.7243,0 0,-42.15943 -51.8991,0 z"
+         style="opacity:0.98999999;fill:url(#linearGradient3321-7);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714455;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.24144869,0,0,0.25357143,372.39691,-22.312389)"
+         d="m 645.82419,691.15222 a 167.3486,150.84944 0 1 1 -334.69721,0 167.3486,150.84944 0 1 1 334.69721,0 z"
+         sodipodi:ry="150.84944"
+         sodipodi:rx="167.3486"
+         sodipodi:cy="691.15222"
+         sodipodi:cx="478.47559"
+         id="path3277-5"
+         style="opacity:0.98999999;fill:url(#linearGradient3298-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:14.78016663;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.17692229,0,0,0.21002446,440.97831,45.799811)"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         sodipodi:ry="30.641294"
+         sodipodi:rx="146.13541"
+         sodipodi:cy="321.0997"
+         sodipodi:cx="579.82758"
+         id="path3308-0"
+         style="opacity:0.98999999;fill:url(#linearGradient3323-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:18.97210884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3331-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:21.31934929;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3327-1"
+         sodipodi:cx="579.82758"
+         sodipodi:cy="321.0997"
+         sodipodi:rx="146.13541"
+         sodipodi:ry="30.641294"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         transform="matrix(0.15368023,0,0,0.19147749,473.91531,34.425031)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path3364-5"
+         d="m 482.44261,62.257891 c -7.82,-1.61883 -15.4664,-12.02999 -20.7157,-3.79575 -3.9485,8.88953 12.6684,13.03963 17.679,19.49034 2.2767,6.98894 -2.7432,18.69454 4.6917,23.154259 7.3928,-2.535749 25.2092,6.4227 31.2996,0.87008 -2.6643,-9.772839 6.2773,-23.338549 22.4244,-22.877809 7.0337,0.46889 11.3116,-16.6733 1.485,-14.53824 -18.0762,7.1183 -32.1401,-0.52696 -29.3451,-8.54715 -4.0826,-5.63761 -5.0833,-3.85805 -11.0465,-4.7621 -0.9551,6.94224 -4.9886,13.13394 -16.4724,11.00637 z"
+         style="fill:url(#linearGradient3388-0);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path3366-8"
+         d="m 489.98131,37.031001 c -1.1947,-6.24699 5.2505,-9.51937 10.1595,-6.28946 6.1886,2.14002 12.7974,7.45433 12.019,14.69116 0.7401,5.10086 -3.7575,11.70319 -9.2819,8.34355 -9.2733,-2.0365 -11.0818,-7.17099 -12.8966,-16.74525 z"
+         style="fill:url(#linearGradient3390-8);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssssssssssssc"
+         id="path3368-6"
+         d="m 495.89711,36.220621 c -4.1849,-1.04623 -3.2012,6.05129 -2.155,10.23621 1.1642,4.65684 2.4717,4.63487 -2.6937,5.92623 -4.175,1.04376 -2.7344,-0.22363 -7.0037,-1.07749 -4.5832,-0.91664 -3.8177,-0.62793 -8.0813,1.07749 -0.7524,0.30096 -6.0919,-1.5906 -8.0812,-1.61624 -6.2236,-0.0802 24.1369,-5.19167 12.93,-15.6237 -2.8467,-2.64985 5.7855,-6.44104 6.4649,-9.15871 1.1509,-4.60331 4.439,-3.77124 8.62,-3.77124 3.4542,0 4.9613,3.23249 9.6975,3.23249 5.1219,0 7.6884,0.68469 10.2362,3.23249 1.4774,1.47739 3.2325,8.25854 3.2325,10.77496 0,2.59866 6.3239,8.47893 7.5425,9.69746 6.2466,6.2467 1.6903,5.92623 -4.31,5.92623 -10.5163,0 -3.1846,-1.56837 -8.0813,-6.46497 -1.5923,-1.59231 -2.1328,-6.42077 -3.2324,-8.61997 -0.3133,-0.62643 -5.5976,-4.52008 -6.465,-5.38748 -1.698,-1.69798 -1.7776,-2.69374 -5.3875,-2.69374 -3.1766,0 0.615,3.54048 -3.2325,4.30998 z"
+         style="fill:url(#linearGradient3398-1);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3400-7"
+         d="m 466.26601,59.925531 -21.0112,-12.3912"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3402-1"
+         d="m 540.07451,71.239241 25.3211,-11.85245"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="b">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect5056-71"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.20911451,0,0,0.18432023,617.55919,-21.581012)"
+         d="m 584.54161,889.14215 a 212.13203,292.27081 0 1 1 -424.26407,0 212.13203,292.27081 0 1 1 424.26407,0 z"
+         sodipodi:ry="292.27081"
+         sodipodi:rx="212.13203"
+         sodipodi:cy="889.14215"
+         sodipodi:cx="372.40958"
+         id="path3173-7"
+         style="fill:url(#linearGradient4056);fill-opacity:1;stroke:#000000;stroke-width:23.28484535;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccssc"
+         id="path2899-8"
+         d="m 669.09939,118.06983 c -4.5078,-29.197372 -24.5661,-42.233322 -41.9226,-73.666112 11.4297,-4.77019 24.5214,3.8145 33.9586,15.62662 -1.9888,-11.84117 -0.9555,-27.20763 -4.075,-41.4109 9.9577,5.97928 20.7816,24.29493 25.6994,33.17176 2.4205,-7.9625 7.5757,-28.77817 5.4267,-43.0623097 11.537,8.5771897 10.4623,30.4459097 13.9504,41.0572297 1.0346,-3.97654 9.461,-26.25689 11.7993,-40.6227697 10.1277,8.0921897 6.0856,28.2438997 9.3004,38.0704397 6.5083,-2.49757 13.9089,-16.85334 17.4713,-27.13414 11.7407,14.86377 -0.128,26.39275 21.6656,30.06015 -17.5488,26.43762 -38.5057,24.2048 -34.7041,54.444252 0.5343,8.43216 -7.9463,-4.04268 -15.1603,-5.951802 -13.1616,-3.48314 -17.4627,-1.58152 -29.8827,4.240402 -6.4878,3.04115 -10.9441,7.46856 -13.527,15.17718 z"
+         style="fill:url(#linearGradient2914);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccccccccccc"
+         id="path4058-6"
+         d="m 645.56449,120.84525 c 15.355,-9.34386 2.8246,0.36289 3.9472,0.35872 3.1926,-0.0119 5.181,-0.61908 9.0111,1.63656 9.3035,3.19057 19.3585,1.72163 28.9147,3.53502 14.6814,1.16311 29.9245,-1.61562 42.5783,-9.17782 4.4715,-2.05559 13.4279,27.07989 10.0149,30.82546 -2.9062,3.30319 -1.7233,-16.26102 -15.3334,-21.21174 -6.5787,0.38478 -12.6002,3.24305 -18.8312,4.99481 -4.5241,0.67268 -10.1864,-0.50614 -13.4504,3.43995 -3.8237,5.16178 1.0067,12.42943 -3.5097,17.33497 -4.2357,4.54627 -13.2123,4.47738 -16.6413,-0.95084 -2.0252,-3.55971 -1.4925,-8.23666 -4.5579,-11.27328 -4.8984,-1.38003 -5.8195,4.98391 -7.9856,7.79036 -3.1089,4.02979 -10.5736,3.08678 -12.1571,-1.8653 -3.835,-7.82968 -5.1431,-17.16225 -1.9996,-25.43687 z"
+         style="fill:url(#linearGradient4077);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path4079-1"
+         d="m 660.14569,149.64855 c 1.5694,4.20615 -3.1242,13.76968 -5.2283,17.88332 -3.9676,7.75716 6.9119,6.8146 12.5479,6.8146"
+         style="fill:url(#linearGradient4106);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4083-0"
+         d="m 718.70269,131.93058 c -0.2574,0.50335 2.6841,13.42514 4.1827,16.35505 4.6564,9.10392 -6.8251,9.58801 5.5768,13.6292 4.6069,1.50118 6.9711,-9.67642 6.9711,-13.6292 0,-8.83856 0.3,-12.11964 -5.5769,-14.99213 -8.4237,-4.11733 -4.529,6.13739 -2.7884,9.54045"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4085-8"
+         d="m 729.68759,156.70675 c -5.0644,1.11577 -8.6286,6.0213 -8.1367,11.54888 0.5336,5.99601 5.6338,10.46757 11.3841,9.97854 5.7504,-0.48903 9.984,-5.75437 9.4504,-11.75038 -0.3577,-4.01962 -2.7635,-7.35046 -6.0457,-8.96399 1.7952,1.26526 3.0596,3.34734 3.2762,5.78148 0.3773,4.23907 -2.5665,7.95854 -6.5693,8.29896 -4.0028,0.34041 -7.5594,-2.82625 -7.9367,-7.06532 -0.3112,-3.49722 1.6386,-6.64453 4.5777,-7.82817 z"
+         style="fill:url(#linearGradient4098);fill-opacity:1;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="n">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect5056-39"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssccscssssc"
+         id="path9661-9"
+         d="m 920.82051,91.841942 c 0.049,17.483928 -20.16603,32.606288 -40.10424,24.990548 -3.05344,-1.16631 -30.75842,23.95504 -35.19852,20.51791 -3.50284,-2.71159 3.88081,-13.88996 3.34402,-12.46222 -2.55582,6.79793 -13.83929,14.36436 -22.90059,4.59712 -3.5436,-3.81967 -2.44779,-14.80596 5.18493,-23.75613 7.94898,-9.321018 16.02019,-23.674758 19.14441,-31.953348 6.28396,-16.65129 3.81839,-17.015 15.8609,-32.11561 2.26234,-2.83684 -3.67739,-13.85043 -1.51858,-21.03944 8.52749,1.52073 11.81479,10.09428 15.7361,13.69224 2.28585,-5.29182 0.74992,-19.5111 4.81349,-18.84852 4.06357,0.66257 8.73774,12.98093 15.4412,18.39137 80.28856,24.70763 79.63224,153.189418 57.19345,153.605678 -27.69633,0.51379 -60.85496,0.39751 -88.70967,-0.0463 -6.74914,-0.10753 -9.87347,-8.83916 -8.57204,-14.05721 6.20686,-24.88642 32.41901,-42.30553 45.25898,-50.93792 13.18793,-8.86634 15.60253,-17.57941 15.02616,-30.578178 z"
+         style="fill:url(#linearGradient2319-0);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path31300-9"
+         d="m 834.46198,118.46619 c -3.16681,-1.09379 -5.45787,4.00845 -3.43731,4.21661"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path31308-7"
+         d="m 872.42883,108.41242 2.16857,2.69497"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path31312-9"
+         d="m 920.85784,84.396782 0.0665,-5.69551"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path32040-6"
+         d="m 874.48657,37.177012 -2.31158,1.20709"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path32768-3"
+         d="m 886.69031,24.885392 c 6.89194,9.62746 9.38036,11.57494 1.18548,10.19359"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2732-0"
+         d="m 900.1479,166.74312 -5.89252,14.05538"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path1898-6"
+         d="m 850.60982,59.223562 c 11.26404,2.55861 38.14752,3.77999 60.58139,-0.76311 4.70064,-0.95194 12.95819,0.11144 4.15822,2.18847 -9.48449,2.2386 -15.02058,3.19686 -24.43738,4.31759 -9.67053,1.15093 -13.07282,7.30325 -15.94626,15.89671 -1.70175,5.08936 -15.19947,2.56171 -15.69878,-1.73142 -2.61958,-22.52343 -13.25929,-13.16063 -8.65719,-19.90824 z"
+         style="fill:url(#linearGradient2802-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssccccccscccs"
+         id="path2812-6"
+         d="m 904.20152,31.176182 c -1.54791,8.07417 6.42833,42.46312 4.49936,66.99894 -1.35362,17.217538 -18.03189,43.652678 -15.54781,61.309418 0.80004,5.68669 14.33186,-13.02936 14.72824,10.88373 12.44808,3.14376 16.76474,-17.02112 19.71601,1.73792 14.58114,10.26285 4.32214,-27.5192 13.31719,-34.61166 6.04367,9.09426 -4.24493,38.73822 6.34353,35.65725 -1.02372,-11.0541 7.85547,-24.8993 9.06548,-6.32385 10.23714,14.25631 11.26019,-18.50012 16.51637,-25.21798 -5.68876,-26.18129 -0.68625,-38.45221 -9.84533,-57.779668 -1.45105,-3.06202 -6.33113,-14.59604 -9.36782,-17.92597 -2.57493,-6.16549 -11.81457,-11.43535 -14.53084,-13.39961 -1.68084,-6.55522 -15.27929,-15.54515 -19.39761,-12.65192 -3.18859,-7.61953 -14.88246,-11.88098 -15.49677,-8.6766 z"
+         style="fill:url(#linearGradient2826-8);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2828-8"
+         d="m 920.67955,48.573522 c 3.15338,11.44401 5.37018,28.14888 4.07533,39.91939 -1.96753,12.163558 -6.32601,24.109388 -5.24525,36.604888 0,2.41437 3.77123,20.45243 3.77123,22.8668"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2830-3"
+         d="m 938.01193,61.095452 c 3.88951,9.34941 6.96851,27.1909 4.51389,37.59389 -1.16296,8.889578 1.46507,17.276118 -1.37384,25.831788"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2832-3"
+         d="m 954.08193,84.931082 c 0.52223,8.38054 3.89125,23.359228 2.49888,32.011308 -0.19171,7.57801 5.07664,18.32521 2.99474,25.71768 -0.44245,2.06841 -0.96292,4.12734 -1.72238,6.10472"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2846-5"
+         d="m 848.05585,126.8312 c 7.73207,6.73917 15.9703,4.28414 24.44698,9.88665 9.88036,-0.31231 11.56689,18.80793 0.59986,15.67298 -5.88378,-4.88778 -24.1971,-16.09221 -31.07341,-19.50032 3.32611,-4.1301 0.83834,0.20797 6.02657,-6.05931 z"
+         style="fill:url(#linearGradient2862-4);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714502;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2814-72"
+         d="m 872.04308,143.23456 c -1.08081,0.85665 -2.24534,3.34019 -2.7227,5.31263 -0.46377,1.91636 1.7662,2.46216 3.02522,3.43759 1.06114,0.82213 4.05344,0.31251 5.4454,0.31251 1.43503,0 2.05948,-1.94715 2.42019,-3.43759 0.3245,-1.34087 0.30252,-2.85408 0.30252,-4.37511 0,-1.60265 -2.686,-4.68762 -3.9328,-4.68762 -1.57065,0 -2.98499,3.11677 -4.53783,3.43759 z"
+         style="fill:url(#linearGradient2822-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.60900903;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="p">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect9996"
+         width="200"
+         height="200"
+         x="1000"
+         y="0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscccccccscc"
+         id="path35274-0"
+         d="m 1087.7986,83.997582 c -4.4788,0.057 -8.9742,1.92359 -8.9444,5.30162 0.3318,38.415138 -19.5945,28.092838 -28.9093,34.672698 -7.724,5.45618 1.9511,62.71336 12.2,63.38363 6.3508,0.41533 46.6372,2.48448 52.7341,-0.0404 2.2015,-0.91169 5.1041,-34.70066 5.3743,-34.66821 10.443,0.54708 17.4615,12.49765 27.905,13.15861 6.3761,1.59674 8.7275,-4.41463 7.1582,-9.53214 1.0306,-10.73186 -0.1967,-45.22267 -5.2105,-45.85224 -5.6103,-0.8497 -11.0442,8.07405 -10.2114,12.58745 -0.24,7.05377 1.3331,8.10854 -1.7727,14.72597 -3.9383,3.71361 -6.7692,-4.43961 -8.5063,-6.08979 -0.6803,0.91016 -1.1599,-7.28717 -1.6783,-8.31956 -6.2762,-12.4992 -30.7607,6.12865 -31.2819,-33.951898 -0.049,-3.73056 -4.4474,-5.43186 -8.8568,-5.37572 z"
+         style="fill:url(#linearGradient2296-2);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006442;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.16426994,0,0,0.19426503,1018.6196,-3.285667)"
+         d="m 540.00002,435 a 116.66667,116.66667 0 1 1 -233.33335,0 116.66667,116.66667 0 1 1 233.33335,0 z"
+         sodipodi:ry="116.66667"
+         sodipodi:rx="116.66667"
+         sodipodi:cy="435"
+         sodipodi:cx="423.33334"
+         id="path3371-8"
+         style="opacity:0.98999999;fill:url(#linearGradient3243-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:19.31306076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccsc"
+         id="path4628-4"
+         d="m 1066.2082,111.5353 c -5.2679,3.46199 -12.8574,6.44012 -15.6645,7.72675 7.1256,8.54835 39.7004,58.01413 41.0251,70.8332 3.7493,0.37746 11.3426,0.40399 19.4728,0.31662 -2.3334,-10.92307 -37.1248,-65.44492 -44.8334,-78.87657 z m 41.4126,1.10478 c -6.5029,13.69535 -47.7254,68.11909 -49.7255,77.64379 7.8235,-0.13368 15.0327,-0.29389 18.637,-0.26272 0.5111,-4.55693 41.0224,-66.61349 45.6611,-71.38559 -8.2398,-6.26594 -8.6486,-4.11225 -13.6694,-5.72602 -0.2987,-0.096 -0.598,-0.18391 -0.9032,-0.26946 z"
+         style="fill:url(#linearGradient2294-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006371;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccsscccccccscc"
+         id="path3219-5"
+         d="m 1085.9229,62.601042 c -10.5947,0.67991 -14.5464,13.09545 -13.2879,21.51918 -0.7143,8.47929 3.9134,17.553168 5.4848,25.776188 -4.3211,8.81198 -9.9164,-14.264458 -11.1653,-5.93671 2.0548,6.61616 -0.6721,13.71458 -8.5969,10.69479 -7.9876,3.91619 -10.4614,-4.60016 -3.9905,-8.52764 2.6192,-7.319508 -17.6221,4.19009 -8.7281,-4.74548 7.3437,-4.381568 12.2019,-9.901138 12.887,-18.445228 1.0512,-10.61098 5.8864,-20.1017 13.2245,-27.1306 5.8116,-5.56671 15.8721,-5.83986 22.9953,-3.69512 7.6759,2.31116 11.2339,6.86363 15.1627,12.98718 3.1308,6.66953 4.6297,14.01591 7.8401,20.72008 1.5125,9.27168 6.4068,15.787298 14.4546,20.919788 1.5274,4.67776 -8.7611,3.91174 -11.484,6.48789 -2.7603,-1.38374 -5.2003,-10.91793 -5.3535,-2.77368 2.9314,9.19519 -15.9269,12.79595 -14.1532,3.16118 2.6352,-3.51122 3.3803,-8.27584 -2.4024,-4.13274 -3.7018,-1.96394 3.1458,-12.450948 3.846,-18.267078 0.8896,-7.38919 1.6506,-10.72389 -1.3259,-17.75722 -3.365,-5.04961 -8.7201,-11.45246 -15.4073,-10.85478 z"
+         style="fill:url(#linearGradient3230-7);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006442;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssssssss"
+         id="path2957-3"
+         d="m 1092.0357,154.0227 c 0.8912,1.12956 20.8982,0.7212 17.3432,9.63672 -1.6101,4.03809 -13.7295,4.54253 -17.2468,6.22418 -5.9437,2.84172 -10.1606,8.69724 -11.4656,15.24429 -1.0358,5.19637 -2.2547,9.73552 -7.5473,12.06916 -12.3342,5.43853 -8.1434,-8.92071 -10.2544,-14.94663 -1.9674,-5.61632 -10.6373,-5.40474 -14.3007,-10.31363 -1.6933,-2.26903 -1.0242,-5.9833 1.8112,-7.34831 5.2639,-2.53425 10.6512,-2.57578 16.0014,-3.99944 5.0236,-1.3368 12.6641,-9.48165 13.6953,-14.08526 1.9967,-8.91449 1.42,-20.03157 10.3485,-21.68279 4.3243,-0.79973 5.5404,10.31254 5.2234,14.28181 -0.4074,5.10117 -4.438,13.86808 -3.6082,14.9199 z"
+         style="fill:url(#linearGradient2983-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19235921;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2967-5"
+         d="m 1072.6926,177.26177 81.9198,-69.187 -1.9507,-8.705658 -84.6507,72.568198 4.6816,5.32446 z"
+         style="fill:url(#linearGradient2975-2);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19236016;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc"
+         id="path1395-5"
+         d="m 1052.5332,121.68823 c -1.5744,0.23051 -2.9996,0.82938 -4.1183,2.14894 -1.0028,2.59597 -0.774,5.55095 -2.0289,8.09053 -3.9902,9.66061 -6.4912,19.8557 -10.589,29.47888 -3.6278,5.47842 1.2614,9.69275 6.6122,9.91611 9.7836,4.54145 20.358,7.49906 30.9853,9.07405 4.0784,-0.66359 10.0594,1.41728 12.3214,-3.09879 2.6681,-5.00514 -2.2517,-8.72133 -6.7876,-9.43782 -6.5759,-2.57277 -14.2012,-3.5951 -19.4121,-8.72375 -2.194,-4.94731 -0.4698,-10.36434 1.3481,-15.08974 -0.1733,-3.12306 1.3565,-4.06513 3.4915,-5.15341 -4.4978,-6.71253 -8.4152,-12.97403 -11.8226,-17.205 z"
+         style="fill:url(#linearGradient2292-2);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.4500649;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2985-4"
+         d="m 1154.5662,107.51131 20.6161,-3.13491 -2.0086,-17.957738 -22.1866,14.007968 3.5791,7.08468 z"
+         style="fill:url(#linearGradient2993-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19235969;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4122-2"
+         d="m 1079.8163,80.210582 c 0.3348,0.2053 3.4142,-0.85305 4.31,-1.07688"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4124-5"
+         d="m 1089.5138,79.133702 c 0.8979,-0.17948 1.7958,-0.35896 2.6937,-0.53844 0.7917,-0.15824 1.8687,0 2.6938,0"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1086.2813,91.517842 c 0.3347,0.2053 3.4141,-0.85305 4.31,-1.07688"
+         id="path4128-9" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="K">
+      <rect
+         y="200"
+         x="0"
+         height="200"
+         width="200"
+         id="rect5056"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.21236206,-0.01003656,0.00971585,0.21937189,-18.21667,189.42362)"
+         d="m 716.66667,558.33331 a 196.66667,293.33334 0 1 1 -393.33334,0 196.66667,293.33334 0 1 1 393.33334,0 z"
+         sodipodi:ry="293.33334"
+         sodipodi:rx="196.66667"
+         sodipodi:cy="558.33331"
+         sodipodi:cx="520"
+         id="path4289"
+         style="fill:url(#linearGradient2695);fill-opacity:1;stroke:#000000;stroke-width:20;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2569"
+         d="m 76.3713,258.08777 c -0.50817,-0.74198 -4.68974,-1.34054 -7.1759,-1.85917 -1.65376,-0.34498 -3.97427,0.18783 -5.66299,0.26764 -2.52629,0.1194 -5.18771,1.16436 -7.35172,2.17939 -4.25762,1.99703 -7.28314,5.17336 -10.59961,8.92781 -2.04673,2.31704 -3.04436,4.74883 -4.64744,7.18096 -1.5061,2.28498 -2.11237,3.78998 -4.35829,5.70176 -2.36797,2.01569 -4.07573,3.97245 -5.74165,6.49991 -1.00726,1.52818 -0.98299,3.89971 -1.54298,5.20232 -0.71242,1.65717 -1.24173,2.76434 -1.57537,4.47108"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2573"
+         d="m 70.96971,272.2657 c 0.0826,1.8643 -3.50699,0.89852 -5.26048,1.34777 -4.84076,1.24024 -7.18224,5.34856 -8.07347,9.90758 -0.78554,4.01838 -1.77183,8.15253 -3.72907,11.90057 -1.80182,3.45044 -4.07478,6.83239 -6.28759,10.18957 -1.85112,2.80844 -2.52378,6.67721 -3.82622,9.70685 -1.93338,4.49727 -3.21825,9.8531 -4.67753,14.51009 -1.16738,3.72548 -2.65291,8.18941 -3.37512,11.88384 -0.72313,3.6991 -2.10541,7.31718 -3.43991,10.42137 -0.83724,1.94754 -1.88435,4.25783 -2.21847,5.96701"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2577"
+         d="m 62.58855,331.28345 c -2.40744,3.65247 -2.95708,7.15832 -3.71287,12.26619 -0.55013,3.71795 0.33887,7.68603 -0.20589,11.36767 -0.66446,4.49063 -3.1847,8.66743 -4.03442,13.01416 -0.45996,2.35287 -0.95163,4.04501 -2.21847,5.96702 -1.16262,1.76386 -2.63674,4.11695 -3.29648,5.65157 -0.73684,1.714 -1.26458,2.89253 -3.03969,3.44113"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2579"
+         d="m 79.33003,252.81854 c -0.56914,1.32389 -7.35406,-1.92319 -8.97797,-2.50677 -2.93524,-1.05482 -5.78601,-1.56923 -8.60784,-2.15787 -3.47025,-0.72391 -8.15423,0.38538 -11.67993,0.55201 -3.7625,0.17782 -5.08348,-0.004 -6.99777,2.16265 -2.0132,2.27907 -4.629,4.08846 -6.46572,6.16774 -0.11258,0.12745 -0.22516,0.2549 -0.33774,0.38235"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2581"
+         d="m 87.79213,251.68584 c -0.0405,0.0459 -8.59686,-7.40287 -8.85074,-7.64218 -1.60836,-1.51607 -17.91692,-7.21369 -19.46885,-7.14035 -0.87347,0.0413 -8.44425,-12.05801 -9.39898,-12.01289"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2585"
+         d="m 91.67155,251.18819 c -0.0695,-0.23991 3.40608,-12.42141 3.66429,-13.36306 2.19368,-7.99997 -2.53256,-14.2733 0.47655,-21.27287"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2591"
+         d="m 97.74261,252.12614 c -2.4862,1.43445 3.06195,-7.76901 5.01527,-14.89244 1.40913,-5.13886 9.59196,-10.0908 12.86666,-13.79797 1.01516,-1.14923 2.69286,-1.81799 3.77996,-2.74335"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2593"
+         d="m 101.88484,249.55426 c 1.07137,-1.21286 3.95312,-6.39494 6.33617,-9.09271 3.58723,-4.06098 8.94088,-10.083 14.02563,-11.65443 2.92174,-0.90296 6.44669,-0.67107 9.54011,-0.81727 1.06181,-0.0502 2.12362,-0.10036 3.18543,-0.15054"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2597"
+         d="m 116.25283,253.63821 c 0.66509,0.37062 10.49463,-1.25207 13.44962,-0.63565 3.4238,0.71422 6.2823,2.48781 9.71823,3.20456 4.27015,0.89077 8.50215,-3.44257 12.33921,-1.68233 2.32339,1.06586 10.45078,5.20815 13.01702,5.61335"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2599"
+         d="m 119.77832,261.16569 c 2.10834,0.96719 19.61756,-0.0338 26.69102,2.036 2.86878,0.83944 5.39982,3.19354 8.72119,4.71722 3.35699,1.54001 5.14643,4.71594 7.08106,7.72582 2.1929,3.41168 3.91291,6.56567 5.76246,9.98644 0.0814,0.15063 0.24675,0.2326 0.37013,0.34889"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2601"
+         d="m 125.58705,264.18862 c 1.90834,3.5295 13.25449,7.52866 18.55278,10.48111 3.80338,2.11942 6.5545,5.83088 7.53215,9.90281 1.32974,5.53838 2.88288,12.45266 6.07013,16.93322 1.97792,2.78052 1.61005,5.99886 3.23632,9.00668 0.39897,0.73789 0.47306,2.67276 0.51587,3.63948"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2605"
+         d="m 135.58519,289.72945 c 1.66939,2.09276 5.93813,4.30368 7.43499,7.70909 1.03294,2.34999 1.08135,5.28229 1.7558,7.61111 0.97706,3.37365 2.00097,5.94996 3.9442,8.97322 2.81676,4.38227 8.01056,7.2188 9.39899,12.01289 0.90659,3.13033 1.17637,6.25208 1.83677,9.43921 0.65493,3.16071 1.30657,6.36966 2.19071,9.42248 0.83493,2.88291 1.72326,5.3308 2.47987,7.94327 0.267,0.92192 0.64343,1.91197 0.82122,2.52589"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2607"
+         d="m 141.10938,310.35233 c 0.81023,2.79764 1.35126,6.48531 1.48283,9.45593 0.23896,5.39545 1.21164,10.96042 4.21948,15.18877 2.86953,4.03392 4.78612,9.22292 7.66169,12.82777 1.01819,1.2764 1.83696,3.55541 2.36652,5.38393 1.00616,3.47413 2.64413,6.65217 3.63884,10.08681 0.82127,2.83572 1.14818,5.81595 2.49606,8.30889 0.17277,0.31955 0.0324,0.73125 0.0486,1.09686"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2611"
+         d="m 69.33188,283.33466 c -3.89308,-0.21646 -10.39517,2.14945 -15.07356,4.00987 -0.9417,0.37448 -1.85528,0.82045 -2.78292,1.23068 -2.02643,0.89614 -1.77803,4.9425 -2.54002,6.71498 -1.74432,4.05752 -7.24847,9.35758 -10.08374,12.56729 -0.5629,0.63724 -1.12581,1.27449 -1.68872,1.91174 -1.83273,2.07477 -3.47928,4.49823 -5.01758,6.83207 -1.21143,1.83793 -2.53842,3.56761 -2.94254,5.63485"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2613"
+         d="m 66.26211,294.10492 c -0.53412,2.73224 -4.93116,2.28266 -7.28694,3.64186 -4.76815,2.75104 -5.99325,9.08844 -9.35968,12.89945 -3.93091,4.45004 -3.61134,8.95946 -10.11612,11.83605 -2.87094,1.2696 -6.28953,6.0305 -8.12205,8.81072 -1.24767,1.8929 -1.99005,3.27933 -3.31267,5.28595 -1.15906,1.75847 -1.82869,4.42157 -2.20228,6.33263"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2615"
+         d="m 63.5347,320.61356 c -0.53971,2.76087 -5.49596,0.30867 -8.10817,1.11597 -4.27842,1.32225 -5.89958,2.93394 -5.70926,7.23115 0.25961,5.86164 -6.79631,12.3554 -9.90561,16.58911 -4.4399,6.04549 -9.54381,11.92996 -13.01009,18.56776 -1.12286,2.15024 -2.16479,4.79551 -2.54002,6.71497 -0.0523,0.26741 -0.21437,0.49865 -0.32155,0.74797"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2621"
+         d="m 81.22415,257.56897 c -0.45179,0.51146 -7.7627,-0.62317 -9.62107,-1.01084 -2.96365,-0.61823 -7.27493,-0.38895 -10.29656,-0.24614 -2.66791,0.12609 -5.04613,-0.1279 -7.80281,0.002 -2.82662,0.13359 -6.07846,2.88832 -8.31636,4.42328 -3.56603,2.44592 -6.06999,6.98209 -9.13528,9.95777 -1.28368,1.24615 -5.19981,3.75002 -6.88443,4.72199 -1.27316,0.73456 -3.29262,2.51821 -4.45544,3.50804"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2627"
+         d="m 90.4455,247.5302 c -0.48003,-0.45249 -0.32244,-7.28032 -0.40482,-9.1405 -0.12955,-2.92496 -0.25909,-5.84992 -0.38864,-8.77488 -0.12375,-2.7942 -0.35145,-5.23973 -1.04793,-7.64456 -0.31042,-1.07186 -0.32743,-1.61261 -0.82122,-2.52589"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2631"
+         d="m 98.90761,246.3975 c 1.53099,-2.32275 6.95219,-7.17953 10.56722,-9.65906 2.26008,-1.55018 5.37023,-0.62019 8.12436,-0.75035 4.00132,-0.18911 7.3647,1.11747 11.39076,0.92719 3.73856,-0.17669 7.14579,-1.43687 10.92347,-1.61541 0.16685,-0.008 0.22516,-0.2549 0.33774,-0.38235"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2633"
+         d="m 105.08647,249.76933 c 3.11247,-0.1471 8.67652,-1.50922 13.04709,-1.71578 3.42914,-0.16207 6.98668,1.44291 10.39372,2.43985 3.18182,0.93105 6.24749,0.7599 9.28333,1.39319 5.04451,1.05231 12.8919,1.22263 17.77782,0.99172 2.23441,-0.1056 4.20301,0.7862 6.0817,1.17811"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2635"
+         d="m 116.43096,257.66003 c 5.73019,-0.27082 12.98268,1.23437 19.66085,3.46742 0.46328,0.15492 0.95463,0.19914 1.43195,0.29872 1.38415,0.28873 3.8797,3.36724 4.81169,4.53559 2.01259,2.52301 7.1693,5.61715 9.88016,6.86076 1.97149,0.90442 2.9834,3.49956 3.78227,5.31702 0.98711,2.24572 2.28426,4.12975 3.81465,6.04826 1.20531,1.511 1.44282,2.76146 2.65568,3.90473"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2639"
+         d="m 138.01417,288.5155 c 5.95976,7.47122 12.459,18.05051 19.53824,24.72356 2.38991,2.25278 2.42481,6.7 2.56084,9.77137 0.11506,2.598 3.33505,4.8715 4.53872,6.38043 1.82712,2.2905 2.9712,4.82394 4.21717,7.1284 0.53305,0.98589 1.21028,2.5741 1.56149,3.22367"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2643"
+         d="m 142.55056,342.89251 c 0.0872,0.0822 0.0108,0.24374 0.0162,0.36562 0.11677,2.63652 4.67789,2.30733 6.56519,4.08634 0.61689,0.58149 1.23377,1.16298 1.85065,1.74446 1.81447,1.71036 3.52325,4.5023 4.53872,6.38043 1.11618,2.06439 1.6593,4.41158 2.76904,6.46406 1.0272,1.89984 1.83725,4.48559 2.41509,6.4808 0.0677,0.23376 0.0216,0.48749 0.0324,0.73124 0.0818,1.8466 1.36732,4.79242 2.38271,5.74955"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2659"
+         d="m 77.14395,259.5168 c -3.1666,1.82702 -8.03437,2.69757 -13.52827,6.86791 -3.92843,2.98202 -6.44169,7.84045 -8.68418,12.13475 -0.25076,0.4802 -0.42873,0.9973 -0.6431,1.49594 -2.10853,4.9047 -2.53867,10.10744 -3.93727,15.20787 -2.60218,9.48973 -6.02141,17.40418 -10.91654,25.79652 -2.21205,3.79241 -5.98806,6.6698 -7.68714,10.6221 -0.0267,0.0622 -0.89748,1.36162 -0.99704,1.51267"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2619"
+         d="m 72.67462,270.71958 c -0.35761,1.82933 -3.5529,-0.93124 -5.35764,-0.84595 -3.74141,0.17683 -6.1309,0.96531 -9.08901,2.99426 -2.056,1.4102 -3.07756,4.2519 -4.69603,6.08411 -3.37873,3.82494 -7.50787,6.8977 -11.24271,10.42375 -3.00075,2.83299 -4.42152,6.8382 -6.64153,10.20629 -1.30951,1.98673 -3.30542,4.1259 -4.37447,5.33614 -1.28874,1.45893 -2.13081,3.56406 -3.32886,4.92033 -0.44471,0.50344 -0.66263,0.50299 -1.02943,0.78143"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2661"
+         d="m 68.62169,275.30776 c -0.33002,0.76766 -4.34961,2.96665 -5.03377,6.46644 -0.0964,0.49307 -0.19278,0.98613 -0.28917,1.47922 -0.71298,3.64723 -0.83212,6.37178 -2.39428,10.00556 -1.37441,3.19704 -2.69888,7.18668 -3.79384,10.43807 -1.39494,4.14217 -4.17368,7.75552 -5.49875,11.98423 -0.31076,0.9917 -0.62151,1.98343 -0.93226,2.97513 -1.22638,3.91373 -2.1587,7.85804 -3.39133,11.51823 -1.68132,4.99254 -6.09551,11.12396 -9.61645,15.10989 -1.13296,1.2826 -2.71205,2.68626 -3.73138,3.8402"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2663"
+         d="m 65.13784,300.75299 c 0.34161,1.21727 -2.54021,5.68126 -3.52088,8.59326 -1.09016,3.23716 -1.43381,5.98925 -2.07272,9.2576 -0.19278,0.98613 -0.38556,1.97228 -0.57834,2.95841 -0.0935,0.47835 0.0432,0.97497 0.0648,1.46249 0.15212,3.43464 -1.55711,8.73542 -3.39132,11.5182 -2.01399,3.05554 -1.88038,5.59259 -1.7188,9.24087 0.12793,2.8885 0.55937,6.10766 0.0347,8.7916 -0.80058,4.0954 -3.84079,5.92521 -6.72249,8.3782 -1.48819,1.26679 -2.57899,4.0428 -3.65041,5.66831 -0.61347,0.93072 -0.90923,2.69987 -1.25382,3.72309"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2665"
+         d="m 69.20539,327.50458 c -2.08985,3.17063 -2.10714,7.63977 -3.005,12.23274 -0.7721,3.94966 -0.87884,7.63487 -1.62164,11.43456 -0.57634,2.94829 -0.76825,6.6782 -0.64078,9.55632 0.13393,3.02404 -0.19538,5.36885 -1.78357,7.77838 -2.88419,4.37576 -6.23007,8.94458 -10.47007,11.85276 -0.84758,0.58137 -0.95112,1.07673 -1.35097,1.5294"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2617"
+         d="m 62.84764,337.13337 c -0.42915,2.19532 -4.05587,1.90383 -5.51725,3.55822 -3.47389,3.93266 -4.66317,6.8262 -4.43695,11.93402 0.17175,3.87777 -1.03021,8.38773 -1.58924,12.16583 -0.36712,2.48106 -0.99144,5.42619 -1.78357,7.77838 -0.57783,1.71581 -0.38482,4.21079 -0.78653,6.26573 -0.0523,0.2674 -0.21437,0.49864 -0.32155,0.74797"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2667"
+         d="m 75.11517,253.75051 c -2.20005,1.50901 -5.2573,0.85043 -7.72184,1.8305 -7.07529,2.81355 -13.15569,2.99057 -18.06467,8.54785 -2.54232,2.87805 -3.80504,5.1139 -4.56649,9.00907 -1.07492,5.4987 -8.46179,13.07248 -11.64292,17.40397 -1.48031,2.01564 -3.03738,3.43576 -4.00434,5.68503 -0.43642,1.01518 -0.86705,2.01686 -1.2862,2.99188"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2571"
+         d="m 73.09102,264.10497 c -0.28109,0.65384 -10.50435,0.47666 -12.72554,0.96781 -2.18114,0.48228 -5.57372,6.51257 -6.36856,8.36146 -2.26629,5.27167 -7.97751,12.87057 -11.65911,17.03837 -2.66517,3.01714 -2.90306,4.73645 -4.26112,7.89548 -1.43075,3.32808 -3.05089,6.37026 -4.18017,9.72357 -1.92331,5.71113 -3.48955,10.99712 -5.28824,16.73727 -0.75516,2.40996 -0.88157,4.11964 -0.77033,6.63134 0.008,0.17236 -0.22516,0.2549 -0.33775,0.38235"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2575"
+         d="m 61.58227,300.55464 c -0.32916,1.6838 -2.62718,6.91772 -3.82622,9.70685 -2.92728,6.80922 -4.18742,15.27079 -6.10716,22.27176 -1.26464,4.61192 -1.53922,9.45238 -2.21616,14.02737 -0.57019,3.85352 -2.59096,9.1923 -4.40455,12.66527 -1.21154,2.32006 -1.69164,4.82593 -2.87777,7.09733 -1.28904,2.46847 -2.77415,4.46894 -4.30971,6.79861 -1.41255,2.14307 -3.02921,4.07554 -4.34209,6.06738 -0.84045,1.2751 -1.53473,1.97036 -2.36421,2.67644"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2669"
+         d="m 85.28219,251.07169 c -1.18388,2.75386 -4.97733,-3.17883 -7.64319,-4.40179 -4.55743,-2.0907 -10.22127,-4.93957 -14.8029,-5.89532 -3.29256,-0.68685 -20.39514,10.0947 -24.65993,11.79065 -1.69222,0.67293 -2.47324,0.8801 -3.4584,1.99537"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2671"
+         d="m 89.49705,250.13973 c -2.03232,0.80817 -0.0986,-4.99793 -1.70723,-6.51425 -3.06093,-2.88531 -5.10521,-7.08644 -9.52622,-6.8775 -2.46178,0.11635 -3.80715,-1.42811 -6.11409,-1.90935 -0.49319,-0.10287 -1.24987,0.0591 -1.76969,0.0836"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2623"
+         d="m 84.69425,252.4393 c -1.98461,1.14505 -6.3114,-3.37437 -8.72119,-4.71722 -2.40021,-1.33751 -4.78345,-2.80906 -7.24067,-3.32165 -3.63645,-0.75858 -7.35684,-1.31064 -11.10159,-2.4064 -2.25049,-0.65852 -3.6566,-1.12503 -5.74397,-1.56046 -0.96268,-0.20082 -1.86592,-0.60396 -2.89626,-1.32866"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2673"
+         d="m 99.32632,247.84324 c -0.0412,-0.009 -2.15869,-7.08021 -3.96039,-9.33883 -1.2827,-1.60801 -1.9698,-4.43451 -2.07736,-6.86315 -0.0727,-1.64056 -0.51459,-3.6108 -0.59683,-5.46757"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="css"
+         id="path2583"
+         d="m 91.84395,253.13769 c -2.31792,0.10954 -0.74376,-4.90165 -2.07736,-6.86315 C 82.69285,235.87027 73.12116,226.8911 73.44386,214.0713"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2675"
+         d="m 107.90177,249.26989 c -0.0418,-0.94459 -0.28077,-6.33941 -0.42102,-9.50613 -0.11343,-2.56119 0.49181,-4.25783 1.84834,-6.3159 0.77261,-1.17216 2.36734,-1.92512 2.3966,-1.94519"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2677"
+         d="m 111.55565,251.68794 c 1.05589,-1.60198 4.85696,-2.89089 7.28694,-3.64186 0.22629,-0.0699 0.47191,-0.0223 0.70787,-0.0335 2.37474,-0.11223 4.94864,-0.60027 7.41649,-0.7169 4.64575,-0.21957 8.01039,4.38443 12.5983,4.1676 0.5899,-0.0279 1.17979,-0.0558 1.76969,-0.0836"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2629"
+         d="m 91.32919,243.4582 c -0.36615,-1.26428 2.48178,-1.18284 3.08828,-2.34427 1.77855,-3.40585 3.88701,-6.67757 5.94984,-9.80722 1.57776,-2.3937 3.01358,-5.09231 4.63126,-7.54659 1.12825,-1.71172 3.1498,-3.31717 4.777,-4.256"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2625"
+         d="m 86.84136,246.235 c -1.8348,-0.38275 -6.6368,-8.00777 -9.33422,-10.55041 -1.96345,-1.8508 -2.74266,-3.286 -4.84408,-5.26685 -2.12205,-2.00029 -3.57183,-3.90215 -5.23039,-5.98135"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2595"
+         d="m 105.71338,247.90777 c 0.38835,-0.0183 5.20996,-2.99997 7.28694,-3.64186 4.246,-1.31222 8.54645,-1.50307 13.04709,-1.71578 4.16685,-0.19693 6.37586,0.0594 10.00739,1.72535 5.09312,2.33646 15.59472,-3.2335 16.18395,-2.96319"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2679"
+         d="m 117.34704,254.31928 c 2.30725,-0.10905 9.30288,2.21479 12.63069,4.89883 2.19338,1.76906 4.57703,3.26332 6.61376,5.1832 2.21981,2.09243 3.78715,4.62092 5.97066,6.67913 2.16132,2.03731 2.88328,7.01103 4.33052,9.68773 2.13984,3.95768 5.25606,7.23922 8.9479,9.8359 1.92658,1.35509 3.5234,1.93597 5.77634,2.29171"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2681"
+         d="m 119.98883,265.91874 c 3.68069,2.58886 8.23318,5.83202 11.05533,9.36991 1.78822,2.24174 3.16801,5.23764 4.94124,7.46056 1.8124,2.27206 3.1574,5.07839 5.27898,7.07821 1.63867,1.54464 2.91217,5.09811 4.21717,7.12841 2.23641,3.47938 3.9925,6.56626 7.16202,9.55391 2.89471,2.72861 5.18867,6.12512 8.54537,8.75576 0.39919,0.31285 0.74026,0.69779 1.11039,1.04667"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2683"
+         d="m 128.40015,283.77761 c 2.74885,2.15428 11.97093,5.95915 16.07522,10.59821 1.37497,1.55412 0.8428,5.07806 1.36948,6.8966 0.75762,2.61597 0.51244,5.63525 1.08031,8.3758 0.71794,3.46479 1.25586,6.50428 2.2069,9.7881 0.88961,3.07171 2.82792,6.86993 5.00601,8.92305 4.24084,3.99749 8.89273,8.03211 12.93836,11.8456 0.12338,0.1163 0.24675,0.23259 0.37013,0.3489"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86142826;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2687"
+         d="m 129.38781,333.98859 c 2.15829,2.03444 4.93656,7.3398 6.84047,10.30187 1.44179,2.24312 2.69336,4.98143 3.86323,7.14511 1.26402,2.33785 2.4293,4.57381 3.84704,6.77951 1.03415,1.60894 1.79293,4.73656 2.3989,6.11517"
+         style="fill:none;stroke:#7c5c00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2641"
+         d="m 139.74221,311.5161 c 3.14655,5.81961 8.05879,10.60867 11.71693,16.29996 1.84322,2.86767 1.93243,6.45126 3.9442,8.97323 1.87534,2.35095 4.51021,6.99902 6.1164,9.96971 1.25432,2.3199 4.30246,4.7563 5.95447,6.31352 1.04432,0.9844 1.66933,2.09269 2.25316,2.82459"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2603"
+         d="m 126.95653,271.08522 c 2.92148,5.40333 9.26874,10.48868 13.77579,14.73711 2.86814,2.70358 5.91626,6.48104 7.86989,9.52046 1.11039,1.72754 0.44648,4.94844 1.01554,6.91333 1.28846,4.4489 2.21273,8.79188 4.47626,12.97831 1.69442,3.13388 4.77891,5.90613 7.09724,8.09144 1.56049,1.47094 2.38056,3.21449 3.76608,4.9514 0.82413,1.03314 1.35483,1.83445 1.89923,2.84132"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2685"
+         d="m 133.59624,306.94386 c 0.061,0.0575 1.11645,6.64231 1.82058,9.0736 1.33635,4.61423 2.04741,9.12381 3.0767,13.41085 0.56195,2.3405 0.72969,4.37775 1.35329,6.53098 1.12737,3.89264 2.78096,7.46266 5.42472,10.36878 0.63168,0.69436 1.24456,1.40673 1.86684,2.11008 3.1789,3.59309 6.86654,6.82289 10.37984,10.1346 1.9597,1.84726 3.92449,4.1286 6.25983,5.19993"
+         style="fill:none;stroke:#7c5c00;stroke-width:4.86144972;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2637"
+         d="m 130.89842,271.99807 c 3.7824,4.74166 13.44395,9.8697 18.74709,14.86856 2.22324,2.09566 3.3689,4.92736 5.63292,7.06148 1.66669,1.57105 2.20842,3.34403 3.78227,5.31702 1.52902,1.9168 3.35252,3.39701 4.84408,5.26685 1.75524,2.20038 2.72854,5.15283 4.23336,7.49401"
+         style="fill:none;stroke:#000000;stroke-width:5.40161085;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2609"
+         d="m 137.62552,335.79757 c 0.45948,0.84981 1.66931,6.77979 3.26871,9.73791 1.27883,2.36523 1.41,5.50929 2.47987,7.94328 1.21185,2.75701 2.72882,5.70578 3.57407,8.62433 0.56049,1.93532 1.58881,4.28121 2.38271,5.74955 1.05292,1.94739 1.7319,3.87452 2.73665,5.73283 0.10211,0.18886 0.68352,0.6443 0.74026,0.69778"
+         style="fill:none;stroke:#5a462f;stroke-width:6.48193312;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2701"
+         d="m 73.25755,339.93884 c 0.14204,1.65238 -1.67524,4.982 -2.15369,7.42951 -0.63674,3.25719 -0.80272,5.90026 -0.64079,9.55629 0.22346,5.04552 -0.62728,9.86155 -0.3979,15.0406 0.18518,4.18121 -1.14087,7.43477 -3.79384,10.4381 -0.77751,0.88019 -1.23133,1.61725 -2.02646,2.29408"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2705"
+         d="m 87.51451,349.52383 c -0.44515,2.2771 -1.76711,8.14222 -2.31332,11.83365 -0.34404,2.32515 0.0652,5.04792 -0.38401,7.34587 -0.44018,2.2517 -3.09419,5.34468 -4.29352,7.16423 -1.44298,2.18923 -1.95843,3.83026 -1.84834,6.31592 0.0705,1.59145 0.42402,0.78421 0.77265,1.42901"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2707"
+         d="m 93.4042,354.37486 c 0.0833,1.88035 -2.79456,8.01709 -3.40751,11.15261 -0.46479,2.37756 0.24686,5.57402 0.35624,8.04364 0.128,2.89007 -0.57688,6.74909 -0.99472,9.57303 -0.32486,2.19546 0.34274,4.52507 -0.0625,6.59788"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2711"
+         d="m 103.4116,356.10021 c 0.0887,2.00298 1.53538,10.64245 1.72573,14.94025 0.22051,4.97889 -0.27467,11.32486 4.1709,14.0919 1.82711,1.13723 0.28814,4.57248 -0.11104,5.50103 -0.0678,0.15768 -0.22516,0.2549 -0.33775,0.38233"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2713"
+         d="m 109.37995,354.71898 c -0.24687,0.57426 4.23584,7.54993 4.39529,11.15022 0.19265,4.34975 0.53033,7.35861 2.62561,11.23386 1.08753,2.01141 0.8948,4.187 0.99935,6.54771 0.0983,2.2198 0.0449,4.49092 0.64541,6.56443 0.44755,1.54532 0.21714,0.30524 0.75646,1.06341"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2717"
+         d="m 118.96632,346.93822 c 0.28767,6.49505 8.59868,13.27568 10.44693,19.65746 0.81946,2.82949 -0.0793,6.2178 0.0509,9.15721 0.0639,1.44222 0.24735,2.13584 0.85362,3.25712"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2719"
+         d="m 124.70797,340.43831 c 0.11083,2.5022 3.86357,11.82641 5.68381,16.21872 0.39712,0.95824 0.79424,1.91652 1.19135,2.87476 1.59705,3.85372 2.42337,7.87245 4.73304,10.76787"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2721"
+         d="m 81.21767,327.47192 c 0.0508,1.14769 0.20659,4.66446 0.30767,6.94679 0.0991,2.23671 0.15704,3.66362 -0.83511,5.16885"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2723"
+         d="m 86.20517,327.96899 c 0.0638,1.44061 0.23972,5.41256 0.35625,8.04362 0.0768,1.73471 -1.29931,3.67803 -1.91311,4.85344"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2727"
+         d="m 97.91749,328.14821 c 0.0784,1.76991 1.54165,6.71918 2.1907,9.42247 0.2719,1.13247 0.44507,2.04083 0.49968,3.27386"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2729"
+         d="m 104.35313,329.3096 c 0.17099,0.71217 0.9191,4.73596 1.04792,7.64457 0.0594,1.3406 0.11875,2.6812 0.17813,4.02181"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2733"
+         d="m 117.09486,328.70741 c 0.0545,0.22712 2.30578,4.58818 3.12297,6.44734 0.29431,0.66954 0.52694,1.1988 0.78884,1.79463"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2737"
+         d="m 89.06906,328.5664 c 0.12259,2.76806 -0.38718,5.47666 0.35625,8.04365"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2739"
+         d="m 95.76148,327.51734 c 0.0286,0.64575 -0.13142,5.04101 -0.0139,7.69475 0.055,1.24169 -0.99751,2.86039 -1.23763,4.08872"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2743"
+         d="m 109.96754,327.9451 c 0.0318,0.71772 -0.1241,5.20626 0.002,8.06035 0.0317,0.71522 -0.17397,1.17575 -0.27297,1.84485"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2747"
+         d="m 76.81312,340.13719 c 0.63869,2.20532 -2.37587,3.91341 -3.28029,6.01721 -0.67168,1.56242 0.25109,5.66921 0.32387,7.31239 0.1523,3.4389 -2.7087,12.51086 -3.51856,16.65363 -0.15791,0.80778 -2.49121,2.97185 -3.00731,4.17236"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2751"
+         d="m 87.91702,350.60396 c -3.08574,3.49325 -5.97336,17.28443 -5.70464,23.35189 0.16926,3.82154 0.69625,8.12107 0.16424,11.71656 -0.0399,0.26968 -0.21436,0.49866 -0.32155,0.74798"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2753"
+         d="m 92.42336,356.25316 c -0.44696,3.02063 0.0617,10.99148 1.01785,14.97368 0.74129,3.08749 0.30332,6.96907 -0.27066,9.9052 -0.37287,1.90742 -1.52188,3.94337 -2.23467,5.60139"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2759"
+         d="m 113.96493,354.13592 c 0.32811,7.40812 4.82509,18.82835 7.23142,27.13713 0.26123,0.90199 0.35281,2.76674 0.49967,3.27385"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2763"
+         d="m 122.66531,342.36677 c 0.55965,2.33093 10.92,11.90626 12.81113,16.98102 0.77607,2.08256 0.56109,4.66048 0.66161,6.93006 0.052,1.17456 0.83809,2.90672 0.91838,4.71959"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2767"
+         d="m 87.6857,329.36455 c -0.7385,1.12042 -0.49103,4.92957 -0.38402,7.34585 0.0956,2.15783 -0.82651,3.33111 -1.18904,5.1856"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2765"
+         d="m 81.95793,328.16971 c 0.69082,1.61864 0.97795,5.14949 -0.72176,7.7282 -0.9574,1.45252 -1.95567,2.7658 -2.26705,4.87015"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2735"
+         d="m 83.61427,325.52673 c 0.0596,1.34651 0.22944,5.18054 0.34005,7.67802 0.0324,0.73123 0.0648,1.46249 0.0972,2.19372"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2769"
+         d="m 94.76444,329.03 c 0.0663,1.49699 0.23882,5.39233 0.35625,8.04364 0.0784,1.7706 0.0719,3.42098 -0.12724,5.13541"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2725"
+         d="m 92.2383,328.05022 c 0.0605,1.36632 0.25844,5.83517 0.37244,8.40928 0.053,1.19619 0.009,2.19832 -0.2082,3.30731"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2771"
+         d="m 101.21627,330.557 c 0.12088,2.72923 0.5874,5.25468 0.71018,8.02691 0.0694,1.56664 0.0464,3.01164 -0.15961,4.40417"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2741"
+         d="m 102.92118,329.01089 c 0.0148,0.33386 -1.60437,3.8162 -1.4944,6.29917 0.0902,2.03708 -0.18714,3.78279 -0.0949,5.86665"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2773"
+         d="m 107.84392,328.04546 c 0.1338,3.02106 -0.5681,8.15688 2.1907,9.42248 4.1645,1.91046 9.04804,3.55364 7.4188,7.34347"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2775"
+         d="m 116.01686,328.39196 c 1.9844,0.91034 1.14894,4.58658 2.75284,6.09845 1.71731,1.61877 3.26819,1.7182 3.39594,4.60251 0.0305,0.68942 -0.90065,1.01959 -1.35097,1.52939"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2731"
+         d="m 110.01612,329.04196 c 0.11619,2.62338 2.24572,5.47714 2.8338,7.92653 0.26471,1.10248 0.2143,2.28847 0.49968,3.27385"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2745"
+         d="m 113.82846,327.02984 c 0.0109,0.24691 3.62017,3.82821 4.1524,5.66593 0.27255,0.94109 0.42226,1.52609 0.46728,2.54261"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2777"
+         d="m 78.27976,349.22751 c 0.046,1.03823 -2.06499,6.97568 -2.44287,8.9087 -1.24261,6.3565 -1.55815,9.64239 -5.70695,15.29151 -2.02527,2.75766 -3.99076,5.65344 -5.29055,8.6769 -0.34539,0.80343 -0.66651,1.5504 -0.96465,2.24391"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2779"
+         d="m 88.48147,355.34029 c -1.20405,2.80077 -4.05828,6.85783 -4.83946,10.8539 -0.56376,2.88391 -0.43402,6.21665 -0.30304,9.17395 0.13063,2.94957 -1.22744,4.8716 -2.1699,7.06387 -0.71431,1.66158 -1.59845,2.3469 -1.94549,4.12219"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2749"
+         d="m 83.29849,346.42561 c -0.44182,2.26011 -3.13113,7.04802 -3.79384,10.4381 -0.63334,3.23987 0.66535,7.01465 0.80735,10.22064 0.15964,3.60465 -0.81674,6.68385 -3.13455,9.30776 -1.50274,1.7012 -2.4588,3.93538 -4.00434,5.68503"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2703"
+         d="m 79.29299,348.08047 c -0.88078,0.99711 -1.40144,8.3981 -1.2677,11.41785 0.11305,2.55259 0.54676,5.18077 -0.38401,7.34587 -1.111,2.5843 -2.35429,3.97099 -2.89396,6.7317 -0.20516,1.04946 -0.3675,1.87993 -0.57833,2.95841"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2781"
+         d="m 96.10615,351.31609 c -1.5676,3.64645 -0.59651,10.55611 -0.41409,14.67498 0.13797,3.11499 0.28149,6.81768 -0.64078,9.5563 -0.74717,2.21864 -1.39638,4.45234 -1.83215,6.68153 -0.4265,2.18173 -0.87626,4.2397 -0.77034,6.63134"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2783"
+         d="m 106.09736,352.67582 c -0.94346,4.82619 0.61347,13.85151 0.89062,20.10909 0.13382,3.0217 0.61188,5.80725 0.74257,8.75816 0.11989,2.70694 0.58792,5.26643 0.71018,8.02691 0.0108,0.24374 0.0216,0.48749 0.0324,0.73124"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2785"
+         d="m 114.8972,351.16076 c 0.14339,3.23762 -3.15162,6.13847 1.16128,10.20391 3.53446,3.33165 4.75296,3.09395 6.00305,7.41038 0.94242,3.25404 -0.46285,5.56568 -0.31924,8.80833 0.0702,1.58436 0.14034,3.16871 0.21051,4.75306"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2757"
+         d="m 105.84058,354.88626 c 0.37478,8.46227 8.30827,19.41863 8.72812,28.89833 0.0918,2.07184 0.18352,4.14369 0.27529,6.21553 0.005,0.12189 0.23595,-0.0112 0.35393,-0.0167"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2755"
+         d="m 102.63895,354.6712 c -1.5646,8.00365 -2.43495,17.09547 -2.00334,26.84079 0.15835,3.57519 1.71898,6.77971 1.88535,10.53609"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2709"
+         d="m 99.18054,356.66657 c -0.63128,4.26644 -3.79834,10.3362 -3.53474,16.288 0.10202,2.30356 0.87822,3.81286 0.98315,6.1821 0.0915,2.06681 0.14127,3.89456 0.59684,5.46757"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2787"
+         d="m 122.21653,348.25015 c 0.14297,3.22817 2.4705,5.7445 5.00601,8.92304 2.37455,2.97676 3.1969,8.11657 3.36587,11.93163 0.15077,3.40426 1.05532,6.51066 2.17451,9.05687 0.28076,0.63874 0.54245,1.00326 0.77265,1.42902"
+         style="fill:none;stroke:#130500;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2761"
+         d="m 118.29083,347.7029 c 0.88549,3.05747 2.20171,5.24101 5.0384,9.65428 1.46086,2.2728 0.1908,8.84543 0.87212,11.68313 0.58812,2.44953 2.11418,4.20295 2.76903,6.46407"
+         style="fill:none;stroke:#4e3400;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2715"
+         d="m 116.28057,350.36262 c 0.74784,2.5822 1.06903,8.62698 1.96631,12.36417 0.73152,3.04678 2.65832,4.22355 3.50929,7.16185 0.91671,3.16526 2.00298,5.18368 2.15832,8.69124 0.10059,2.27115 0.55454,4.51249 0.66161,6.93006"
+         style="fill:none;stroke:#755a00;stroke-width:5.71428585;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2789"
+         d="m 94.83717,307.78163 c -1.51463,3.12926 -2.81278,3.54944 -3.41036,6.01867 -0.54674,2.25913 -1.04307,3.93618 -1.04307,7.00372 0,1.50152 6.69478,1.61624 7.823,1.61624 2.64609,0 5.56753,-2.69374 8.34453,-2.69374"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccssc"
+         id="path2791"
+         d="m 81.53279,283.84937 c -6.44249,1.00711 -10.87369,7.87225 -9.92437,15.45055 0.2371,1.89279 0.78719,3.653 1.58112,5.21929 12.49996,4.19981 16.12593,-0.47437 21.96438,-2.93607 0.38183,-1.72345 0.48006,-3.57033 0.24296,-5.46312 -0.96058,-7.66815 -7.07116,-13.17869 -13.6378,-12.3009 -0.077,0.0103 -0.1499,0.0183 -0.22629,0.0303 z"
+         style="fill:url(#linearGradient2812);fill-opacity:1;stroke:#130500;stroke-width:2.74285722;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccssc"
+         style="fill:url(#linearGradient2810);fill-opacity:1;stroke:#130500;stroke-width:2.74285722;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 114.43998,284.9014 c -6.48929,-0.60696 -12.37582,4.97039 -13.2011,12.56417 -0.20613,1.89666 -0.0777,3.74156 0.33224,5.4581 6.76746,4.26454 14.2292,4.36342 22.00925,2.55244 0.76821,-1.57991 1.28944,-3.34947 1.49556,-5.24612 0.83507,-7.68382 -3.82915,-14.5392 -10.40919,-15.3023 -0.0771,-0.009 -0.14981,-0.0191 -0.22676,-0.0263 z"
+         id="path2796" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2798"
+         d="m 82.2624,301.69219 c -0.47776,-3.97636 -1.64074,-3.81974 2.34369,-4.84873 2.74693,-0.7094 1.48695,2.45795 2.2675,4.07059"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2800"
+         d="m 109.55886,301.77841 c 0.83451,-1.83632 1.06831,-4.68007 5.10063,-3.17962 0.43033,0.16013 -0.65214,3.37238 -0.22554,4.04274"
+         style="fill:none;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2802"
+         d="m 105.13351,341.20074 c 2.93097,0.60636 12.40598,2.56658 18.40963,3.80863 5.57561,1.15349 9.83108,3.13276 15.13653,4.23037 5.18914,1.07354 10.71342,3.31531 16.15928,4.44196 4.69221,0.97074 10.05929,3.17998 15.13652,4.23037 8.10594,1.67698 7.30205,3.08386 2.86205,7.18546 -7.35901,6.79815 4.19521,5.31196 4.29447,5.28402 1.96003,-0.55163 3.38655,-6.49393 1.2262,4.64925 -1.25465,6.4715 -6.53967,3.04262 -12.06964,1.89857 -5.53098,-1.14426 -10.59462,-2.41096 -13.90894,-5.0753 -3.73215,-3.00021 -8.31769,-4.65116 -12.47652,-6.97674 -5.41648,-3.02883 -10.00394,-4.03082 -14.72687,-6.3434 -4.91091,-2.40463 -9.79851,-3.06263 -13.90894,-5.0753 -2.56803,-1.25744 -5.53919,-8.93638 -6.13377,-12.25789 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.49779892;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2814"
+         d="m 167.68182,364.28481 c -1.86327,1.47682 -3.87086,5.75833 -4.69379,9.15872 -0.79954,3.3037 3.04484,4.24463 5.21533,5.92623 1.82935,1.4173 6.98791,0.53875 9.38759,0.53875 2.47391,0 3.55043,-3.35678 4.17227,-5.92623 0.55943,-2.3116 0.52153,-4.92029 0.52153,-7.54247 0,-2.76288 -4.63052,-8.08123 -6.77993,-8.08123 -2.70774,0 -5.14599,5.37316 -7.823,5.92623 z"
+         style="fill:url(#linearGradient2822);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.49779892;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4063"
+         d="m 73.90476,278.66665 c 2.95915,-2.50428 9.73171,-4.03939 14.47619,-5.33334"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4065"
+         d="m 106.28572,274.85712 c 2.15863,-0.87008 7.90174,1.5607 10.66666,2.66667 0.91915,0.36766 1.91664,1.07379 2.66667,1.52381"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="Q">
+      <rect
+         y="200"
+         x="200"
+         height="200"
+         width="200"
+         id="rect5056-7"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path2901"
+         d="m 236.05082,308.07946 c -3.63973,17.98871 -2.38687,34.80685 -16.20264,49.50303 -8.90333,9.28155 -4.18375,28.44858 8.26516,17.03677 13.54195,-10.23619 22.19631,-2.1647 36.79003,-4.96836 19.62014,4.5953 49.19054,9.49779 70.02323,6.96213 22.49327,-9.96108 39.58161,11.71025 50.09875,-7.52046 -5.16347,-13.36414 -20.35832,-19.76076 -18.99545,-38.32677 1.76301,-22.60476 -9.21524,-49.13125 -30.59752,-59.02341 -17.88217,-6.52548 -39.88302,-8.94871 -57.39638,-0.47055 -10.46246,1.40054 -34.3536,43.33185 -41.98518,36.80762 z"
+         style="fill:url(#linearGradient2944);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2950"
+         d="m 239.79607,329.8858 c 0.77619,2.20047 0.62378,7.8967 0,11.63946 -0.43375,2.60259 -2.2076,4.3965 -2.77124,6.65113 -0.59396,2.37588 -2.77294,4.06684 -3.87974,5.5426 -1.63366,2.17826 -2.89351,4.00209 -4.43399,5.5426 -2.10799,2.10804 -1.34117,4.37591 1.1085,4.98834 1.67177,0.41795 6.04622,-2.75867 8.31373,-3.32556 2.39723,-0.59932 3.87974,-5.76723 3.87974,-7.75964 0,-1.96445 2.28132,-4.00848 3.32549,-6.09686 1.33544,-2.67096 2.5272,2.0847 2.21699,3.32556 -0.7817,3.12685 1.42684,5.86096 2.77124,7.20538 2.99251,2.99258 6.09673,-4.26211 6.09673,-4.98834 0,-3.71474 2.54797,-1.55509 3.87974,1.10852 1.00335,2.00675 1.15498,4.48057 2.77124,6.09686 0.29211,0.29212 0.3695,0.73901 0.55425,1.10852"
+         style="fill:none;stroke:#000000;stroke-width:1.82857168;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2952"
+         d="m 358.95947,336.53692 c 2.3551,2.35516 -0.25355,6.74544 0.55424,9.97669 0.8985,3.59405 3.3665,6.13786 5.54249,8.3139 1.65654,1.65658 2.94812,4.0567 4.43398,5.5426 1.54586,1.54589 2.27857,3.57189 2.77124,5.5426 0.83037,3.32152 -1.37651,2.84286 -3.87974,2.21704 -3.10361,-0.77592 -8.05028,-4.46144 -9.42221,-7.20538 -1.17407,-2.34818 -2.3188,-4.63769 -3.3255,-6.65112 -2.09722,-4.19455 -4.30065,-2.35038 -6.09673,-0.55426 -2.90985,2.90991 -3.87974,2.1863 -3.87974,6.65112 0,2.74437 -1.10681,2.49333 -3.87973,3.87982 -2.97791,1.48899 -4.56659,2.56047 -7.20523,3.87982"
+         style="fill:none;stroke:#000000;stroke-width:1.82857168;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2374"
+         d="m 302.71888,243.94326 c -26.53598,0 -48.07501,31.32918 -48.07501,69.94075 0,38.61157 31.23891,69.28255 48.07501,69.94982 15.87379,0.62914 48.07503,-31.33824 48.07503,-69.94982 0,-38.61157 -21.53905,-69.94074 -48.07503,-69.94075 z"
+         style="fill:url(#linearGradient2382);fill-opacity:1;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3412"
+         d="m 299.51404,319.07221 c -0.82886,8.82491 -9.54159,19.20139 -3.12041,24.95407 3.66256,3.28127 9.82405,2.2602 11.86837,2.2602"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsscsssss"
+         id="path3433"
+         d="m 300.59356,242.79109 c -15.59707,-0.1484 -39.23599,3.18305 -47.61233,18.23197 -9.94854,19.95926 -18.31861,22.15947 -15.3567,46.08231 2.17762,17.58835 16.26241,30.92755 17.4349,17.39377 0.85559,-9.87586 3.50144,-26.93919 7.23376,-36.38811 6.33185,-19.91146 19.0705,-26.78053 40.00158,-27.48134 22.61469,-0.75718 35.17611,7.35495 42.77695,25.08427 6.76748,15.7855 1.73822,28.20922 8.03774,42.73109 1.90951,4.40186 13.6383,-13.9347 8.64203,-43.1889 -4.81965,-35.46703 -28.99587,-39.09721 -61.15793,-42.46506 z"
+         style="fill:#804020;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2823"
+         d="m 346.64214,324.76919 c -2.07921,2.11711 -3.64218,10.95381 -3.64218,21.5293 0,12.15294 2.06469,22.01922 4.60496,22.01922 2.54026,0 4.60495,-9.86628 4.60495,-22.01922 0,-8.06065 -0.90957,-15.1074 -2.2616,-18.94361 3.03682,4.96979 5.16808,16.56906 5.16808,30.0757 0,18.02909 -3.80385,32.6614 -8.48329,32.66139 -4.67943,0 -8.47421,-14.6323 -8.47421,-32.66139 0,-18.02909 3.79478,-32.66139 8.47421,-32.66139 0.003,0 0.006,-2e-5 0.009,0 z"
+         style="opacity:0.98999999;fill:#ffff40;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path4323"
+         d="m 322.75019,354.82239 c -0.89702,0.41978 -11.61548,4.4757 -19.67162,4.60909 -7.22428,0.11961 -17.08891,-3.36669 -18.23068,-3.65165"
+         style="fill:none;stroke:#000000;stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscsssc"
+         id="path1928"
+         d="m 236.40464,315.80002 c 11.22802,-23.91737 37.01504,-47.55029 68.52902,-45.632 22.12646,1.34686 51.37881,13.04053 59.94488,44.49543 8.57058,-12.4026 2.32072,-23.6795 -2.28515,-41.91586 -6.14453,-24.3284 -28.57691,-46.17238 -60.31456,-45.39069 -31.75878,0.7822 -50.16583,18.89624 -57.50093,43.91292 -5.89126,20.09242 -12.2522,17.6582 -8.37326,44.5302 z"
+         style="fill:url(#linearGradient2936);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:#ffff40;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 255.10667,323.96558 c -2.07921,2.11712 -3.64219,10.95382 -3.64219,21.52931 0,12.15294 2.06469,22.01922 4.60496,22.01922 2.54026,0 4.60496,-9.86628 4.60496,-22.01922 0,-8.06065 -0.90958,-15.1074 -2.26161,-18.94361 3.03682,4.96979 5.16809,16.56906 5.16809,30.0757 0,18.02909 -3.80386,32.6614 -8.4833,32.66139 -4.67943,0 -8.47421,-14.6323 -8.47421,-32.66139 0,-18.02909 3.79478,-32.6614 8.47421,-32.6614 0.003,0 0.006,-10e-6 0.009,0 z"
+         id="path2828" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 297.49098,309.18643 c 1.57362,2.29269 -0.0639,4.46234 -1.7474,6.73509 -6.2051,2.79307 -18.40681,4.36645 -26.78441,-2.79722 -4.70777,-4.02561 6.46981,-10.33129 14.4572,-10.16799 9.08642,0.18011 11.56432,2.57277 14.07461,6.23012 z"
+         id="path2860"
+         sodipodi:nodetypes="ccsss" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:#713e01;stroke-width:13.15185261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         id="path2862"
+         sodipodi:cx="361.66666"
+         sodipodi:cy="545"
+         sodipodi:rx="20"
+         sodipodi:ry="20"
+         d="m 381.66666,545 a 20,20 0 1 1 -40,0 20,20 0 1 1 40,0 z"
+         transform="matrix(-0.2368784,-0.00369816,-0.00419688,0.18354903,372.43799,212.73589)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 295.46949,304.52742 c -0.18142,-0.79881 1.16947,-3.19582 1.51283,-4.40123"
+         id="path2864" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 289.28308,301.65096 c 0.22832,-1.16564 0.6858,-5.68292 0.58778,-7.49123"
+         id="path2866"
+         sodipodi:nodetypes="cs" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 282.75138,300.7352 c 0.0717,-0.25172 -1.47328,-6.16921 -0.77069,-11.29623"
+         id="path2868"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 276.05168,302.57566 c 0.0112,-0.34569 -2.63744,-4.33609 -2.90461,-5.57156 -0.38708,-1.78989 -0.5207,-3.97975 -0.85052,-5.50491"
+         id="path2870"
+         sodipodi:nodetypes="css" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 270.24659,305.02703 c -0.20228,-0.41123 -2.47714,-0.95812 -2.95217,-3.16619 -0.0759,-0.35259 -1.31743,-2.56541 -1.50101,-2.87592"
+         id="path2872"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2874"
+         d="m 256.54087,319.31652 c -1.26336,9.02521 -4.59832,26.21981 2.71071,21.2151 4.63503,-3.17374 -2.2364,-11.36317 2.12825,-24.76293"
+         style="fill:url(#linearGradient2891);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2895);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 349.30457,320.97931 c 1.26337,9.0252 4.59832,26.2198 -2.7107,21.21509 -4.63503,-3.17374 2.2364,-11.36317 -2.12825,-24.76293"
+         id="path2893"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2897"
+         d="m 271.1308,287.26944 c 7.11907,-2.38935 14.68666,-3.88166 23.27843,-3.32556"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsss"
+         id="path2908"
+         d="m 307.18858,309.57835 c -1.57362,2.29269 0.0639,4.46234 1.7474,6.73509 6.2051,2.79307 18.40681,4.36646 26.78441,-2.79722 4.70777,-4.0256 -6.46981,-10.33129 -14.4572,-10.16799 -9.08642,0.18011 -11.56432,2.57277 -14.07461,6.23012 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.2368784,-0.00369816,0.00419688,0.18354903,232.24146,213.12781)"
+         d="m 381.66666,545 a 20,20 0 1 1 -40,0 20,20 0 1 1 40,0 z"
+         sodipodi:ry="20"
+         sodipodi:rx="20"
+         sodipodi:cy="545"
+         sodipodi:cx="361.66666"
+         id="path2910"
+         style="fill:#000000;fill-opacity:1;stroke:#713e01;stroke-width:13.15185261;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2912"
+         d="m 309.21007,304.91935 c 0.18142,-0.79881 -1.16947,-3.19583 -1.51283,-4.40124"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path2914"
+         d="m 315.39648,302.04289 c -0.22833,-1.16565 -0.68581,-5.68293 -0.58779,-7.49124"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2916"
+         d="m 321.92818,301.12712 c -0.0717,-0.25172 1.47328,-6.1692 0.77069,-11.29623"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="css"
+         id="path2918"
+         d="m 328.62788,302.96758 c -0.0111,-0.34569 2.63743,-4.33609 2.90461,-5.57156 0.38707,-1.78989 0.52069,-3.97975 0.85052,-5.5049"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2920"
+         d="m 334.43297,305.41895 c 0.20228,-0.41123 2.47713,-0.95812 2.95217,-3.16619 0.0759,-0.35259 1.31742,-2.56541 1.50101,-2.87591"
+         style="fill:none;stroke:#000000;stroke-width:2.74285769;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 333.54876,287.66136 c -7.11908,-2.38935 -14.68666,-3.88165 -23.27843,-3.32556"
+         id="path2922"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path2924"
+         d="m 247.72345,280.85904 c 10.87663,-11.26199 34.43608,-23.475 52.50631,-22.69611 27.46749,1.18395 44.84324,10.40555 59.28395,25.16501"
+         style="fill:none;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="R">
+      <rect
+         y="200"
+         x="400"
+         height="200"
+         width="200"
+         id="rect5056-1"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:url(#linearGradient3360);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 408.83649,311.60553 0,38.71019 c -0.17049,0.26226 -0.25934,0.52945 -0.25934,0.80287 0,2.91645 10.06444,5.28601 22.46132,5.28601 11.36682,0 20.76586,-1.99046 22.25001,-4.56935 l 0.62914,0 0,-40.22972 -45.08113,0 z"
+         id="path3356" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3362);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:19.3214283;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3358"
+         sodipodi:cx="579.82758"
+         sodipodi:cy="321.0997"
+         sodipodi:rx="146.13541"
+         sodipodi:ry="30.641294"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         transform="matrix(0.15368023,0,0,0.23312411,341.92818,237.42427)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path3333"
+         d="m 442.45937,297.28287 0,91.3427"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3354);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714216;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 472.83019,285.82028 c -19.28424,6.91923 -36.47633,9.82768 -58.83295,0.1014 9.10182,4.72028 21.90316,9.07537 29.17265,13.84148 11.62251,-6.61275 16.09036,-8.63103 29.6603,-13.94288 z"
+         id="path3344"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3335"
+         d="m 412.96824,280.96225 c 18.5954,7.80874 35.53781,9.01883 58.8299,0.60847 -9.0442,-4.82975 -21.79206,-9.33899 -29.00352,-14.19246 -11.70145,6.47203 -16.19333,8.43625 -29.82638,13.58399 z"
+         style="fill:url(#linearGradient3352);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3306);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:14.78016663;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3279"
+         sodipodi:cx="478.47559"
+         sodipodi:cy="691.15222"
+         sodipodi:rx="167.3486"
+         sodipodi:ry="150.84944"
+         d="m 645.82419,691.15222 a 167.3486,150.84944 0 1 1 -334.69721,0 167.3486,150.84944 0 1 1 334.69721,0 z"
+         transform="matrix(0.24144869,0,0,0.25357143,365.93195,169.06761)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.98999999;fill:url(#linearGradient3329);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714335;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 540.8236,295.35415 0,31.79479 c -0.17049,0.21541 -0.25934,0.43487 -0.25934,0.65944 0,2.39544 10.06444,4.34169 22.46133,4.34169 11.36681,0 20.76585,-1.63487 22.25,-3.75306 l 0.62914,0 0,-33.04286 -45.08113,0 z"
+         id="path3325" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3310"
+         d="m 518.00572,312.63065 0,40.56701 c -0.19628,0.27484 -0.29856,0.55485 -0.29856,0.84139 0,3.05634 11.58657,5.53956 25.85833,5.53956 13.0859,0 23.90643,-2.08593 25.61504,-4.78853 l 0.7243,0 0,-42.15943 -51.89911,0 z"
+         style="opacity:0.98999999;fill:url(#linearGradient3321);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714455;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.24144869,0,0,0.25357143,372.39694,177.68759)"
+         d="m 645.82419,691.15222 a 167.3486,150.84944 0 1 1 -334.69721,0 167.3486,150.84944 0 1 1 334.69721,0 z"
+         sodipodi:ry="150.84944"
+         sodipodi:rx="167.3486"
+         sodipodi:cy="691.15222"
+         sodipodi:cx="478.47559"
+         id="path3277"
+         style="opacity:0.98999999;fill:url(#linearGradient3298);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:14.78016663;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.17692229,0,0,0.21002446,440.97835,245.79979)"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         sodipodi:ry="30.641294"
+         sodipodi:rx="146.13541"
+         sodipodi:cy="321.0997"
+         sodipodi:cx="579.82758"
+         id="path3308"
+         style="opacity:0.98999999;fill:url(#linearGradient3323);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:18.97210884;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient3331);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:21.31934929;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path3327"
+         sodipodi:cx="579.82758"
+         sodipodi:cy="321.0997"
+         sodipodi:rx="146.13541"
+         sodipodi:ry="30.641294"
+         d="m 725.96298,321.0997 a 146.13541,30.641294 0 1 1 -292.27081,0 146.13541,30.641294 0 1 1 292.27081,0 z"
+         transform="matrix(0.15368023,0,0,0.19147749,473.91529,234.42501)" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path3364"
+         d="m 482.4426,262.25787 c -7.81994,-1.61883 -15.46636,-12.02999 -20.71568,-3.79575 -3.94853,8.88953 12.66844,13.03963 17.67901,19.49034 2.27675,6.98894 -2.7432,18.69454 4.69174,23.15426 7.39274,-2.53575 25.20914,6.4227 31.29956,0.87008 -2.66425,-9.77284 6.27735,-23.33855 22.42436,-22.87781 7.03372,0.46889 11.31164,-16.6733 1.48508,-14.53824 -18.07619,7.1183 -32.14017,-0.52696 -29.34511,-8.54715 -4.08264,-5.63761 -5.0833,-3.85805 -11.04651,-4.7621 -0.9551,6.94224 -4.98857,13.13394 -16.47245,11.00637 z"
+         style="fill:url(#linearGradient3388);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path3366"
+         d="m 489.98134,237.03098 c -1.19473,-6.24699 5.2505,-9.51937 10.15945,-6.28946 6.18865,2.14002 12.79744,7.45433 12.01903,14.69116 0.74014,5.10086 -3.75751,11.70319 -9.28189,8.34355 -9.27329,-2.0365 -11.08178,-7.17099 -12.89659,-16.74525 z"
+         style="fill:url(#linearGradient3390);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssssssssssssc"
+         id="path3368"
+         d="m 495.89715,236.2206 c -4.18493,-1.04623 -3.20123,6.05129 -2.15499,10.23621 1.16421,4.65684 2.47171,4.63487 -2.69374,5.92623 -4.17502,1.04376 -2.73442,-0.22363 -7.00373,-1.07749 -4.58315,-0.91664 -3.81767,-0.62793 -8.08122,1.07749 -0.7524,0.30096 -6.09193,-1.5906 -8.08122,-1.61624 -6.22363,-0.0802 24.13693,-5.19167 12.92996,-15.6237 -2.84671,-2.64985 5.78555,-6.44104 6.46497,-9.15871 1.15083,-4.60331 4.43898,-3.77124 8.61997,-3.77124 3.45422,0 4.96128,3.23249 9.69746,3.23249 5.12193,0 7.68841,0.68469 10.23622,3.23249 1.47739,1.47739 3.23248,8.25854 3.23248,10.77496 0,2.59866 6.32395,8.47893 7.54248,9.69746 6.24669,6.2467 1.69035,5.92623 -4.30999,5.92623 -10.51629,0 -3.18461,-1.56837 -8.08122,-6.46497 -1.59231,-1.59231 -2.13288,-6.42077 -3.23249,-8.61997 -0.31321,-0.62643 -5.59757,-4.52008 -6.46497,-5.38748 -1.69797,-1.69798 -1.77762,-2.69374 -5.38748,-2.69374 -3.17661,0 0.61503,3.54048 -3.23249,4.30998 z"
+         style="fill:url(#linearGradient3398);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3400"
+         d="m 466.26601,259.92551 -21.01118,-12.3912"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3402"
+         d="m 540.07449,271.23922 25.32115,-11.85245"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="B">
+      <rect
+         y="200"
+         x="600"
+         height="200"
+         width="200"
+         id="rect5056-3"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.20911451,0,0,0.18432023,617.55921,178.419)"
+         d="m 584.54161,889.14215 a 212.13203,292.27081 0 1 1 -424.26407,0 212.13203,292.27081 0 1 1 424.26407,0 z"
+         sodipodi:ry="292.27081"
+         sodipodi:rx="212.13203"
+         sodipodi:cy="889.14215"
+         sodipodi:cx="372.40958"
+         id="path3173"
+         style="fill:url(#linearGradient7010);fill-opacity:1;stroke:#000000;stroke-width:23.28484535;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccssc"
+         id="path2899"
+         d="m 669.09944,318.06983 c -4.50786,-29.19737 -24.56616,-42.23332 -41.92261,-73.66611 11.42968,-4.77019 24.52135,3.8145 33.95858,15.62662 -1.98879,-11.84117 -0.95544,-27.20763 -4.07496,-41.4109 9.95763,5.97928 20.78162,24.29493 25.69941,33.17176 2.42045,-7.9625 7.57569,-28.77817 5.42666,-43.06231 11.53696,8.57719 10.46232,30.44591 13.95041,41.05723 1.03462,-3.97654 9.46098,-26.25689 11.79934,-40.62277 10.12763,8.09219 6.08557,28.2439 9.3004,38.07044 6.5083,-2.49757 13.90882,-16.85334 17.47124,-27.13414 11.74069,14.86377 -0.12796,26.39275 21.66557,30.06015 -17.5488,26.43762 -38.50569,24.2048 -34.70403,54.44425 0.5343,8.43216 -7.94634,-4.04268 -15.16028,-5.9518 -13.16167,-3.48314 -17.46271,-1.58152 -29.88278,4.2404 -6.48779,3.04115 -10.94404,7.46856 -13.52695,15.17718 z"
+         style="fill:url(#linearGradient7002);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccccccccccc"
+         id="path4058"
+         d="m 645.56453,320.84525 c 15.35498,-9.34386 2.82455,0.36289 3.94722,0.35872 3.19256,-0.0119 5.18094,-0.61908 9.01112,1.63656 9.30347,3.19057 19.35841,1.72163 28.91464,3.53502 14.68146,1.16311 29.92455,-1.61562 42.5783,-9.17782 4.47149,-2.05559 13.42795,27.07989 10.01493,30.82546 -2.90621,3.30319 -1.7233,-16.26102 -15.33339,-21.21174 -6.57875,0.38478 -12.60026,3.24305 -18.83124,4.99481 -4.52405,0.67268 -10.18642,-0.50614 -13.45034,3.43995 -3.82374,5.16178 1.00666,12.42943 -3.50975,17.33497 -4.2357,4.54627 -13.21229,4.47738 -16.64125,-0.95084 -2.02526,-3.55971 -1.4925,-8.23666 -4.55796,-11.27328 -4.89835,-1.38003 -5.81945,4.98391 -7.98562,7.79036 -3.10887,4.02979 -10.57361,3.08678 -12.15711,-1.8653 -3.83496,-7.82968 -5.14307,-17.16225 -1.99955,-25.43687 z"
+         style="fill:url(#linearGradient7004);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path4079"
+         d="m 660.14574,349.64855 c 1.56934,4.20615 -3.12426,13.76968 -5.22831,17.88332 -3.96763,7.75716 6.91187,6.8146 12.54793,6.8146"
+         style="fill:url(#linearGradient7006);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4083"
+         d="m 718.70274,331.93058 c -0.25745,0.50335 2.68406,13.42514 4.18265,16.35505 4.65648,9.10392 -6.82511,9.58801 5.57685,13.6292 4.60692,1.50118 6.97108,-9.67642 6.97108,-13.6292 0,-8.83856 0.30003,-12.11964 -5.57686,-14.99213 -8.42373,-4.11733 -4.52903,6.13739 -2.78843,9.54045"
+         style="fill:none;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4085"
+         d="m 729.68758,356.70675 c -5.06436,1.11577 -8.62856,6.0213 -8.13664,11.54888 0.53361,5.99601 5.6338,10.46757 11.38413,9.97854 5.75033,-0.48903 9.984,-5.75437 9.45039,-11.75038 -0.35771,-4.01962 -2.7635,-7.35046 -6.04578,-8.96399 1.79529,1.26526 3.05967,3.34734 3.27629,5.78148 0.37726,4.23907 -2.56652,7.95854 -6.56935,8.29896 -4.00283,0.34041 -7.55943,-2.82625 -7.93668,-7.06532 -0.31123,-3.49722 1.63856,-6.64453 4.57764,-7.82817 z"
+         style="fill:url(#linearGradient7008);fill-opacity:1;stroke:#000000;stroke-width:4.57142878;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="N">
+      <rect
+         y="200"
+         x="800"
+         height="200"
+         width="200"
+         id="rect5056-8"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssccscssssc"
+         id="path9661"
+         d="m 920.8205,291.84194 c 0.049,17.48393 -20.16603,32.60629 -40.10424,24.99055 -3.05344,-1.16631 -30.75842,23.95504 -35.19852,20.51791 -3.50284,-2.71159 3.88081,-13.88996 3.34402,-12.46222 -2.55582,6.79793 -13.83929,14.36436 -22.90059,4.59712 -3.5436,-3.81967 -2.44779,-14.80596 5.18493,-23.75613 7.94898,-9.32102 16.02019,-23.67476 19.14441,-31.95335 6.28396,-16.65129 3.81839,-17.015 15.8609,-32.11561 2.26234,-2.83684 -3.67739,-13.85043 -1.51858,-21.03944 8.52749,1.52073 11.81479,10.09428 15.7361,13.69224 2.28585,-5.29182 0.74992,-19.5111 4.81349,-18.84852 4.06357,0.66257 8.73774,12.98093 15.4412,18.39137 80.28854,24.70763 79.63224,153.18941 57.19344,153.60567 -27.6963,0.51379 -60.85495,0.39751 -88.70966,-0.0463 -6.74914,-0.10753 -9.87347,-8.83915 -8.57204,-14.0572 6.20686,-24.88642 32.41901,-42.30553 45.25898,-50.93792 13.18793,-8.86634 15.60253,-17.57941 15.02616,-30.57818 z"
+         style="fill:url(#linearGradient2319);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path31300"
+         d="m 834.46197,318.46619 c -3.16681,-1.09379 -5.45787,4.00845 -3.43731,4.21661"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path31308"
+         d="m 872.42882,308.41242 2.16857,2.69497"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path31312"
+         d="m 920.85783,284.39678 0.0665,-5.69551"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path32040"
+         d="m 874.48656,237.17701 -2.31158,1.20709"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cs"
+         id="path32768"
+         d="m 886.6903,224.88539 c 6.89194,9.62746 9.38036,11.57494 1.18548,10.19359"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2732"
+         d="m 900.14789,366.74312 -5.89252,14.05537"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path1898"
+         d="m 850.60981,259.22356 c 11.26404,2.55861 38.14752,3.77999 60.58139,-0.76311 4.70064,-0.95194 12.95819,0.11144 4.15822,2.18847 -9.48449,2.2386 -15.02058,3.19686 -24.43738,4.31759 -9.67053,1.15093 -13.07282,7.30325 -15.94626,15.89671 -1.70175,5.08936 -15.19947,2.56171 -15.69878,-1.73142 -2.61958,-22.52343 -13.25929,-13.16063 -8.65719,-19.90824 z"
+         style="fill:url(#linearGradient2802);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssccccccscccs"
+         id="path2812"
+         d="m 904.20151,231.17618 c -1.54791,8.07417 6.42833,42.46312 4.49936,66.99894 -1.35362,17.21754 -18.03189,43.65268 -15.54781,61.30942 0.80004,5.68669 14.33186,-13.02936 14.72824,10.88373 12.44808,3.14376 16.76474,-17.02112 19.71606,1.73792 14.5811,10.26284 4.3221,-27.5192 13.3171,-34.61166 6.0437,9.09426 -4.2449,38.73822 6.3436,35.65725 -1.0237,-11.0541 7.8554,-24.8993 9.0655,-6.32385 10.2371,14.2563 11.2601,-18.50012 16.5163,-25.21798 -5.6887,-26.18129 -0.6862,-38.45221 -9.8453,-57.77967 -1.4511,-3.06202 -6.3311,-14.59604 -9.3678,-17.92597 -2.575,-6.16549 -11.8146,-11.43535 -14.5309,-13.39961 -1.6808,-6.55522 -15.27926,-15.54515 -19.39758,-12.65192 -3.18859,-7.61953 -14.88246,-11.88098 -15.49677,-8.6766 z"
+         style="fill:url(#linearGradient2826);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2828-4"
+         d="m 920.67954,248.57352 c 3.15338,11.44401 5.37018,28.14888 4.07533,39.91939 -1.96753,12.16356 -6.32601,24.10939 -5.24525,36.60489 0,2.41437 3.77123,20.45243 3.77123,22.8668"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2830"
+         d="m 938.01196,261.09545 c 3.8895,9.34941 6.9685,27.1909 4.5139,37.59389 -1.163,8.88958 1.465,17.27612 -1.3739,25.83179"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2832"
+         d="m 954.08196,284.93108 c 0.5222,8.38054 3.8912,23.35923 2.4988,32.01131 -0.1917,7.57801 5.0767,18.32521 2.9948,25.71768 -0.4425,2.06841 -0.9629,4.12734 -1.7224,6.10472"
+         style="fill:none;stroke:#000000;stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2846"
+         d="m 848.05584,326.8312 c 7.73207,6.73917 15.9703,4.28414 24.44698,9.88665 9.88036,-0.31231 11.56689,18.80793 0.59986,15.67298 -5.88378,-4.88778 -24.1971,-16.09221 -31.07341,-19.50032 3.32611,-4.1301 0.83834,0.20797 6.02657,-6.05931 z"
+         style="fill:url(#linearGradient2862);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714502;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2814-7"
+         d="m 871.75733,343.13031 c -1.08082,0.85665 -2.24534,3.34019 -2.72271,5.31264 -0.46377,1.91635 1.76621,2.46215 3.02523,3.43758 1.06114,0.82213 4.05343,0.31251 5.4454,0.31251 1.43503,0 2.05948,-1.94714 2.42018,-3.43759 0.32451,-1.34087 0.30252,-2.85408 0.30252,-4.37511 0,-1.60264 -2.68599,-4.68762 -3.93279,-4.68762 -1.57065,0 -2.985,3.11677 -4.53783,3.43759 z"
+         style="fill:url(#linearGradient2822-2);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.60900903;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="P">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect9994"
+         width="200"
+         height="200"
+         x="1000"
+         y="200" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscccccccscc"
+         id="path35274"
+         d="m 1087.7986,283.99759 c -4.4788,0.057 -8.9741,1.92359 -8.9444,5.30162 0.3318,38.41514 -19.5945,28.09284 -28.9093,34.6727 -7.724,5.45618 1.951,62.71335 12.2,63.38362 6.3508,0.41534 46.6372,2.48448 52.7341,-0.0404 2.2015,-0.91169 5.1041,-34.70066 5.3743,-34.66821 10.443,0.54709 17.4615,12.49766 27.905,13.15861 6.3762,1.59674 8.7275,-4.41462 7.1582,-9.53213 1.0306,-10.73187 -0.1967,-45.22267 -5.2105,-45.85224 -5.6103,-0.8497 -11.0442,8.07405 -10.2114,12.58746 -0.24,7.05376 1.3332,8.10853 -1.7727,14.72596 -3.9383,3.71361 -6.7692,-4.43961 -8.5063,-6.08979 -0.6803,0.91016 -1.1599,-7.28717 -1.6783,-8.31956 -6.2762,-12.4992 -30.7607,6.12866 -31.2819,-33.9519 -0.049,-3.73056 -4.4474,-5.43186 -8.8568,-5.37572 z"
+         style="fill:url(#linearGradient2296);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006442;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.16426994,0,0,0.19426503,1018.6195,196.71433)"
+         d="m 540.00002,435 a 116.66667,116.66667 0 1 1 -233.33335,0 116.66667,116.66667 0 1 1 233.33335,0 z"
+         sodipodi:ry="116.66667"
+         sodipodi:rx="116.66667"
+         sodipodi:cy="435"
+         sodipodi:cx="423.33334"
+         id="path3371"
+         style="opacity:0.98999999;fill:url(#linearGradient3243);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:19.31306076;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccsc"
+         id="path4628"
+         d="m 1066.2082,311.53531 c -5.2679,3.46199 -12.8574,6.44012 -15.6645,7.72675 7.1256,8.54835 39.7004,58.01412 41.0251,70.83319 3.7493,0.37746 11.3426,0.404 19.4728,0.31662 -2.3333,-10.92307 -37.1248,-65.44491 -44.8334,-78.87656 z m 41.4126,1.10478 c -6.5029,13.69535 -47.7254,68.11908 -49.7255,77.64379 7.8235,-0.13369 15.0328,-0.2939 18.6371,-0.26273 0.511,-4.55693 41.0223,-66.61347 45.661,-71.38558 -8.2398,-6.26594 -8.6486,-4.11225 -13.6694,-5.72602 -0.2987,-0.096 -0.598,-0.18391 -0.9032,-0.26946 z"
+         style="fill:url(#linearGradient2294);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006371;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccsscccccccscc"
+         id="path3219"
+         d="m 1085.9229,262.60105 c -10.5947,0.67991 -14.5464,13.09545 -13.2879,21.51918 -0.7143,8.47929 3.9134,17.55317 5.4848,25.77619 -4.3211,8.81198 -9.9164,-14.26446 -11.1653,-5.93671 2.0548,6.61616 -0.6721,13.71458 -8.5969,10.69479 -7.9876,3.91619 -10.4614,-4.60016 -3.9906,-8.52764 2.6193,-7.31951 -17.622,4.19009 -8.728,-4.74548 7.3437,-4.38157 12.2018,-9.90114 12.887,-18.44523 1.0512,-10.61099 5.8864,-20.1017 13.2245,-27.1306 5.8116,-5.56671 15.8722,-5.83986 22.9953,-3.69512 7.6759,2.31116 11.2339,6.86363 15.1627,12.98718 3.1308,6.66953 4.6297,14.01591 7.8401,20.72008 1.5125,9.27168 6.4068,15.7873 14.4546,20.91979 1.5274,4.67776 -8.7611,3.91174 -11.484,6.48789 -2.7603,-1.38374 -5.2003,-10.91793 -5.3535,-2.77368 2.9314,9.19519 -15.9269,12.79596 -14.1532,3.16118 2.6353,-3.51122 3.3803,-8.27584 -2.4024,-4.13274 -3.7018,-1.96394 3.1458,-12.45095 3.846,-18.26708 0.8896,-7.38919 1.6506,-10.72389 -1.3259,-17.75722 -3.365,-5.04962 -8.7201,-11.45246 -15.4073,-10.85478 z"
+         style="fill:url(#linearGradient3230);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.45006442;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssssssss"
+         id="path2957"
+         d="m 1092.0357,354.0227 c 0.8912,1.12956 20.8982,0.7212 17.3432,9.63672 -1.6101,4.03809 -13.7294,4.54253 -17.2467,6.22418 -5.9438,2.84172 -10.1607,8.69724 -11.4657,15.24429 -1.0358,5.19638 -2.2547,9.73553 -7.5473,12.06916 -12.3342,5.43853 -8.1434,-8.92071 -10.2544,-14.94663 -1.9674,-5.61631 -10.6373,-5.40474 -14.3007,-10.31362 -1.6933,-2.26904 -1.0242,-5.98331 1.8111,-7.34832 5.2639,-2.53425 10.6513,-2.57578 16.0015,-3.99944 5.0236,-1.3368 12.6641,-9.48165 13.6953,-14.08526 1.9967,-8.91448 1.42,-20.03156 10.3486,-21.68278 4.3242,-0.79973 5.5403,10.31254 5.2233,14.28181 -0.4073,5.10117 -4.438,13.86807 -3.6082,14.91989 z"
+         style="fill:url(#linearGradient2983);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19235921;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2967"
+         d="m 1072.6926,377.26178 81.9198,-69.187 -1.9506,-8.70566 -84.6508,72.56819 4.6816,5.32447 z"
+         style="fill:url(#linearGradient2975);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19236016;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc"
+         id="path1395"
+         d="m 1052.5332,321.68824 c -1.5745,0.23051 -2.9996,0.82938 -4.1183,2.14894 -1.0029,2.59597 -0.774,5.55095 -2.0289,8.09053 -3.9902,9.66061 -6.4912,19.85569 -10.589,29.47887 -3.6278,5.47842 1.2614,9.69275 6.6122,9.91611 9.7836,4.54145 20.358,7.49907 30.9854,9.07405 4.0783,-0.66359 10.0593,1.41729 12.3213,-3.09879 2.6681,-5.00514 -2.2517,-8.72133 -6.7875,-9.43782 -6.576,-2.57277 -14.2013,-3.5951 -19.4122,-8.72375 -2.194,-4.9473 -0.4699,-10.36434 1.348,-15.08973 -0.1732,-3.12306 1.3566,-4.06513 3.4915,-5.15341 -4.4978,-6.71252 -8.4152,-12.97402 -11.8225,-17.205 z"
+         style="fill:url(#linearGradient2292);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.4500649;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2985"
+         d="m 1154.5662,307.51132 20.6161,-3.13491 -2.0086,-17.95774 -22.1866,14.00797 3.5791,7.08468 z"
+         style="fill:url(#linearGradient2993);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.19235992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4122"
+         d="m 1079.5715,281.55921 c 0.3348,0.2053 3.4142,-0.85305 4.31,-1.07688"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4124"
+         d="m 1089.269,280.48233 c 0.8979,-0.17948 1.7958,-0.35896 2.6937,-0.53845 0.7917,-0.15823 1.8687,0 2.6938,0"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#000000;stroke-width:3.42759466;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1086.0365,292.86647 c 0.3347,0.2053 3.4142,-0.85305 4.31,-1.07688"
+         id="path4128" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/prmi.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/prmi.svg
@@ -1,0 +1,6832 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="prmi.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title14623">Prmi Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       id="linearGradient4702">
+      <stop
+         id="stop4704"
+         offset="0"
+         style="stop-color:#808080;stop-opacity:0.75294119;" />
+      <stop
+         id="stop4706"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.75294119;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientSand">
+      <stop
+         style="stop-color:#776672;stop-opacity:0.64016736;"
+         offset="0"
+         id="stop4710" />
+      <stop
+         style="stop-color:#0e0e0e;stop-opacity:0.54393303;"
+         offset="1"
+         id="stop4712" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePiecesGrad">
+      <stop
+         id="stop4680"
+         offset="0"
+         style="stop-color:#ab7469;stop-opacity:1;" />
+      <stop
+         id="stop4682"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesGrad">
+      <stop
+         style="stop-color:#64779c;stop-opacity:1;"
+         offset="0"
+         id="stop4686" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4688" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesShade">
+      <stop
+         id="stop13366"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop13368"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePiecesShade">
+      <stop
+         offset="0"
+         id="stop13557"
+         style="stop-color:#1a0f00;stop-opacity:1;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop13559" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop7929"
+         offset="0"
+         style="stop-color:#ede3de;stop-opacity:1;" />
+      <stop
+         id="stop7931"
+         offset="1"
+         style="stop-color:#d0b090;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#181818;stop-opacity:1;"
+         offset="0"
+         id="stop7192" />
+      <stop
+         style="stop-color:#181818;stop-opacity:1;"
+         offset="1"
+         id="stop7194" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         id="stop12143"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop12145"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         id="stop2268"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop2270"
+         offset="1"
+         style="stop-color:#505070;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,75.284646,227.25879)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,121.72186,226.02423)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3256"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,-4.3148837,117.5827)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10410"
+       x1="-303.40869"
+       y1="-139.80017"
+       x2="651.23621"
+       y2="525.12677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12307246,0,0,0.15793852,46.688806,28.630147)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient4883"
+       x1="-153.70424"
+       y1="-341.60275"
+       x2="889.69318"
+       y2="659.1109"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient12112"
+       gradientUnits="userSpaceOnUse"
+       x1="188.83656"
+       y1="5.5850191"
+       x2="526.30945"
+       y2="257.17569"
+       gradientTransform="matrix(0.16694469,0,0,0.16694469,25.528756,6.8087573)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2367"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,219.98431,125.97333)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,93.605996,242.48686)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,124.16614,240.68983)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2335"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,208.74847,149.83666)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2333"
+       gradientUnits="userSpaceOnUse"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,205.75286,148.58181)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2323"
+       gradientUnits="userSpaceOnUse"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,102.1908,241.69691)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2317"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,72.025606,240.29509)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2311"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,-12.713074,149.96027)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2313"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,-8.3265137,147.79182)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3274"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,48.609937)" />
+    <linearGradient
+       id="linearGradientWhitePiecesEye">
+      <stop
+         id="stop4692"
+         offset="0"
+         style="stop-color:#4f98ae;stop-opacity:1;" />
+      <stop
+         id="stop4694"
+         offset="1"
+         style="stop-color:#7294cd;stop-opacity:0.1375;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesEye">
+      <stop
+         style="stop-color:#a7cc52;stop-opacity:1;"
+         offset="0"
+         id="stop4698" />
+      <stop
+         style="stop-color:#afc14d;stop-opacity:0.27083334;"
+         offset="1"
+         id="stop4700" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3278"
+       gradientUnits="userSpaceOnUse"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,178.73756,48.897987)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient3290"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,48.609937)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3296"
+       gradientUnits="userSpaceOnUse"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,48.609937)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3264-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00384395,-0.03919383,0.03919383,0.00384395,1080.7608,217.14016)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3260-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00384395,-0.03919383,-0.03919383,0.00384395,1124.4121,215.97966)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3256-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03888114,-0.00625959,-0.00625959,-0.03888114,1005.9366,114.04368)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2367-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03561257,0,0,0.03561257,1216.7797,121.93095)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2363"
+       gradientUnits="userSpaceOnUse"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863"
+       gradientTransform="matrix(0.03561257,0,0,0.03561257,990.41242,122.47253)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2339-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00157892,-0.03935017,-0.03935017,0.00157892,1097.983,231.45463)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2337-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00384395,-0.03919383,-0.03919383,0.00384395,1126.7098,229.76549)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2335-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03938194,0,0,0.03938194,1206.218,144.3627)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2333-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientTransform="matrix(-0.03938194,0,0,0.03938194,1203.4021,143.18311)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2323-5"
+       gradientUnits="userSpaceOnUse"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462"
+       gradientTransform="matrix(0.00157892,-0.03935017,0.03935017,0.00157892,1106.0528,230.71223)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2317-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00384395,-0.03919383,0.03919383,0.00384395,1077.6973,229.39429)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2311-6"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03938194,0,0,0.03938194,998.04218,144.47888)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2313-9"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03938194,0,0,0.03938194,1002.1656,142.44053)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3274-3"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16246811,0,0,0.16246811,1026.3686,49.208706)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3278-4"
+       gradientUnits="userSpaceOnUse"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientTransform="matrix(-0.16246811,0,0,0.16246811,1178.0075,49.479466)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient3290-9"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16246812,0,0,0.16246812,1026.3686,49.208726)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3296-1"
+       gradientUnits="userSpaceOnUse"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026"
+       gradientTransform="matrix(0.16246812,0,0,0.16246812,1026.3686,49.208726)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7403"
+       x1="120.73775"
+       y1="168.28075"
+       x2="536.52966"
+       y2="749.29095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,403.70627,-28.351526)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientSand"
+       id="linearGradient8324"
+       x1="-24.895142"
+       y1="375.82123"
+       x2="8.518218"
+       y2="865.33405"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,392.66986,-32.188306)" />
+    <linearGradient
+       id="linearGradient8318">
+      <stop
+         style="stop-color:#808080;stop-opacity:0.75294119;"
+         offset="0"
+         id="stop8320" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.75294119;"
+         offset="1"
+         id="stop8322" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7411"
+       x1="352.38409"
+       y1="117.34422"
+       x2="375.94513"
+       y2="501.8501"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,401.55128,-30.269906)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3264-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,275.01848,226.87598)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3260-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,321.45569,225.64123)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3256-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,195.41897,117.19973)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1342"
+       gradientUnits="userSpaceOnUse"
+       x1="-18.257166"
+       y1="54.897514"
+       x2="120.35538"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       x1="-4.1851606"
+       y1="121.50303"
+       x2="126.04134"
+       y2="285.82776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient1334"
+       gradientUnits="userSpaceOnUse"
+       x1="-30.318884"
+       y1="123.72321"
+       x2="127.46282"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient10327"
+       x1="-26.298311"
+       y1="119.28284"
+       x2="128.88431"
+       y2="288.96759"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9438"
+       x1="-240.84088"
+       y1="-81.381439"
+       x2="646.93561"
+       y2="602.71436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08688183,0,0,0.15594743,259.78387,12.901427)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2367-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,419.71814,125.59035)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2363-6"
+       gradientUnits="userSpaceOnUse"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,178.90407,126.16649)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2339-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,293.33983,242.10377)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2337-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,323.89996,240.30674)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2335-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,408.4823,149.45369)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2333-9"
+       gradientUnits="userSpaceOnUse"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,405.48668,148.19883)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2323-2"
+       gradientUnits="userSpaceOnUse"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,301.92463,241.31383)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2317-51"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,271.75944,239.912)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2311-60"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,187.02078,149.5773)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2313-4"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,191.40734,147.40885)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3274-31"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,48.226967)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3278-6"
+       gradientUnits="userSpaceOnUse"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,378.47142,48.515017)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient3290-5"
+       x1="466.62888"
+       y1="160.41989"
+       x2="463.51178"
+       y2="586.85248"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,48.226967)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3296-8"
+       gradientUnits="userSpaceOnUse"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,48.226967)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient6389"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02907017,-0.01075687,-0.01075687,0.02907017,1006.516,212.75035)"
+       x1="585.86346"
+       y1="-458.22153"
+       x2="2624.375"
+       y2="-647.81598" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient6342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,901.01212,116.90176)"
+       x1="1290.3789"
+       y1="-26.147289"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3264-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00545415,-0.0270457,0.0270457,0.00545415,838.71277,108.666)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3260-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.5723291e-5,-0.02759001,-0.02759001,-9.5723291e-5,869.21974,110.94757)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3256-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02754304,-0.00161011,-0.00161011,-0.02754304,793.85997,31.510637)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2367-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02482174,-0.00252138,-0.00252138,0.02482174,940.25813,51.935807)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2363-2"
+       gradientUnits="userSpaceOnUse"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863"
+       gradientTransform="matrix(0.02482174,0.00252138,-0.00252138,0.02482174,782.44297,36.286387)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2339-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00168549,-0.02753854,-0.02753854,-0.00168549,849.70314,119.86236)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2337-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.5723291e-5,-0.02759001,-0.02759001,-9.5723291e-5,869.84513,120.71886)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2335-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02744902,-0.00278826,-0.00278826,0.02744902,931.3084,66.822837)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2323-1"
+       gradientUnits="userSpaceOnUse"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462"
+       gradientTransform="matrix(0.0038865,-0.02731496,0.02731496,0.0038865,855.3803,119.91616)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2317-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00545415,-0.0270457,0.0270457,0.00545415,835.70992,116.99012)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2311-8"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02744902,0.00278826,-0.00278826,0.02744902,786.20281,52.164897)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2313-0"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02744902,0.00278826,-0.00278826,0.02744902,789.22112,51.036077)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3274-6"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11323947,0.01150281,-0.01150281,0.11323947,812.69135,-12.232373)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3278-3"
+       gradientUnits="userSpaceOnUse"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientTransform="matrix(-0.11323947,-0.01150281,-0.01150281,0.11323947,918.36362,-1.3075627)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient3290-2"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11323927,0.01150279,-0.01150279,0.11323927,812.69135,-12.232343)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3296-7"
+       gradientUnits="userSpaceOnUse"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026"
+       gradientTransform="matrix(0.11323927,0.01150279,-0.01150279,0.11323927,812.69135,-12.232343)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient6369"
+       gradientUnits="userSpaceOnUse"
+       x1="539.62653"
+       y1="160.31224"
+       x2="387.86493"
+       y2="602.17395"
+       gradientTransform="matrix(0.21986469,0,0,0.21986469,800.9063,7.8557773)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6373"
+       gradientUnits="userSpaceOnUse"
+       x1="412.63089"
+       y1="830.20721"
+       x2="545.04303"
+       y2="675.33276"
+       gradientTransform="matrix(0.21986469,0,0,0.21986469,800.9063,7.8557773)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3264-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,679.82347,227.26985)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3260-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,726.26064,226.03534)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06028869,-0.00399079,0.007582,0.08553806,713.19705,34.71986)"
+       x1="-1567.2875"
+       y1="-173.39944"
+       x2="-199.66586"
+       y2="439.2937" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18767452,0,0,0.15070789,623.12144,0.84571)"
+       x1="-153.95351"
+       y1="-67.192932"
+       x2="615.71777"
+       y2="620.05176" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7567"
+       gradientUnits="userSpaceOnUse"
+       x1="696.98621"
+       y1="124.25547"
+       x2="216.33333"
+       y2="486.99237"
+       gradientTransform="matrix(-0.18767452,0,0,0.15070789,781.37068,-0.66139)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient3256-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,600.22396,117.59374)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient7571"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18767452,0,0,0.15070789,624.99819,15.57745)"
+       x1="-32.538746"
+       y1="195.9679"
+       x2="575.18024"
+       y2="588.12415" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2367-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,824.52304,125.98437)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2363-15"
+       gradientUnits="userSpaceOnUse"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,583.70906,126.56059)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2339-07"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,698.14482,242.49806)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2337-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,728.70498,240.70103)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2335-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,813.28715,149.84791)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2333-7"
+       gradientUnits="userSpaceOnUse"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,810.2915,148.59305)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2323-6"
+       gradientUnits="userSpaceOnUse"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,706.72967,241.70811)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2317-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,676.56443,240.30629)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2311-3"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,591.82576,149.97134)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient2313-6"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,596.21232,147.80288)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3274-5"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,48.6211)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesEye"
+       id="linearGradient3278-2"
+       gradientUnits="userSpaceOnUse"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,783.27641,48.90914)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesGrad"
+       id="linearGradient3290-7"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,48.6211)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient3296-73"
+       gradientUnits="userSpaceOnUse"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,48.6211)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,248.60994)"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10671"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,248.60994)"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10673"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,178.73756,248.89799)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10675"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,17.421166,248.60994)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,-8.3265137,347.79182)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10679"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,-12.713074,349.96027)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,72.025606,440.29509)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10683"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,102.1908,441.69691)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,205.75286,348.58181)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,208.74847,349.83666)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,124.16614,440.68983)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,93.605996,442.48686)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,-20.829784,326.54946)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,219.98431,325.97333)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16694469,0,0,0.16694469,25.528756,206.80876)"
+       x1="188.83656"
+       y1="5.5850191"
+       x2="526.30945"
+       y2="257.17569" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10699"
+       gradientUnits="userSpaceOnUse"
+       x1="-153.70424"
+       y1="-341.60275"
+       x2="889.69318"
+       y2="659.1109" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10701"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12307246,0,0,0.15793852,46.688806,228.63015)"
+       x1="-303.40869"
+       y1="-139.80017"
+       x2="651.23621"
+       y2="525.12677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,-4.3148837,317.5827)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10705"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,121.72186,426.02423)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,75.284646,427.25879)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16246812,0,0,0.16246812,1026.3686,249.20873)"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10711"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16246812,0,0,0.16246812,1026.3686,249.20873)"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10713"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.16246811,0,0,0.16246811,1178.0075,249.47947)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10715"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16246811,0,0,0.16246811,1026.3686,249.20871)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03938194,0,0,0.03938194,1002.1656,342.44053)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10719"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03938194,0,0,0.03938194,998.04218,344.47888)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10721"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00384395,-0.03919383,0.03919383,0.00384395,1077.6973,429.39429)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00157892,-0.03935017,0.03935017,0.00157892,1106.0528,430.71223)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03938194,0,0,0.03938194,1203.4021,343.18311)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03938194,0,0,0.03938194,1206.218,344.3627)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00384395,-0.03919383,-0.03919383,0.00384395,1126.7098,429.76549)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00157892,-0.03935017,-0.03935017,0.00157892,1097.983,431.45463)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10733"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03561257,0,0,0.03561257,990.41242,322.47253)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10735"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03561257,0,0,0.03561257,1216.7797,321.93095)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03888114,-0.00625959,-0.00625959,-0.03888114,1005.9366,314.04368)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10739"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00384395,-0.03919383,-0.03919383,0.00384395,1124.4121,415.97966)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10741"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00384395,-0.03919383,0.03919383,0.00384395,1080.7608,417.14016)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10743"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,401.55128,169.73009)"
+       x1="352.38409"
+       y1="117.34422"
+       x2="375.94513"
+       y2="501.8501" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientSand"
+       id="linearGradient10745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,392.66986,167.81169)"
+       x1="-24.895142"
+       y1="375.82123"
+       x2="8.518218"
+       y2="865.33405" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.2713024,403.70627,171.64847)"
+       x1="120.73775"
+       y1="168.28075"
+       x2="536.52966"
+       y2="749.29095" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,248.22697)"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,248.22697)"
+       x1="466.62888"
+       y1="160.41989"
+       x2="463.51178"
+       y2="586.85248" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10753"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,378.47142,248.51502)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,217.15502,248.22697)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,191.40734,347.40885)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,187.02078,349.5773)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10761"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,271.75944,439.912)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,301.92463,441.31383)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,405.48668,348.19883)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10767"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,408.4823,349.45369)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10769"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,323.89996,440.30674)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,293.33983,442.10377)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10773"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,178.90407,326.16649)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10775"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,419.71814,325.59035)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08688183,0,0,0.15594743,259.78387,212.90143)"
+       x1="-240.84088"
+       y1="-81.381439"
+       x2="646.93561"
+       y2="602.71436" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10779"
+       gradientUnits="userSpaceOnUse"
+       x1="-26.298311"
+       y1="119.28284"
+       x2="128.88431"
+       y2="288.96759" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10781"
+       gradientUnits="userSpaceOnUse"
+       x1="-30.318884"
+       y1="123.72321"
+       x2="127.46282"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10783"
+       gradientUnits="userSpaceOnUse"
+       x1="-4.1851606"
+       y1="121.50303"
+       x2="126.04134"
+       y2="285.82776" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10785"
+       gradientUnits="userSpaceOnUse"
+       x1="-18.257166"
+       y1="54.897514"
+       x2="120.35538"
+       y2="290.53751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10787"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,195.41897,317.19973)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10789"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,321.45569,425.64123)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10791"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,275.01848,426.87598)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10793"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21986469,0,0,0.21986469,800.9063,207.85578)"
+       x1="412.63089"
+       y1="830.20721"
+       x2="545.04303"
+       y2="675.33276" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21986469,0,0,0.21986469,800.9063,207.85578)"
+       x1="539.62653"
+       y1="160.31224"
+       x2="387.86493"
+       y2="602.17395" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11323927,0.01150279,-0.01150279,0.11323927,812.69135,187.76766)"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11323927,0.01150279,-0.01150279,0.11323927,812.69135,187.76766)"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10801"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.11323947,-0.01150281,-0.01150281,0.11323947,918.36362,198.69244)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11323947,0.01150281,-0.01150281,0.11323947,812.69135,187.76763)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02744902,0.00278826,-0.00278826,0.02744902,789.22112,251.03608)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02744902,0.00278826,-0.00278826,0.02744902,786.20281,252.1649)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00545415,-0.0270457,0.0270457,0.00545415,835.70992,316.99012)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0038865,-0.02731496,0.02731496,0.0038865,855.3803,319.91616)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10815"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02744902,-0.00278826,-0.00278826,0.02744902,931.3084,266.82284)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10817"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.5723291e-5,-0.02759001,-0.02759001,-9.5723291e-5,869.84513,320.71886)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10819"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00168549,-0.02753854,-0.02753854,-0.00168549,849.70314,319.86236)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10821"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02482174,0.00252138,-0.00252138,0.02482174,782.44297,236.28639)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10823"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02482174,-0.00252138,-0.00252138,0.02482174,940.25813,251.93581)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10825"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02754304,-0.00161011,-0.00161011,-0.02754304,793.85997,231.51064)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(9.5723291e-5,-0.02759001,-0.02759001,-9.5723291e-5,869.21974,310.94757)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00545415,-0.0270457,0.0270457,0.00545415,838.71277,308.666)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10835"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02997691,-0.00788555,-0.00788555,0.02997691,994.9294,370.78482)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10837"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02907017,-0.01075687,-0.01075687,0.02907017,995.91603,396.24434)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10847"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,901.01212,316.90176)"
+       x1="1290.3789"
+       y1="-26.147289"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10849"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,896.88966,295.60238)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10851"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,888.64474,279.11253)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10853"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02907017,-0.01075687,-0.01075687,0.02907017,1006.516,412.75035)"
+       x1="585.86346"
+       y1="-458.22153"
+       x2="2624.375"
+       y2="-647.81598" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10855"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,248.6211)"
+       x1="472.81"
+       y1="747.08655"
+       x2="472.81"
+       y2="566.33026" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesGrad"
+       id="linearGradient10857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,248.6211)"
+       x1="466.62888"
+       y1="160.41989"
+       x2="466.62888"
+       y2="546.33032" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10859"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1728368,0,0,0.1728368,783.27641,248.90914)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesEye"
+       id="linearGradient10861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1728368,0,0,0.1728368,621.96,248.6211)"
+       x1="337.50623"
+       y1="472.64157"
+       x2="352.78772"
+       y2="578.18219" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,596.21232,347.80288)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10865"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04189531,0,0,0.04189531,591.82576,349.97134)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,676.56443,440.30629)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00167969,-0.04186149,0.04186149,0.00167969,706.72967,441.70811)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10871"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,810.2915,348.59305)"
+       x1="2087.1404"
+       y1="-485"
+       x2="2033.2518"
+       y2="-862.51611" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04189531,0,0,0.04189531,813.28715,349.84791)"
+       x1="2394.7349"
+       y1="-485"
+       x2="2394.7349"
+       y2="-938.33337" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,728.70498,440.70103)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00167969,-0.04186149,-0.04186149,0.00167969,698.14482,442.49806)"
+       x1="2234.7434"
+       y1="-614.40747"
+       x2="1987.2833"
+       y2="-832.36462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,583.70906,326.56059)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03788526,0,0,0.03788526,824.52304,325.98437)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10883"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18767452,0,0,0.15070789,624.99819,215.57745)"
+       x1="-32.538746"
+       y1="195.9679"
+       x2="575.18024"
+       y2="588.12415" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10885"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04136251,-0.00665908,-0.00665908,-0.04136251,600.22396,317.59374)"
+       x1="2653.51"
+       y1="1167.8967"
+       x2="2228.9055"
+       y2="-1469.516" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18767452,0,0,0.15070789,781.37068,199.33861)"
+       x1="696.98621"
+       y1="124.25547"
+       x2="216.33333"
+       y2="486.99237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10889"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18767452,0,0,0.15070789,623.12144,200.84571)"
+       x1="-153.95351"
+       y1="-67.192932"
+       x2="615.71777"
+       y2="620.05176" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient10891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06028869,-0.00399079,0.007582,0.08553806,713.19705,234.71986)"
+       x1="-1567.2875"
+       y1="-173.39944"
+       x2="-199.66586"
+       y2="439.2937" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10893"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.00408927,-0.04169509,-0.04169509,0.00408927,726.26064,426.03534)"
+       x1="2437.9685"
+       y1="-388.63342"
+       x2="2293.6538"
+       y2="-745.58392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient10895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.00408927,-0.04169509,0.04169509,0.00408927,679.82347,427.26985)"
+       x1="2470.0815"
+       y1="-364.98831"
+       x2="2309.7107"
+       y2="-733.76135" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11799"
+       x1="406.46521"
+       y1="102.55879"
+       x2="595.86932"
+       y2="102.55879"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11801"
+       x1="405.8338"
+       y1="140.37169"
+       x2="595.84729"
+       y2="140.37169"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11809"
+       x1="430.07938"
+       y1="115.61155"
+       x2="582.81036"
+       y2="115.61155"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11811"
+       x1="491.78247"
+       y1="112.85697"
+       x2="558.67767"
+       y2="112.85697"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11813"
+       x1="446.82053"
+       y1="103.96663"
+       x2="504.85513"
+       y2="103.96663"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11829"
+       x1="314.55786"
+       y1="178.22981"
+       x2="349.4191"
+       y2="178.22981"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11831"
+       x1="311.18384"
+       y1="181.76114"
+       x2="342.42447"
+       y2="181.76114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11833"
+       x1="315.56259"
+       y1="167.31906"
+       x2="353.32864"
+       y2="167.31906"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11835"
+       x1="306.7645"
+       y1="162.97026"
+       x2="344.49649"
+       y2="162.97026"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11837"
+       x1="246.68523"
+       y1="178.6248"
+       x2="281.54648"
+       y2="178.6248"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11839"
+       x1="253.67982"
+       y1="182.15611"
+       x2="284.92047"
+       y2="182.15611"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11841"
+       x1="274.47284"
+       y1="174.42068"
+       x2="319.7207"
+       y2="174.42068"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11843"
+       x1="249.35735"
+       y1="171.93837"
+       x2="287.24445"
+       y2="171.93837"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11845"
+       x1="242.77568"
+       y1="167.71404"
+       x2="280.54172"
+       y2="167.71404"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11847"
+       x1="251.60785"
+       y1="163.36526"
+       x2="289.33984"
+       y2="163.36526"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11849"
+       x1="286.57349"
+       y1="165.59206"
+       x2="308.24286"
+       y2="165.59206"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11851"
+       x1="308.85989"
+       y1="171.5434"
+       x2="346.74698"
+       y2="171.5434"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11853"
+       x1="262.45978"
+       y1="145.85728"
+       x2="292.25168"
+       y2="145.85728"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11855"
+       x1="303.48175"
+       y1="145.32648"
+       x2="333.27365"
+       y2="145.32648"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11857"
+       x1="245.20686"
+       y1="138.04398"
+       x2="352.54108"
+       y2="138.04398"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11897"
+       x1="39.999996"
+       y1="245.83333"
+       x2="133.33333"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11899"
+       x1="39.999996"
+       y1="245.83333"
+       x2="133.33333"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11901"
+       x1="39.999996"
+       y1="245.83333"
+       x2="133.33333"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11903"
+       x1="39.999996"
+       y1="245.83333"
+       x2="133.33333"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11905"
+       x1="251.04636"
+       y1="69.702599"
+       x2="341.8764"
+       y2="69.702599"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11913"
+       x1="45.473019"
+       y1="138.42693"
+       x2="152.80724"
+       y2="138.42693"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11915"
+       x1="73.667786"
+       y1="40.290787"
+       x2="122.48566"
+       y2="40.290787"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11917"
+       x1="316.61819"
+       y1="546.96198"
+       x2="1106.3282"
+       y2="546.96198"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11919"
+       x1="53.68819"
+       y1="82.306328"
+       x2="143.37979"
+       y2="82.306328"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11921"
+       x1="62.725922"
+       y1="146.24023"
+       x2="92.517822"
+       y2="146.24023"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11923"
+       x1="103.74792"
+       y1="145.70943"
+       x2="133.53981"
+       y2="145.70943"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11925"
+       x1="114.824"
+       y1="178.61276"
+       x2="149.68526"
+       y2="178.61276"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11927"
+       x1="111.45"
+       y1="182.14409"
+       x2="142.69063"
+       y2="182.14409"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11929"
+       x1="109.12604"
+       y1="171.92633"
+       x2="147.01314"
+       y2="171.92633"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11933"
+       x1="46.951382"
+       y1="179.00775"
+       x2="81.812637"
+       y2="179.00775"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11935"
+       x1="53.94598"
+       y1="182.53908"
+       x2="85.186623"
+       y2="182.53908"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11937"
+       x1="74.738968"
+       y1="174.80363"
+       x2="119.98684"
+       y2="174.80363"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11939"
+       x1="49.623489"
+       y1="172.32133"
+       x2="87.510597"
+       y2="172.32133"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11941"
+       x1="43.041832"
+       y1="168.09698"
+       x2="80.807892"
+       y2="168.09698"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11943"
+       x1="51.873989"
+       y1="163.74821"
+       x2="89.605988"
+       y2="163.74821"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11945"
+       x1="86.839622"
+       y1="165.97501"
+       x2="108.50901"
+       y2="165.97501"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11969"
+       x1="108.85922"
+       y1="163.35321"
+       x2="142.93407"
+       y2="163.35321"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11971"
+       x1="117.65732"
+       y1="167.702"
+       x2="151.76622"
+       y2="167.702"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11973"
+       x1="83.918159"
+       y1="97.479866"
+       x2="113.21502"
+       y2="97.479866"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11981"
+       x1="650.01184"
+       y1="138.4381"
+       x2="757.34607"
+       y2="138.4381"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11983"
+       x1="671.0036"
+       y1="55.351688"
+       x2="744.99353"
+       y2="55.351688"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11985"
+       x1="677.3183"
+       y1="70.734879"
+       x2="710.34222"
+       y2="70.734879"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11987"
+       x1="669.06531"
+       y1="83.144768"
+       x2="732.8877"
+       y2="83.144768"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11989"
+       x1="694.63049"
+       y1="104.60498"
+       x2="708.32458"
+       y2="104.60498"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11991"
+       x1="667.26477"
+       y1="146.25139"
+       x2="697.05664"
+       y2="146.25139"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11993"
+       x1="708.28674"
+       y1="145.72061"
+       x2="738.07861"
+       y2="145.72061"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11995"
+       x1="719.36285"
+       y1="178.62393"
+       x2="754.22406"
+       y2="178.62393"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11997"
+       x1="715.98883"
+       y1="182.15526"
+       x2="747.22949"
+       y2="182.15526"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient11999"
+       x1="713.66486"
+       y1="171.93752"
+       x2="751.552"
+       y2="171.93752"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12001"
+       x1="720.36761"
+       y1="167.71317"
+       x2="758.13361"
+       y2="167.71317"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12003"
+       x1="711.56952"
+       y1="163.3644"
+       x2="749.30145"
+       y2="163.3644"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12005"
+       x1="651.49023"
+       y1="179.01892"
+       x2="686.3515"
+       y2="179.01892"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12007"
+       x1="658.4848"
+       y1="182.55025"
+       x2="689.72546"
+       y2="182.55025"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12009"
+       x1="679.27783"
+       y1="174.8148"
+       x2="724.5257"
+       y2="174.8148"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12011"
+       x1="654.16235"
+       y1="172.3325"
+       x2="692.04944"
+       y2="172.3325"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12013"
+       x1="647.58069"
+       y1="168.10817"
+       x2="685.34674"
+       y2="168.10817"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12015"
+       x1="656.41284"
+       y1="163.75938"
+       x2="694.14484"
+       y2="163.75938"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12017"
+       x1="691.37848"
+       y1="165.98618"
+       x2="713.04785"
+       y2="165.98618"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12019"
+       x1="658.46643"
+       y1="57.223347"
+       x2="738.61884"
+       y2="57.223347"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12027"
+       x1="866.9798"
+       y1="80.585518"
+       x2="889.74353"
+       y2="80.585518"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12029"
+       x1="864.74054"
+       y1="82.554146"
+       x2="884.71942"
+       y2="82.554146"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12031"
+       x1="863.45459"
+       y1="75.926178"
+       x2="888.67487"
+       y2="75.926178"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12033"
+       x1="867.97302"
+       y1="73.766945"
+       x2="893.38757"
+       y2="73.766945"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12035"
+       x1="862.30762"
+       y1="69.768745"
+       x2="888.10181"
+       y2="69.768745"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12037"
+       x1="821.54883"
+       y1="76.327179"
+       x2="846.18427"
+       y2="76.327179"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12039"
+       x1="825.69019"
+       y1="78.98587"
+       x2="848.36615"
+       y2="78.98587"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12041"
+       x1="840.2962"
+       y1="76.257553"
+       x2="870.79498"
+       y2="76.257553"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12043"
+       x1="823.98163"
+       y1="72.174011"
+       x2="850.12543"
+       y2="72.174011"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12045"
+       x1="820.07001"
+       y1="68.79509"
+       x2="845.8609"
+       y2="68.79509"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12047"
+       x1="826.35754"
+       y1="66.820374"
+       x2="851.72418"
+       y2="66.820374"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12049"
+       x1="848.30438"
+       y1="69.939278"
+       x2="863.3714"
+       y2="69.939278"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12057"
+       x1="839.53564"
+       y1="136.44556"
+       x2="970.9306"
+       y2="136.44556"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12059"
+       x1="887.95624"
+       y1="104.16133"
+       x2="971.50403"
+       y2="104.16133"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12061"
+       x1="826.01733"
+       y1="50.731064"
+       x2="899.16779"
+       y2="50.731064"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12063"
+       x1="860.71814"
+       y1="57.805115"
+       x2="882.55402"
+       y2="57.805115"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12065"
+       x1="836.14453"
+       y1="56.011978"
+       x2="854.48431"
+       y2="56.011978"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12073"
+       x1="867.32007"
+       y1="180.88002"
+       x2="917.56512"
+       y2="180.88002"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12081"
+       x1="1052.6279"
+       y1="133.63753"
+       x2="1153.7426"
+       y2="133.63753"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12083"
+       x1="1068.8458"
+       y1="140.9821"
+       x2="1097.0699"
+       y2="140.9821"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12085"
+       x1="1107.4069"
+       y1="140.48314"
+       x2="1135.631"
+       y2="140.48314"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12087"
+       x1="1117.8184"
+       y1="171.41257"
+       x2="1150.8077"
+       y2="171.41257"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12089"
+       x1="1114.6469"
+       y1="174.73206"
+       x2="1144.2328"
+       y2="174.73206"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12091"
+       x1="1112.4623"
+       y1="165.12726"
+       x2="1148.296"
+       y2="165.12726"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12093"
+       x1="1118.7629"
+       y1="161.15636"
+       x2="1154.4828"
+       y2="161.15636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12095"
+       x1="1110.4926"
+       y1="157.06845"
+       x2="1146.1805"
+       y2="157.06845"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12097"
+       x1="1054.0176"
+       y1="171.78386"
+       x2="1087.007"
+       y2="171.78386"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12099"
+       x1="1060.5927"
+       y1="175.10333"
+       x2="1090.1785"
+       y2="175.10333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12101"
+       x1="1080.1382"
+       y1="167.83195"
+       x2="1122.891"
+       y2="167.83195"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12103"
+       x1="1056.5294"
+       y1="165.49857"
+       x2="1092.3632"
+       y2="165.49857"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12105"
+       x1="1050.3427"
+       y1="161.52766"
+       x2="1086.0624"
+       y2="161.52766"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12107"
+       x1="1058.6449"
+       y1="157.43974"
+       x2="1094.3326"
+       y2="157.43974"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient12109"
+       x1="1091.5129"
+       y1="159.53297"
+       x2="1112.1018"
+       y2="159.53297"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12153"
+       x1="1117.8184"
+       y1="371.41257"
+       x2="1150.8077"
+       y2="371.41257"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12155"
+       x1="1114.6469"
+       y1="374.73206"
+       x2="1144.2328"
+       y2="374.73206"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12157"
+       x1="1112.4623"
+       y1="365.12726"
+       x2="1148.296"
+       y2="365.12726"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12159"
+       x1="1118.7629"
+       y1="361.15637"
+       x2="1154.4828"
+       y2="361.15637"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12161"
+       x1="1110.4926"
+       y1="357.06845"
+       x2="1146.1805"
+       y2="357.06845"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12163"
+       x1="1054.0176"
+       y1="371.78387"
+       x2="1087.007"
+       y2="371.78387"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12165"
+       x1="1060.5927"
+       y1="375.10333"
+       x2="1090.1785"
+       y2="375.10333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12167"
+       x1="1080.1382"
+       y1="367.83194"
+       x2="1122.891"
+       y2="367.83194"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12169"
+       x1="1056.5294"
+       y1="365.49857"
+       x2="1092.3632"
+       y2="365.49857"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12171"
+       x1="1050.3427"
+       y1="361.52765"
+       x2="1086.0624"
+       y2="361.52765"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12173"
+       x1="1058.6449"
+       y1="357.43976"
+       x2="1094.3326"
+       y2="357.43976"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12175"
+       x1="1091.5129"
+       y1="359.53296"
+       x2="1112.1018"
+       y2="359.53296"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12183"
+       x1="1068.8458"
+       y1="340.98209"
+       x2="1097.0699"
+       y2="340.98209"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12185"
+       x1="1107.4069"
+       y1="340.48315"
+       x2="1135.631"
+       y2="340.48315"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12187"
+       x1="1052.6279"
+       y1="333.63751"
+       x2="1153.7426"
+       y2="333.63751"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12195"
+       x1="826.01733"
+       y1="250.73106"
+       x2="899.16779"
+       y2="250.73106"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12197"
+       x1="836.14453"
+       y1="256.01199"
+       x2="854.48431"
+       y2="256.01199"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12199"
+       x1="860.71814"
+       y1="257.80511"
+       x2="882.55402"
+       y2="257.80511"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12201"
+       x1="864.74054"
+       y1="282.55414"
+       x2="884.71942"
+       y2="282.55414"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12203"
+       x1="866.9798"
+       y1="280.58551"
+       x2="889.74353"
+       y2="280.58551"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12205"
+       x1="863.45459"
+       y1="275.92618"
+       x2="888.67487"
+       y2="275.92618"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12207"
+       x1="867.97302"
+       y1="273.76694"
+       x2="893.38757"
+       y2="273.76694"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12209"
+       x1="862.30762"
+       y1="269.76874"
+       x2="888.10181"
+       y2="269.76874"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12211"
+       x1="821.54883"
+       y1="276.32718"
+       x2="846.18427"
+       y2="276.32718"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12213"
+       x1="825.69019"
+       y1="278.98587"
+       x2="848.36615"
+       y2="278.98587"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12215"
+       x1="840.2962"
+       y1="276.25757"
+       x2="870.79498"
+       y2="276.25757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12217"
+       x1="823.98163"
+       y1="272.17401"
+       x2="850.12543"
+       y2="272.17401"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12219"
+       x1="820.07001"
+       y1="268.7951"
+       x2="845.8609"
+       y2="268.7951"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12221"
+       x1="848.30438"
+       y1="269.93927"
+       x2="863.3714"
+       y2="269.93927"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12229"
+       x1="839.53564"
+       y1="336.44556"
+       x2="970.9306"
+       y2="336.44556"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12231"
+       x1="867.32007"
+       y1="380.88"
+       x2="917.56512"
+       y2="380.88"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12233"
+       x1="826.35754"
+       y1="266.82037"
+       x2="851.72418"
+       y2="266.82037"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12241"
+       x1="887.95624"
+       y1="304.16132"
+       x2="971.50403"
+       y2="304.16132"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12249"
+       x1="719.36285"
+       y1="378.62393"
+       x2="754.22406"
+       y2="378.62393"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12251"
+       x1="715.98883"
+       y1="382.15527"
+       x2="747.22949"
+       y2="382.15527"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12253"
+       x1="713.66486"
+       y1="371.9375"
+       x2="751.552"
+       y2="371.9375"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12255"
+       x1="720.36761"
+       y1="367.71317"
+       x2="758.13361"
+       y2="367.71317"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12257"
+       x1="711.56952"
+       y1="363.36438"
+       x2="749.30145"
+       y2="363.36438"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12259"
+       x1="651.49023"
+       y1="379.01892"
+       x2="686.3515"
+       y2="379.01892"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12261"
+       x1="658.4848"
+       y1="382.55026"
+       x2="689.72546"
+       y2="382.55026"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12263"
+       x1="679.27783"
+       y1="374.81482"
+       x2="724.5257"
+       y2="374.81482"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12265"
+       x1="654.16235"
+       y1="372.33249"
+       x2="692.04944"
+       y2="372.33249"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12267"
+       x1="647.58069"
+       y1="368.10818"
+       x2="685.34674"
+       y2="368.10818"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12269"
+       x1="656.41284"
+       y1="363.75937"
+       x2="694.14484"
+       y2="363.75937"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12271"
+       x1="691.37848"
+       y1="365.98618"
+       x2="713.04785"
+       y2="365.98618"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12279"
+       x1="671.0036"
+       y1="255.35168"
+       x2="744.99353"
+       y2="255.35168"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12281"
+       x1="658.46643"
+       y1="257.22333"
+       x2="738.61884"
+       y2="257.22333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12283"
+       x1="677.3183"
+       y1="270.73489"
+       x2="710.34222"
+       y2="270.73489"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12285"
+       x1="669.06531"
+       y1="283.14478"
+       x2="732.8877"
+       y2="283.14478"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12287"
+       x1="694.63049"
+       y1="304.60498"
+       x2="708.32458"
+       y2="304.60498"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12289"
+       x1="667.26477"
+       y1="346.2514"
+       x2="697.05664"
+       y2="346.2514"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12291"
+       x1="708.28674"
+       y1="345.72061"
+       x2="738.07861"
+       y2="345.72061"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12293"
+       x1="650.01184"
+       y1="338.43808"
+       x2="757.34607"
+       y2="338.43808"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12301"
+       x1="406.46521"
+       y1="302.55878"
+       x2="595.86932"
+       y2="302.55878"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12303"
+       x1="430.07938"
+       y1="315.61154"
+       x2="582.81036"
+       y2="315.61154"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12305"
+       x1="491.78247"
+       y1="312.85696"
+       x2="558.67767"
+       y2="312.85696"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12307"
+       x1="446.82053"
+       y1="303.96664"
+       x2="504.85513"
+       y2="303.96664"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12315"
+       x1="405.8338"
+       y1="340.3717"
+       x2="595.84729"
+       y2="340.3717"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12323"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12325"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12327"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12329"
+       x1="32.829487"
+       y1="245.83333"
+       x2="140.50385"
+       y2="245.83333"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12331"
+       x1="249.21779"
+       y1="269.70261"
+       x2="343.70499"
+       y2="269.70261"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12333"
+       x1="262.45978"
+       y1="345.8573"
+       x2="292.25168"
+       y2="345.8573"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12335"
+       x1="303.48175"
+       y1="345.32648"
+       x2="333.27365"
+       y2="345.32648"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12337"
+       x1="245.20686"
+       y1="338.04398"
+       x2="352.54108"
+       y2="338.04398"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12339"
+       x1="314.55786"
+       y1="378.22983"
+       x2="349.4191"
+       y2="378.22983"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12341"
+       x1="311.18384"
+       y1="381.76114"
+       x2="342.42447"
+       y2="381.76114"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12343"
+       x1="308.85989"
+       y1="371.5434"
+       x2="346.74698"
+       y2="371.5434"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12345"
+       x1="315.56259"
+       y1="367.31906"
+       x2="353.32864"
+       y2="367.31906"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12347"
+       x1="306.7645"
+       y1="362.97025"
+       x2="344.49649"
+       y2="362.97025"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12349"
+       x1="246.68523"
+       y1="378.62479"
+       x2="281.54648"
+       y2="378.62479"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12351"
+       x1="253.67982"
+       y1="382.15613"
+       x2="284.92047"
+       y2="382.15613"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12353"
+       x1="274.47284"
+       y1="374.42068"
+       x2="319.7207"
+       y2="374.42068"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12355"
+       x1="249.35735"
+       y1="371.93839"
+       x2="287.24445"
+       y2="371.93839"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12357"
+       x1="242.77568"
+       y1="367.71405"
+       x2="280.54172"
+       y2="367.71405"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12359"
+       x1="251.60785"
+       y1="363.36526"
+       x2="289.33984"
+       y2="363.36526"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12361"
+       x1="286.57349"
+       y1="365.59207"
+       x2="308.24286"
+       y2="365.59207"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12369"
+       x1="73.667786"
+       y1="240.29079"
+       x2="122.48566"
+       y2="240.29079"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12371"
+       x1="316.61819"
+       y1="546.96198"
+       x2="1106.3282"
+       y2="546.96198"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12373"
+       x1="82.089584"
+       y1="297.47986"
+       x2="115.04359"
+       y2="297.47986"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12375"
+       x1="53.68819"
+       y1="282.30634"
+       x2="143.37979"
+       y2="282.30634"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12377"
+       x1="45.473019"
+       y1="338.42691"
+       x2="152.80724"
+       y2="338.42691"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12379"
+       x1="103.74792"
+       y1="345.70944"
+       x2="133.53981"
+       y2="345.70944"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12381"
+       x1="62.725922"
+       y1="346.24023"
+       x2="92.517822"
+       y2="346.24023"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12383"
+       x1="114.824"
+       y1="378.61276"
+       x2="149.68526"
+       y2="378.61276"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12385"
+       x1="111.45"
+       y1="382.1441"
+       x2="142.69063"
+       y2="382.1441"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12387"
+       x1="109.12604"
+       y1="371.92633"
+       x2="147.01314"
+       y2="371.92633"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12389"
+       x1="115.82875"
+       y1="367.702"
+       x2="153.59479"
+       y2="367.702"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12391"
+       x1="107.03065"
+       y1="363.35321"
+       x2="144.76263"
+       y2="363.35321"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12393"
+       x1="46.951382"
+       y1="379.00775"
+       x2="81.812637"
+       y2="379.00775"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12395"
+       x1="53.94598"
+       y1="382.53909"
+       x2="85.186623"
+       y2="382.53909"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12397"
+       x1="74.738968"
+       y1="374.80365"
+       x2="119.98684"
+       y2="374.80365"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12399"
+       x1="49.623489"
+       y1="372.32132"
+       x2="87.510597"
+       y2="372.32132"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12401"
+       x1="43.041832"
+       y1="368.09698"
+       x2="80.807892"
+       y2="368.09698"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12403"
+       x1="51.873989"
+       y1="363.7482"
+       x2="89.605988"
+       y2="363.7482"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient12405"
+       x1="86.839622"
+       y1="365.97501"
+       x2="108.50901"
+       y2="365.97501"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03788526,0,0,0.03788526,-20.829784,126.54946)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,795.20228,172.79307)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,795.88936,152.86786)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,832.30444,175.99035)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,829.55612,158.12635)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02907017,-0.01075687,-0.01075687,0.02907017,995.91603,196.24434)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13543"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,896.88966,95.602377)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,888.64474,79.112527)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,975.89681,111.21621)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,987.53617,124.08866)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13551"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,996.3271,139.34542)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesShade"
+       id="linearGradient13553"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.02997691,-0.00788555,-0.00788555,0.02997691,994.9294,170.78482)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,795.20228,372.79307)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13606"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,795.88936,352.86786)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,832.30444,375.99035)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.02802994,0,0,0.02802994,829.55612,358.12635)"
+       x1="1647.1403"
+       y1="-382.90863"
+       x2="2633.2517"
+       y2="-582.90863" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,975.89681,311.21621)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13614"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,987.53617,324.08866)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesShade"
+       id="linearGradient13616"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0309968,0,0,0.0309968,996.3271,339.34542)"
+       x1="3417.1067"
+       y1="711.96979"
+       x2="1424.2903"
+       y2="-1470.3201" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.5"
+     inkscape:cx="-54.8452"
+     inkscape:cy="181.2731"
+     inkscape:document-units="px"
+     inkscape:current-layer="BlackPieces"
+     showgrid="false"
+     inkscape:window-width="1660"
+     inkscape:window-height="885"
+     inkscape:window-x="254"
+     inkscape:window-y="38"
+     showguides="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Prmi Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:description>Chess piece set &quot;Prmi&quot; by Maurizio Monge.</dc:description>
+        <dc:date>2017-10-29</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect6707-7"
+         style="fill:none;stroke:none" />
+      <path
+         sodipodi:nodetypes="cscsccssssscccccccccssccsccc"
+         inkscape:connector-curvature="0"
+         id="path6371"
+         d="m 944.8643,47.064287 c -4.63777,2.7483 -7.74595,9.22953 1.01428,26.75 7.21799,14.43597 7.53592,25.81459 7,35.021423 -9.71632,-18.214233 -11.9886,-16.313653 -25.77143,-31.257143 -8.61163,-9.33682 -26.82606,-17.5719 -34.62933,-21.27284 -14.74431,5.42428 -40.09131,30.63037 -49.89924,27.12998 0,0 -3.76905,8.24282 -1.36428,22.671433 2.40476,14.42862 4.35305,11.06151 6.41428,30.47143 2.06123,19.40992 0.85443,16.78806 -1.37857,30.01429 -2.233,13.22623 -2.42515,17.15072 10.30714,15.12143 14.17209,-2.25878 10.70681,-19.44269 9.62143,-28.65 -3.93017,-33.33976 13.99452,-42.85261 17.63572,0.69285 0.27699,5.96266 -1.35057,11.89954 -3.06072,17.85358 l -5.55714,3.24285 -5.7,7.21786 -0.22143,7.39643 6.23214,3.34285 15.08572,-7.26071 c 6.6036,0.79289 9.40082,-1.44699 10.74285,-5.62143 L 916.29287,171.4 c 0.90439,0.41414 7.81974,3.57285 8.98571,3.74286 8.61109,1.25553 -20.30944,4.96575 -21.06428,15.32857 -0.67412,9.25452 20.85772,1.68065 37.72142,-4.68572 12.32673,-3.08722 40.28463,-15.11896 18.9,-22.28571 6.06314,-13.82423 1.7723,-25.20943 3.07858,-33.52857 1.02295,-6.5148 7.59653,-11.01426 6.77142,-20.50714 C 967.76565,79.919977 960.04497,62.82392 958.384,59.73926 954.56137,55.11741 951.59254,43.188627 944.8643,47.064287 z"
+         style="fill:url(#linearGradient6373);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient6369);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 842.77161,81.413927 c 0,0 -3.05092,10.26522 -0.64615,24.693843 2.40477,14.42861 3.44083,12.431 5.50206,31.84092 2.06124,19.40992 0.85885,15.87728 -1.37415,29.10351 -2.233,13.22623 -2.43901,17.06254 10.30615,15.11569 14.34209,-2.19077 12.25003,-17.64658 9.61908,-27.72936 -7.5641,-28.98841 12.25451,-47.13358 18.55107,0.68708 1.23938,9.41268 -8.22179,27.15894 1.37416,29.55793 17.864,4.466 15.11569,-4.99493 17.17692,-19.93885 3.77032,-15.81532 4.87547,-6.55259 8.52875,3.35283 2.87155,7.78585 16.83649,4.00136 29.59486,5.49617 -11.46796,2.82894 -35.11422,6.17494 -35.86907,16.53776 0.0835,11.7799 21.30783,0.96313 38.17153,-3.26037 37.58054,-17.22936 22.23986,-20.3798 16.94679,-23.61273 7.90162,-16.02432 -0.78537,-23.88848 3.65757,-32.51996 4.92491,-9.56785 7.26391,-18.88217 6.27622,-30.24568 -2.92008,-29.544313 -9.76252,-33.907223 -11.42349,-36.991883 -3.736,-4.63764 -7.54112,-19.69574 -14.13068,-15.8992 -4.63777,2.74831 -7.91394,8.69306 0.84628,26.21353 7.21799,14.43597 7.53744,25.45585 7.00152,34.662683 -8.46632,-18.392803 -10.46967,-12.609893 -24.2525,-27.553383 -16.31808,-17.69223 -40.18289,-21.40774 -36.14228,-23.17551"
+         id="path6367"
+         sodipodi:nodetypes="csccssssccccccscccscsc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13547);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 918.14639,75.925867 c -22.12676,28.630873 -24.08243,20.42612 -28.02241,9.97772 7.68307,-9.18108 23.66362,-11.37164 18.02718,-16.51249 z"
+         id="path2325-2"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6308"
+         d="m 932.8572,89.184047 c 3.23671,2.16096 -9.62489,15.046883 -23.48375,16.440143 -2.69739,-11.507763 -9.77254,4.42878 14.68137,-23.910633 z"
+         style="fill:url(#linearGradient13549);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccc"
+         id="path6387"
+         d="m 971.48207,101.76269 c 2.0798,0.24349 -7.28533,17.28995 -8.2813,32.95919 -0.77634,12.21393 7.40865,12.97676 -3.15317,27.61465 32.80654,13.82897 -53.37596,36.11021 -49.17959,29.31131 21.09579,-23.24283 21.98268,-97.877073 60.61406,-89.88515 z"
+         style="fill:url(#linearGradient6389);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13551);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 943.42876,102.94778 c -2.96316,4.74031 -20.07863,22.4737 -25.58576,14.48225 1.20153,-15.86008 6.43192,-1.00072 19.66418,-22.227713 z"
+         id="path6312"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6316"
+         d="m 953.11288,122.11592 c -4.27441,2.19379 -21.39275,15.77653 -23.1041,9.49566 -2.09424,-12.49871 21.25374,-13.41164 17.73079,-19.18166 z"
+         style="fill:url(#linearGradient13553);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13541);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 959.26554,140.61074 c -8.00263,-1.00921 -15.08204,5.64775 -18.19622,1.75585 -0.87167,-12.64293 16.95083,-6.13467 14.00434,-12.21928 z"
+         id="path6320"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6324"
+         d="m 851.89165,134.59957 c 0.61732,2.52814 0.3533,4.81186 1.92608,13.64335 1.60023,-4.23563 5.16124,0.1194 8.19541,-13.04822 -8.05119,-3.90382 -7.09086,-3.62569 -10.12149,-0.59513 z"
+         style="fill:url(#linearGradient13535);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13533);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 851.20457,154.5248 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60024,-4.23562 6.67144,4.5718 9.70561,-8.59583 -8.05118,-3.90382 -8.60106,-3.26854 -11.63169,-0.23798 z"
+         id="path6328"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13539);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 887.34413,139.85808 c 0.61732,2.52814 -0.004,1.95471 1.56894,10.7862 1.60023,-4.23562 7.30409,2.6194 10.33827,-10.54822 -8.05119,-3.90382 -8.87658,-3.26854 -11.90721,-0.23798 z"
+         id="path6332"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6336"
+         d="m 888.30672,157.72208 c 0.61732,2.52814 -1.07527,-2.14055 0.49751,6.69095 1.60024,-4.23563 8.10001,6.71465 11.13418,-6.45297 -8.05118,-3.90382 -8.60106,-3.26854 -11.63169,-0.23798 z"
+         style="fill:url(#linearGradient13537);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6340"
+         d="m 957.01441,98.633467 c 0.61732,2.528143 -0.36099,0.52613 1.21179,9.357633 1.60024,-4.23563 6.16396,2.02767 9.19813,-11.139953 -8.05118,-3.90382 -7.37929,-1.24824 -10.40992,1.78232 z"
+         style="fill:url(#linearGradient6342);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13543);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 952.89195,77.334077 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60023,-4.23562 6.67143,4.5718 9.70561,-8.59582 -8.05119,-3.90382 -8.60106,-3.26855 -11.63169,-0.23799 z"
+         id="path6344"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path6348"
+         d="m 944.64703,60.844237 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60023,-4.23563 6.67143,4.57179 9.7056,-8.59583 -8.05118,-3.90382 -8.60105,-3.26854 -11.63168,-0.23798 z"
+         style="fill:url(#linearGradient13545);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         sodipodi:nodetypes="csccsasc"
+         inkscape:connector-curvature="0"
+         id="path6319"
+         d="m 912.32144,169.91071 c 0,0 5.21006,1.2788 2.8027,3.01643 -2.11289,1.52508 -10.10558,4.26189 -13.359,6.37506 m -12.08237,6.492 c -4.89339,2.44329 -8.12948,5.29505 -12.2399,5.87009 -2.47449,0.34617 -5.83373,0.40025 -7.32143,-1.60715 -1.79329,-2.41973 -0.92442,-6.30088 0.71428,-9.00714 2.3496,-3.88027 3.80908,-6.13158 10.95,-9.3"
+         style="fill:none;stroke:url(#linearGradient12073);stroke-width:3.6114285;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssccczscs"
+         id="path6306"
+         d="m 843.78178,76.628607 c 0,0 -4.06108,17.3363 -1.6563,31.764923 2.40476,14.42862 3.44083,13.34529 5.50206,32.75522 2.06123,19.40993 1.31599,10.39158 -0.91701,23.61781 -2.233,13.22624 -2.42614,17.145 10.30616,15.1157 14.17209,-2.25878 12.4804,-19.5297 9.16193,-28.18652 -7.54184,-19.67425 10.28828,-48.20503 17.17966,0.68708 1.32508,9.40101 -7.30752,29.44467 2.28844,31.84366 17.86401,4.466 17.4622,-7.14187 17.17693,-22.22458 -0.39065,-20.65424 -4.95868,-28.8039 -3.46855,-38.52929 m 55.03371,38.86653 c 3.38814,0.22806 14.80761,3.17619 14.71265,8.09958 -4.15865,8.59636 -15.43745,11.94124 -27.16235,16.01036 -11.7249,4.06911 -37.19301,16.46873 -37.02396,5.1939 0.14953,-9.97332 11.02771,-11.06323 35.2637,-18.46211 -18.17599,5.60929 -33.51582,-8.5481 -25.9567,-23.03129"
+         style="fill:none;stroke:url(#linearGradient12057);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssccssszc"
+         id="path5431"
+         d="m 889.78481,55.571997 c 0,0 21.31596,7.67645 37.926,25.09488 7.47925,7.84325 17.13815,12.03748 30.53615,40.551183 4.79198,10.19832 4.8271,14.3306 6.41872,20.12968 2.85844,10.4147 -3.46661,20.12414 -3.46661,20.12414 m 1.77974,-26.38001 c -1.6159,-6.79699 5.45957,-12.56949 6.33309,-23.73998 2.31455,-29.597913 -7.11553,-42.480663 -8.7765,-45.565323 -4.80954,-8.93201 -11.17863,-21.29394 -15.8164,-18.54563 -4.41176,2.61437 -2.11599,22.921 2.19432,28.63799 4.31032,5.71699 7.56162,32.668263 4.7875,33.064803"
+         style="fill:none;stroke:url(#linearGradient12059);stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssss"
+         id="path3294-6"
+         d="m 851.4547,28.404527 c -7.18404,-3.98844 -6.78547,-11.04205 -19.79274,-15.13486 -4.49454,-1.41424 -0.021,11.5207 -0.27768,22.06285 -0.25676,10.54355 -6.41299,19.16778 -2.36431,28.08662 5.38042,11.85253 10.06203,13.43439 14.05786,17.97651 7.27782,8.27279 17.81272,8.74898 24.76689,3.35259 5.88326,-4.56536 13.67891,-6.35432 20.72957,-17.11488 5.64147,-8.6099 3.50795,-15.71145 5.10078,-25.32219 1.85804,-11.21096 6.53686,-23.55437 1.82831,-23.26529 -14.40075,0.88414 -16.33142,11.4608 -22.78465,12.67658 -6.87547,1.29534 -15.35763,-0.0388 -21.26403,-3.31793 z"
+         style="fill:url(#linearGradient3296-7);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3290-2);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12061);stroke-width:3.25523066999999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 851.4547,28.404527 c -7.18404,-3.98844 -6.78547,-11.04205 -19.79274,-15.13486 -4.49454,-1.41424 -0.021,11.5207 -0.27768,22.06285 -0.25676,10.54355 -6.41299,19.16778 -2.36431,28.08662 5.38042,11.85253 10.06203,13.43439 14.05786,17.97651 7.27782,8.27279 17.81272,8.74898 24.76689,3.35259 5.88326,-4.56536 13.67891,-6.35432 20.72957,-17.11488 5.64147,-8.6099 3.50795,-15.71145 5.10078,-25.32219 1.85804,-11.21096 6.53686,-23.55437 1.82831,-23.26529 -14.40075,0.88414 -16.33142,11.4608 -22.78465,12.67658 -6.87547,1.29534 -15.35763,-0.0388 -21.26403,-3.31793 z"
+         id="path3280-74"
+         sodipodi:nodetypes="cssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3276-3"
+         d="m 866.6027,54.597977 c 2.91665,-6.83809 9.24192,-8.35541 14.91754,-3.07301 1.41432,1.31633 -3.24288,10.74764 -14.91754,3.07301 z"
+         style="fill:url(#linearGradient3278-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3274-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 852.15324,52.939527 c -1.48205,-7.28491 -7.37301,-10.04315 -13.9949,-6.00992 -1.65013,1.00504 1.01546,11.1802 13.9949,6.00992 z"
+         id="path3266-1"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12049);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 849.93198,67.430777 c 0.1785,1.46912 2.90617,3.08235 4.1331,2.54864 0.20188,3.52892 0.92649,2.00009 1.5,1.96787 0.50803,-0.0285 1.08281,2.03698 1.51976,-1.64595 1.24617,0.33519 4.16866,0.15203 4.55813,-1.69304 l 0.10079,-0.0822 c -3.63704,-0.83626 -8.80753,-1.30931 -11.81178,-1.09532 z"
+         id="path2267-67"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2281-58"
+         d="m 850.09656,69.006477 c -7.35309,-3.10086 -14.72999,-3.95002 -22.11141,-4.37221"
+         style="fill:none;stroke:url(#linearGradient12047);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12045);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 844.23328,69.394877 c -7.78366,-1.76013 -15.19497,-1.29939 -22.53567,-0.41755"
+         id="path2283-3"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2285-81"
+         d="m 848.49778,71.091117 c -7.97328,-0.33222 -15.82597,0.0805 -22.88856,2.26753"
+         style="fill:none;stroke:url(#linearGradient12043);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12041);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 869.16734,79.240487 c -7.03031,1.76945 -13.69045,-2.14631 -12.66151,-5.11373 0.65512,-1.88935 -1.05761,-1.5299 -0.77173,-0.0797 0.50245,2.54879 -9.20663,5.40132 -13.81028,2.36707"
+         id="path2289-1"
+         sodipodi:nodetypes="csss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2291-6"
+         d="m 850.57675,66.681047 c -0.16527,-2.58056 3.46277,-4.2541 1.87863,-12.04078 -1.48205,-7.28492 -6.6791,-11.89222 -14.29702,-7.71062 -1.23001,0.67517 -0.14925,10.99169 12.67094,6.5331"
+         style="fill:none;stroke:url(#linearGradient12065);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2293-4"
+         d="m 843.98713,47.642947 c 1.51872,1.58122 0.95111,3.24843 -0.0515,4.93357 -0.60065,-1.39372 -0.93448,-2.89576 0.0515,-4.93357 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.25522757;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2299-92"
+         d="m 842.53212,36.091817 c 2.87776,3.16337 2.85495,3.63847 4.76908,7.39393 1.98841,-3.98866 3.11345,-8.06502 7.85176,-11.77434 l -12.62084,4.38041 z"
+         style="fill:url(#linearGradient2313-0);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-7"
+         d="m 853.19677,33.558107 1.01473,13.17614 1.59947,-13.17205 -2.6142,-0.004 z"
+         style="fill:url(#linearGradient2311-8);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2317-7);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 829.4426,54.047837 c 2.63931,-1.58674 5.97593,-2.31849 7.50074,-5.27174 -3.30849,0.0717 -2.35793,-3.51285 -8.44809,1.41999 l 0.94735,3.85175 z"
+         id="path2315-6" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2323-1);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 843.83091,64.083697 c 3.27619,-2.74863 2.50453,-0.74162 6.33371,-2.50363 -3.90573,-2.14672 -5.8108,-3.74158 -13.49821,-6.1724 -4.89123,3.34366 2.16549,4.9894 7.1645,8.67603 z"
+         id="path2321-5"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2335-9);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 869.4244,35.124667 -3.64352,12.70296 1.08189,-13.22463 2.56163,0.52167 z"
+         id="path2327-1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2329-5"
+         d="m 888.64114,60.322657 c -2.26634,-2.08505 -5.38766,-3.4728 -6.28749,-6.67234 3.2265,0.7355 5.28064,0.22117 10.25449,6.27789 l -3.967,0.39445 z"
+         style="fill:url(#linearGradient2337-1);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2331-40"
+         d="m 872.24358,67.492767 c -2.65656,-3.35127 -2.30424,-1.23009 -5.7009,-3.7261 4.25763,-1.31749 6.44448,-2.4967 14.46366,-3.33205 4.11898,4.25891 -3.12454,4.45204 -8.76276,7.05815 z"
+         style="fill:url(#linearGradient2339-2);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2341-2"
+         d="m 846.73852,73.266007 c -7.55356,2.57432 -13.62742,6.8461 -19.42069,11.43972"
+         style="fill:none;stroke:url(#linearGradient12039);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2343-4"
+         d="m 844.55662,72.759257 c -7.92444,0.94163 -14.75593,3.85208 -21.38015,7.13585"
+         style="fill:none;stroke:url(#linearGradient12037);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12035);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 863.93524,70.150737 c 7.82644,-1.55893 15.22341,-0.90736 22.53895,0.16336"
+         id="path2345-7"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2347-42"
+         d="m 869.60066,71.710217 c 7.9786,-0.159 15.14588,1.78262 22.15931,4.12257"
+         style="fill:none;stroke:url(#linearGradient12033);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12031);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 865.08218,72.514307 c 7.87721,1.27785 15.48652,3.26116 21.96507,6.82374"
+         id="path2349-6"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12029);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 866.36816,74.998507 c 6.88162,4.04065 11.97241,9.44651 16.72365,15.11127"
+         id="path2351-3"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12027);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 868.60741,74.940857 c 7.57322,2.51587 13.67991,6.74058 19.50852,11.28932"
+         id="path2353-9"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2363-2);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 832.04844,16.989717 c 0.31924,2.29431 1.5103,12.44978 2.10864,20.41193 1.79809,-3.60688 8.73381,-3.01381 13.01859,-6.3681 -7.49135,-15.3185 -12.4799,-13.41272 -15.12723,-14.04383 z"
+         id="path2361-0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2365-6"
+         d="m 895.32826,21.903817 c -0.77408,2.18325 -2.66727,13.1579 -4.85446,20.8371 -1.03607,-3.89478 -9.04733,-4.82002 -12.57009,-8.96739 10.41863,-13.49922 13.94944,-11.86052 17.42455,-11.86971 z"
+         style="fill:url(#linearGradient2367-4);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12063);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 862.34575,67.478727 c 0.6808,-2.4946 -1.18386,-4.67964 1.9337,-11.98874 2.91666,-6.8381 9.82962,-10.12239 16.45109,-4.49436 1.06912,0.90872 -2.06406,10.79719 -13.72583,3.85173"
+         id="path3250-3"
+         sodipodi:nodetypes="cssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.25522757;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 873.5655,49.931397 c -1.80566,1.24353 -1.58489,2.99082 -0.94164,4.84314 0.86863,-1.24447 1.49768,-2.6487 0.94164,-4.84314 z"
+         id="path3252-9"
+         sodipodi:nodetypes="ccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscs"
+         id="path3254-68"
+         d="m 856.32105,60.986297 c -2.1472,-12.11222 -0.37631,-27.32467 5.43114,-26.64881 4.65789,0.54439 1.97127,19.11878 -0.49984,28.32705 0,0 -3.69713,5.28365 -4.9313,-1.67824 z"
+         style="fill:url(#linearGradient3256-7);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient3260-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 888.01574,50.551307 c -2.26634,-2.08505 -5.38766,-3.4728 -6.28749,-6.67234 3.2265,0.73551 5.28064,0.22118 10.25449,6.27789 l -3.967,0.39445 z"
+         id="path3258-7" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3262-9"
+         d="m 832.44545,45.723687 c 2.63931,-1.58673 5.97594,-2.31849 7.50075,-5.27173 -3.30849,0.0717 -2.35794,-3.51286 -8.44809,1.41998 l 0.94734,3.85175 z"
+         style="fill:url(#linearGradient3264-9);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         y="0"
+         x="0"
+         height="200"
+         width="200"
+         id="rect6707"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssss"
+         id="path3294"
+         d="m 82.217286,104.05189 c -11.46504,-4.922943 -11.94534,-15.640053 -32.2236,-19.827033 -7.00697,-1.44678 1.73629,17.407643 2.96621,33.373143 1.2301,15.96763 -6.74674,29.94104 0.7383,42.79351 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38095 28.252404,10.48366 37.930014,1.26414 8.1873,-7.79977 19.68974,-11.69866 28.68993,-29.0367 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08655,-17.22162 6.2607,-36.586903 -0.80819,-35.427633 -21.61965,3.54556 -22.91326,19.820093 -32.47564,22.647083 -10.18804,3.01196 -23.206864,2.29811 -32.632914,-1.74931 z"
+         style="fill:url(#linearGradient3296);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3290);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient11913);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 82.217286,104.05189 c -11.46504,-4.922943 -11.94534,-15.640053 -32.2236,-19.827033 -7.00697,-1.44678 1.73629,17.407643 2.96621,33.373143 1.2301,15.96763 -6.74674,29.94104 0.7383,42.79351 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38095 28.252404,10.48366 37.930014,1.26414 8.1873,-7.79977 19.68974,-11.69866 28.68993,-29.0367 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08655,-17.22162 6.2607,-36.586903 -0.80819,-35.427633 -21.61965,3.54556 -22.91326,19.820093 -32.47564,22.647083 -10.18804,3.01196 -23.206864,2.29811 -32.632914,-1.74931 z"
+         id="path3280"
+         sodipodi:nodetypes="cssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3276"
+         d="m 109.12107,141.29799 c 3.35687,-10.77795 12.67966,-14.04082 22.06448,-6.93162 2.33863,1.77155 -3.24974,16.73419 -22.06448,6.93162 z"
+         style="fill:url(#linearGradient3278);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3274);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 87.037656,141.00993 c -3.35687,-10.77795 -12.67966,-14.04082 -22.06448,-6.93163 -2.33863,1.77156 3.24974,16.7342 22.06448,6.93163 z"
+         id="path3266"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11945);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 88.668196,162.96222 c 0.49511,2.19203 4.86339,4.21055 6.63502,3.216 0.84652,5.30019 1.70659,2.87938 2.56804,2.74269 0.76311,-0.12108 1.94841,2.91112 2.04333,-2.71976 1.934044,0.31514 6.320974,-0.41003 6.626204,-3.25717 l 0.13965,-0.13965 c -5.62283,-0.70522 -13.506544,-0.62641 -18.012244,0.15789 z"
+         id="path2267"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2281"
+         d="m 87.777416,165.4577 c -11.58423,-3.55613 -22.85888,-3.70692 -34.07485,-3.21197"
+         style="fill:none;stroke:url(#linearGradient11943);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11941);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 78.979316,166.9442 c -12.02894,-1.46456 -23.15457,0.36879 -34.10891,2.82749"
+         id="path2283"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2285"
+         d="m 85.682026,168.85233 c -12.09628,0.72166 -23.89607,2.55016 -34.22996,6.93799"
+         style="fill:none;stroke:url(#linearGradient11939);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11937);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 118.15827,177.99176 c -10.3492,3.75196 -21.011634,-1.14157 -19.912584,-5.78236 0.69977,-2.9548 -1.83251,-2.14893 -1.17807,-0.002 1.15018,3.77338 -13.07966,9.57264 -20.50007,5.69524"
+         id="path2289"
+         sodipodi:nodetypes="csss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2291"
+         d="m 89.527196,161.73065 c -0.64567,-3.8731 3.19721,-6.81777 -0.39089,-18.33809 -3.35687,-10.77796 -13.29633,-16.8004 -24.1631,-9.3142 -1.75457,1.20873 1.46129,16.62814 20.14464,7.92515"
+         style="fill:none;stroke:url(#linearGradient11921);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2293"
+         d="m 74.578846,134.19133 c 2.537,2.1557 1.93535,4.76147 0.67933,7.46107 -1.12126,-2.01333 -1.85609,-4.23124 -0.67933,-7.46107 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2299"
+         d="m 69.917546,117.03439 c 4.8329,4.33731 4.87135,5.05854 8.33934,10.43821 2.39182,-6.33083 3.46589,-12.66166 10.05486,-18.9925 l -18.3942,8.55429 z"
+         style="fill:url(#linearGradient2313);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303"
+         d="m 85.639916,111.57012 3.55492,19.74959 0.395,-20.14459 -3.94992,0.395 z"
+         style="fill:url(#linearGradient2311);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2317);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 52.898576,146.16936 c 3.74373,-2.80211 8.6721,-4.41961 10.52246,-9.11509 -4.98717,0.616 -4.10123,-4.94505 -12.5447,3.4416 l 2.02224,5.67349 z"
+         id="path2315" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2323);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 76.175186,159.12264 c 4.52758,-4.65513 3.66981,-1.50471 9.1842,-4.75421 -6.22985,-2.64371 -9.35259,-4.76073 -21.33906,-7.2533 -6.87612,5.80188 4.03709,7.20521 12.15486,12.00751 z"
+         id="path2321"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2333);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 127.50877,117.82437 c -4.8329,4.33732 -4.87137,5.05855 -8.33934,10.43822 -2.39182,-6.33083 -3.46589,-12.66167 -10.05486,-18.9925 l 18.3942,8.55428 z"
+         id="path2325"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2335);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 110.39552,111.44649 -3.55492,19.7496 -0.39501,-20.14459 3.94993,0.39499 z"
+         id="path2327" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2329"
+         d="m 143.29322,146.56436 c -3.74375,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.616 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         style="fill:url(#linearGradient2337);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2331"
+         d="m 119.62161,159.91262 c -4.52758,-4.65512 -3.66981,-1.5047 -9.1842,-4.75421 6.22985,-2.64371 9.35259,-4.76073 21.33904,-7.2533 6.87614,5.80189 -4.03707,7.20522 -12.15484,12.00751 z"
+         style="fill:url(#linearGradient2339);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2341"
+         d="m 83.358046,172.4079 c -11.01617,5.04822 -19.53647,12.43369 -27.58349,20.26235"
+         style="fill:none;stroke:url(#linearGradient11935);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2343"
+         d="m 79.984066,171.97718 c -11.82702,2.6386 -21.70077,8.08378 -31.20411,14.06114"
+         style="fill:none;stroke:url(#linearGradient11933);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11969);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 108.85922,165.0627 c 11.58423,-3.55612 22.85888,-3.70691 34.07485,-3.21197"
+         id="path2345"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2347"
+         d="m 117.65732,166.54921 c 12.02894,-1.46456 23.15457,0.36879 34.1089,2.82749"
+         style="fill:none;stroke:url(#linearGradient11971);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11929);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 110.95461,168.45734 c 12.09626,0.72166 23.89607,2.55016 34.22996,6.93799"
+         id="path2349"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11927);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 113.27857,172.01291 c 11.01619,5.04821 19.53647,12.43368 27.58349,20.26236"
+         id="path2351"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11925);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 116.65257,171.58219 c 11.82702,2.6386 21.70075,8.08377 31.20411,14.06114"
+         id="path2353"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient13370);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 51.148406,89.785477 c 0.83437,3.41704 4.19214,18.576223 6.31791,30.512893 2.16288,-5.72489 12.73174,-5.89326 18.69005,-11.61814 C 62.488406,86.688037 55.244616,90.332647 51.148406,89.785477 z"
+         id="path2361"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2365"
+         d="m 147.49987,87.498507 c -0.83437,3.41704 -2.0103,20.287073 -4.13607,32.223733 -2.16288,-5.72488 -14.40755,-5.89326 -20.36585,-11.61814 13.66796,-21.992183 19.25346,-20.058423 24.50192,-20.605593 z"
+         style="fill:url(#linearGradient2367);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient12112);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11915);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 99.594816,15.896807 c -2.36026,0.19298 -5.08426,0.0555 -6.97516,1.69553 -0.92618,2.50049 0.22557,5.11484 0.60947,7.60777 0.46812,1.94334 0.99164,3.87981 1.01302,5.88866 -5.40584,-0.90163 -10.98618,-2.35595 -16.44926,-1.18948 -1.99901,1.0799 -2.10615,3.67772 -2.2916,5.67078 -0.057,2.70372 0.365,5.64101 2.06205,7.81001 3.16684,1.18659 6.57725,0.13609 9.75665,-0.44497 2.07282,-0.44604 4.26666,-1.16996 6.30655,-1.15666 0.0734,4.82559 -0.32046,9.76576 -1.32324,14.41771 -0.12015,0.76604 -2.42694,7.76203 -1.58332,7.76164 2.07582,0.36095 11.131464,0.54592 13.222644,0.73175 1.49006,-0.0297 -1.65555,-11.04593 -1.72458,-12.69617 -0.6991,-3.45316 -1.10789,-7.01589 -0.43729,-10.53838 5.33735,-0.15901 10.62655,1.8163 15.95365,0.87646 2.08818,-1.02162 2.43666,-3.6171 2.83284,-5.65526 0.25974,-2.65187 0.0341,-5.65047 -1.72161,-7.76292 -2.79458,-0.88045 -5.70239,0.14481 -8.49853,0.45909 -2.20584,0.39659 -4.39678,0.87701 -6.60997,1.23122 1.36236,-4.06985 3.95544,-7.75836 4.48664,-12.09827 -0.45096,-1.88998 -2.78691,-2.04544 -4.35099,-2.36331 -1.4045,-0.21627 -2.84841,-0.26746 -4.277964,-0.2452 z"
+         id="path24710"
+         sodipodi:nodetypes="cccccccccccccccccccccc" />
+      <path
+         transform="matrix(0.04057623,0,0,0.0523856,68.913356,44.725027)"
+         d="m 1066.6667,546.96198 a 355.19348,304.1412 0 1 1 -710.38698,0 355.19348,304.1412 0 1 1 710.38698,0 z"
+         sodipodi:ry="304.1412"
+         sodipodi:rx="355.19348"
+         sodipodi:cy="546.96198"
+         sodipodi:cx="711.47321"
+         id="path4002"
+         style="opacity:0.98999999;fill:url(#linearGradient4883);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11917);stroke-width:79.32309723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssscc"
+         id="path10402"
+         d="m 74.718606,109.58378 c 4.24696,-17.053973 -19.71515,-18.392673 -19.19344,-34.259883 0.46598,-14.17251 7.1295,-18.96951 19.50454,-20.14579 16.26869,-1.54638 21.02302,22.54195 23.33729,22.00859 2.575144,-0.59348 9.533184,-22.30528 20.778294,-22.15706 12.89041,0.16991 22.83556,5.2253 22.39163,21.41604 -0.40119,15.08103 -24.44855,15.88082 -20.44703,31.919103 -16.77576,-2.06806 -31.013664,-1.26269 -46.371284,1.219 z"
+         style="fill:url(#linearGradient10410);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11919);stroke-width:3.65714502;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11923);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 106.73854,161.19985 c 0.64567,-3.8731 -3.1972,-6.81777 0.39089,-18.33808 3.35687,-10.77796 13.29633,-16.80041 24.1631,-9.31421 1.75457,1.20874 -1.46129,16.62814 -20.14464,7.92516"
+         id="path3250"
+         sodipodi:nodetypes="cssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 120.99554,132.96919 c -2.53699,2.1557 -1.93534,4.76147 -0.67933,7.46107 1.12127,-2.01333 1.8561,-4.23124 0.67933,-7.46107 z"
+         id="path3252"
+         sodipodi:nodetypes="ccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscs"
+         id="path3254"
+         d="m 94.568836,152.52668 c -5.10249,-17.96854 -4.76166,-41.22186 4.11541,-41.09203 7.120264,0.10762 5.911934,28.5804 3.591884,42.8706 0,0 -4.774474,8.54942 -7.707294,-1.77857 z"
+         style="fill:url(#linearGradient3256);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient3260);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 140.84894,131.89868 c -3.74375,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.616 8.01144,-0.47623 16.45492,7.91042 l -5.93245,1.20468 z"
+         id="path3258" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3262"
+         d="m 56.157616,133.1332 c 3.74373,-2.80211 8.6721,-4.41961 10.52246,-9.11509 -4.98717,0.616 -4.10123,-4.94505 -12.5447,3.4416 l 2.02224,5.67349 z"
+         style="fill:url(#linearGradient3264);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path4885"
+         d="m 83.918156,98.087557 c 8.79869,-1.09303 17.888144,-1.89532 29.296864,-0.37832"
+         style="fill:none;stroke:url(#linearGradient11973);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect6707-3"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssss"
+         id="path3294-8"
+         d="m 1087.2776,101.32468 c -10.7773,-4.627614 -11.2288,-14.701794 -30.2905,-18.637594 -6.5866,-1.35998 1.6321,16.36334 2.7883,31.371064 1.1563,15.00971 -6.342,28.14484 0.694,40.22628 9.3503,16.05541 16.2268,17.62644 22.5564,23.50021 11.5284,10.69819 26.5575,9.85474 35.6545,1.1883 7.6962,-7.33184 18.5086,-10.99684 26.9689,-27.29475 6.7693,-13.04054 2.7152,-22.81753 3.5907,-36.69531 1.0214,-16.188484 5.8852,-34.392024 -0.7597,-33.302294 -20.3226,3.33285 -21.5387,18.631064 -30.5274,21.288464 -9.5769,2.83127 -21.8147,2.16023 -30.6752,-1.64437 z"
+         style="fill:url(#linearGradient3296-1);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3290-9);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12081);stroke-width:3.65715121999999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1087.2776,101.32468 c -10.7773,-4.627614 -11.2288,-14.701794 -30.2905,-18.637594 -6.5866,-1.35998 1.6321,16.36334 2.7883,31.371064 1.1563,15.00971 -6.342,28.14484 0.694,40.22628 9.3503,16.05541 16.2268,17.62644 22.5564,23.50021 11.5284,10.69819 26.5575,9.85474 35.6545,1.1883 7.6962,-7.33184 18.5086,-10.99684 26.9689,-27.29475 6.7693,-13.04054 2.7152,-22.81753 3.5907,-36.69531 1.0214,-16.188484 5.8852,-34.392024 -0.7597,-33.302294 -20.3226,3.33285 -21.5387,18.631064 -30.5274,21.288464 -9.5769,2.83127 -21.8147,2.16023 -30.6752,-1.64437 z"
+         id="path3280-0"
+         sodipodi:nodetypes="cssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3276-7"
+         d="m 1112.5673,136.33629 c 3.1555,-10.13137 11.919,-13.19849 20.7409,-6.51579 2.1983,1.66528 -3.0548,15.73029 -20.7409,6.51579 z"
+         style="fill:url(#linearGradient3278-4);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3274-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1091.8087,136.06551 c -3.1555,-10.13137 -11.919,-13.19849 -20.7408,-6.51579 -2.1983,1.66528 3.0548,15.73028 20.7408,6.51579 z"
+         id="path3266-8"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12109);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1093.3415,156.70092 c 0.4654,2.06052 4.5716,3.95795 6.237,3.02307 0.7957,4.98222 1.6042,2.70664 2.4139,2.57815 0.7174,-0.11382 1.8316,2.73648 1.9208,-2.55659 1.818,0.29622 5.9418,-0.38544 6.2287,-3.06178 l 0.1313,-0.13127 c -5.2856,-0.66291 -12.6963,-0.58883 -16.9317,0.14842 z"
+         id="path2267-6"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2281-5"
+         d="m 1092.5041,159.04669 c -10.8892,-3.34279 -21.4875,-3.48453 -32.0306,-3.01928"
+         style="fill:none;stroke:url(#linearGradient12107);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12105);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1084.2338,160.44402 c -11.3073,-1.3767 -21.7655,0.34666 -32.0626,2.65787"
+         id="path2283-5"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2285-8"
+         d="m 1090.5345,162.23768 c -11.3707,0.67836 -22.4626,2.39717 -32.1765,6.52177"
+         style="fill:none;stroke:url(#linearGradient12103);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12101);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1121.0624,170.82882 c -9.7283,3.52688 -19.7511,-1.07309 -18.718,-5.43547 0.6578,-2.77754 -1.7226,-2.02001 -1.1074,-0.002 1.0812,3.54701 -12.295,8.99836 -19.2702,5.35357"
+         id="path2289-3"
+         sodipodi:nodetypes="csss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2291-5"
+         d="m 1094.1489,155.54323 c -0.6069,-3.64075 3.0055,-6.40877 -0.3674,-17.23797 -3.1555,-10.13137 -12.4987,-15.79253 -22.7135,-8.75543 -1.6493,1.13622 1.3736,15.6306 18.9361,7.44972"
+         style="fill:none;stroke:url(#linearGradient12083);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2293-7"
+         d="m 1080.0974,129.65602 c 2.3848,2.02638 1.8192,4.47583 0.6385,7.01348 -1.054,-1.89255 -1.7447,-3.97741 -0.6385,-7.01348 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2299-9"
+         d="m 1075.7157,113.52829 c 4.5429,4.07712 4.5791,4.75508 7.839,9.81201 2.2484,-5.95103 3.258,-11.90207 9.4517,-17.85311 l -17.2907,8.0411 z"
+         style="fill:url(#linearGradient2313-9);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-1"
+         d="m 1090.4948,108.39183 3.3417,18.56479 0.3713,-18.93609 -3.713,0.3713 z"
+         style="fill:url(#linearGradient2311-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2317-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1059.7177,140.91542 c 3.5191,-2.63401 8.1518,-4.15447 9.8912,-8.56827 -4.688,0.57905 -3.8552,-4.64839 -11.7921,3.23514 l 1.9009,5.33313 z"
+         id="path2315-3" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2323-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1081.5979,153.0916 c 4.256,-4.37585 3.4497,-1.41443 8.6332,-4.46899 -5.8561,-2.48511 -8.7915,-4.47512 -20.0589,-6.81817 -6.4636,5.45383 3.7949,6.77297 11.4257,11.28716 z"
+         id="path2321-4"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2333-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1129.852,114.27088 c -4.5431,4.07712 -4.5792,4.75508 -7.8391,9.81202 -2.2484,-5.95104 -3.258,-11.90208 -9.4517,-17.85312 l 17.2908,8.0411 z"
+         id="path2325-7"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2335-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1113.7653,108.27562 -3.3417,18.56479 -0.3713,-18.93608 3.713,0.37129 z"
+         id="path2327-4" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2329-9"
+         d="m 1144.6895,141.28672 c -3.5192,-2.63402 -8.1519,-4.15448 -9.8912,-8.56828 4.6879,0.57905 7.5308,-0.44765 15.4677,7.43588 l -5.5765,1.1324 z"
+         style="fill:url(#linearGradient2337-7);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2331-4"
+         d="m 1122.4379,153.8342 c -4.256,-4.37586 -3.4496,-1.41443 -8.6332,-4.469 5.8561,-2.48511 8.7915,-4.47513 20.0589,-6.81817 6.4636,5.45383 -3.7949,6.77297 -11.4257,11.28717 z"
+         style="fill:url(#linearGradient2339-0);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2341-4"
+         d="m 1088.3499,165.57995 c -10.3553,4.74537 -18.3645,11.68778 -25.9287,19.04679"
+         style="fill:none;stroke:url(#linearGradient12099);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2343-6"
+         d="m 1085.1783,165.17507 c -11.1175,2.4803 -20.3989,7.59882 -29.3321,13.21759"
+         style="fill:none;stroke:url(#linearGradient12097);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12095);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1112.3212,158.67539 c 10.8893,-3.34279 21.4876,-3.48453 32.0307,-3.01928"
+         id="path2345-8"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2347-5"
+         d="m 1120.5915,160.07272 c 11.3074,-1.3767 21.7656,0.34667 32.0627,2.65787"
+         style="fill:none;stroke:url(#linearGradient12093);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12091);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1114.2909,161.86638 c 11.3706,0.67837 22.4626,2.39717 32.1765,6.52177"
+         id="path2349-9"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12089);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1116.4755,165.20865 c 10.3553,4.74536 18.3645,11.68777 25.9287,19.0468"
+         id="path2351-8"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12087);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1119.647,164.80377 c 11.1176,2.4803 20.399,7.59882 29.3322,13.2176"
+         id="path2353-5"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2363);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1058.0725,87.914086 c 0.7843,3.21204 3.9407,17.461804 5.9389,28.682374 2.0331,-5.38144 11.968,-5.53971 17.5688,-10.92115 -12.848,-20.672854 -19.6572,-17.246884 -23.5077,-17.761224 z"
+         id="path2361-2"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2365-3"
+         d="m 1148.6438,85.764316 c -0.7844,3.21204 -1.8897,19.070014 -3.888,30.290584 -2.0331,-5.38144 -13.5432,-5.53972 -19.1441,-10.92115 12.8481,-20.672854 18.0985,-18.855104 23.0321,-19.369434 z"
+         style="fill:url(#linearGradient2367-8);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12085);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1110.3278,155.04428 c 0.6069,-3.64075 -3.0054,-6.40877 0.3674,-17.23797 3.1555,-10.13138 12.4987,-15.79253 22.7136,-8.75544 1.6493,1.13623 -1.3736,15.63061 -18.9362,7.44972"
+         id="path3250-1"
+         sodipodi:nodetypes="cssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1123.7295,128.5072 c -2.3848,2.02637 -1.8193,4.47582 -0.6386,7.01348 1.054,-1.89255 1.7447,-3.97741 0.6386,-7.01348 z"
+         id="path3252-1"
+         sodipodi:nodetypes="ccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscs"
+         id="path3254-9"
+         d="m 1098.8881,146.89135 c -4.7964,-16.89058 -4.476,-38.7489 3.8685,-38.62686 6.6931,0.10117 5.5573,26.86582 3.3764,40.29873 0,0 -4.488,8.03652 -7.2449,-1.67187 z"
+         style="fill:url(#linearGradient3256-0);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient3260-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1142.3918,127.50085 c -3.5191,-2.63401 -8.1518,-4.15448 -9.8912,-8.56827 4.688,0.57905 7.5308,-0.44766 15.4678,7.43587 l -5.5766,1.1324 z"
+         id="path3258-1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3262-3"
+         d="m 1062.7812,128.66131 c 3.5192,-2.634 8.1519,-4.15446 9.8912,-8.56826 -4.688,0.57905 -3.8552,-4.64839 -11.7921,3.23513 l 1.9009,5.33313 z"
+         style="fill:url(#linearGradient3264-1);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect6707-8"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssss"
+         id="path6490"
+         d="m 408.555,108.64194 c 7.30754,19.35518 61.04822,45.94985 106.97649,41.31372 45.92827,-4.63613 83.89895,-36.17064 77.87945,-58.501724 -4.11158,-15.25308 -97.84687,-38.21189 -114.44316,-36.75942 -9.58326,0.83871 -75.31984,40.95029 -70.41278,53.947424 z"
+         style="fill:url(#linearGradient7411);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11799);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssssssssscssssssssssssc"
+         id="path7431"
+         d="m 431.90796,109.34111 c 1.80885,-7.82894 13.32751,-13.106034 18.66667,-19.443344 2.85748,-3.39169 10.6018,-6.78256 13.71428,-6.78256 2.22581,0 1.17427,4.37255 2.28572,-0.90434 1.02792,-4.88037 5.57406,-8.59124 9.52381,-8.59124 4.14669,0 8.12835,1.65755 12.19047,0.45217 2.23433,-0.66301 2.49795,1.28062 4.95238,-0.90435 3.57347,-3.18113 8.01694,0.54429 10.66667,3.1652 4.1466,4.1015 8.39685,6.33039 13.71429,6.33039 6.47619,0 12.95238,0 19.42857,0 6.02288,0 11.11028,6.13576 14.85714,9.94775 1.77512,1.80598 2.18718,1.04663 4.19048,0.45217 2.35736,-0.69951 3.06507,-1.35651 5.71428,-1.35651 2.04126,0 2.50398,1.1952 4.57143,1.80868 1.77404,0.52643 2.28572,1.61245 2.28572,4.06954 0,2.499634 -0.48351,1.68695 0.7619,3.165204 -0.25397,0.60289 -1.16346,1.33205 -0.7619,1.80868 0.66604,0.79056 1.90476,2.75587 1.90476,4.52171 0,2.59585 6.05285,3.94812 7.85806,3.77252 6.74121,-0.65575 -1.93799,2.81162 -2.66666,4.97388 -0.70246,2.08446 -1.90477,3.36554 -1.90477,6.78256 0,5.12649 -0.14736,8.66381 -1.52381,13.56512 -1.30472,4.64591 -22.01777,20.64469 -26.90568,20.64469 -0.25397,0 -0.55873,-0.18087 -0.7619,0 -6.0286,5.36672 -19.33151,0.6413 -25.52381,-1.80868 -4.13181,-1.63475 -54.53753,-15.2774 -74.24743,-15.2774 -0.60557,0 -10.53047,-9.62995 -11.08591,-10.9485 -0.59189,-1.4051 -1.20905,-4.12889 -0.7619,-6.78256 0.47681,-2.82974 -1.14286,-10.15297 -1.14286,-12.66078 z"
+         style="fill:url(#linearGradient8324);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient11809);stroke-width:3.65714287999999987;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7433"
+         d="m 449.31226,118.94641 c -2.00812,-2.38353 0.99301,-7.96121 3.04762,-10.39993 2.71092,-3.21772 6.95081,-9.043414 11.04762,-9.043414 3.06356,0 5.33272,1.175504 8,1.808684 3.23693,0.76841 3.84868,1.23819 6.85714,-0.90434 2.89553,-2.062104 4.34776,-7.155944 5.71429,-10.399924 0.77436,-1.83826 4.76625,-0.67723 5.71428,-0.45217 1.43571,0.34082 1.82772,3.5945 3.42857,4.06953 1.77698,0.5273 3.26945,0.45217 5.33334,0.45217 1.52381,0 3.04762,0 4.57143,0"
+         style="fill:none;stroke:url(#linearGradient11813);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path7435"
+         d="m 493.61103,132.01391 c 1.80187,0 9.40336,-17.87237 11.80953,-22.15636 2.17201,-3.8671 5.42531,-7.53102 7.23809,-10.399934 1.1663,-1.84578 1.89144,-2.22922 2.66667,-4.06953 0.86724,-2.05873 2.51933,-1.85241 4.19048,-1.35652 2.57145,0.76305 4.46778,2.73381 6.47618,4.52171 1.55589,1.38507 2.25327,1.808694 4.57143,1.808694 3.30159,0 6.60318,0 9.90477,0 3.89105,0 11.68717,3.47214 13.71428,5.87821 1.25808,1.49327 1.40226,2.58808 1.90476,4.97388 0.22218,1.05486 0.47553,1.41106 0.76191,2.26085"
+         style="fill:none;stroke:url(#linearGradient11811);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscsc"
+         id="path7365"
+         d="m 407.66238,108.67408 c 0,0 8.29209,29.56 9.30065,44.36185 0.83541,12.26069 99.57633,34.77574 112.9847,32.30681 17.21624,-3.1701 53.5194,-37.42698 54.78581,-44.99078 2.30538,-13.76918 10.81543,-38.33534 9.04462,-45.138804 -3.46965,13.607764 -42.09469,49.471764 -69.08141,49.616694 -40.03795,0.21503 -115.99327,-26.26986 -117.03437,-36.15577 z"
+         style="fill:url(#linearGradient7403);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11801);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="0"
+         x="200"
+         height="200"
+         width="200"
+         id="rect6707-9"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssss"
+         id="path3294-5"
+         d="m 281.95114,103.66894 c -11.46505,-4.922943 -11.94535,-15.640053 -32.2236,-19.827033 -7.00697,-1.44678 1.73628,17.407643 2.9662,33.373153 1.2301,15.96762 -6.74673,29.94103 0.7383,42.7935 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38094 28.2524,10.48366 37.93001,1.26414 8.18731,-7.79977 19.68974,-11.69865 28.68994,-29.0367 7.20137,-13.87277 2.88845,-24.27373 3.81992,-39.03719 1.08656,-17.22162 6.2607,-36.586903 -0.80818,-35.427633 -21.61965,3.54556 -22.91326,19.820103 -32.47565,22.647093 -10.18804,3.01195 -23.20685,2.2981 -32.6329,-1.74932 z"
+         style="fill:url(#linearGradient3296-8);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3290-5);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient11857);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 281.95114,103.66894 c -11.46505,-4.922943 -11.94535,-15.640053 -32.2236,-19.827033 -7.00697,-1.44678 1.73628,17.407643 2.9662,33.373153 1.2301,15.96762 -6.74673,29.94103 0.7383,42.7935 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38094 28.2524,10.48366 37.93001,1.26414 8.18731,-7.79977 19.68974,-11.69865 28.68994,-29.0367 7.20137,-13.87277 2.88845,-24.27373 3.81992,-39.03719 1.08656,-17.22162 6.2607,-36.586903 -0.80818,-35.427633 -21.61965,3.54556 -22.91326,19.820103 -32.47565,22.647093 -10.18804,3.01195 -23.20685,2.2981 -32.6329,-1.74932 z"
+         id="path3280-7"
+         sodipodi:nodetypes="cssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3276-6"
+         d="m 308.85491,140.91504 c 3.35687,-10.77795 12.67966,-14.04082 22.06449,-6.93162 2.33862,1.77156 -3.24975,16.73419 -22.06449,6.93162 z"
+         style="fill:url(#linearGradient3278-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3274-31);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 286.77151,140.62698 c -3.35687,-10.77795 -12.67966,-14.04082 -22.06449,-6.93162 -2.33862,1.77155 3.24975,16.73419 22.06449,6.93162 z"
+         id="path3266-3"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11849);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 288.40205,162.57927 c 0.49511,2.19202 4.86338,4.21056 6.63501,3.216 0.84652,5.30018 1.70659,2.87938 2.56804,2.7427 0.76311,-0.1211 1.94841,2.91111 2.04333,-2.71977 1.93405,0.31513 6.32097,-0.41004 6.6262,-3.25717 l 0.13966,-0.13966 c -5.62284,-0.70521 -13.50654,-0.6264 -18.01224,0.1579 z"
+         id="path2267-3"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2281-2"
+         d="m 287.51126,165.07475 c -11.58423,-3.55612 -22.85887,-3.70691 -34.07484,-3.21198"
+         style="fill:none;stroke:url(#linearGradient11847);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11845);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 278.71316,166.56126 c -12.02894,-1.46457 -23.15456,0.36878 -34.10891,2.82747"
+         id="path2283-4"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2285-7"
+         d="m 285.41588,168.46937 c -12.09628,0.72167 -23.89607,2.55018 -34.22997,6.93799"
+         style="fill:none;stroke:url(#linearGradient11843);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11841);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 317.89212,177.6088 c -10.34921,3.75198 -21.01163,-1.14155 -19.91258,-5.78235 0.69976,-2.95479 -1.83252,-2.14894 -1.17807,-0.002 1.15017,3.77337 -13.07967,9.57264 -20.50007,5.69524"
+         id="path2289-8"
+         sodipodi:nodetypes="csss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2291-53"
+         d="m 289.26105,161.34771 c -0.64567,-3.87311 3.1972,-6.81778 -0.39089,-18.3381 -3.35687,-10.77796 -13.29634,-16.8004 -24.16311,-9.3142 -1.75456,1.20873 1.4613,16.62814 20.14465,7.92515"
+         style="fill:none;stroke:url(#linearGradient11853);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2293-0"
+         d="m 274.3127,133.80838 c 2.53699,2.1557 1.93534,4.76147 0.67933,7.46108 -1.12127,-2.01334 -1.8561,-4.23125 -0.67933,-7.46108 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2299-96"
+         d="m 269.6514,116.65144 c 4.83289,4.33731 4.87135,5.05855 8.33933,10.43821 2.39182,-6.33083 3.4659,-12.66166 10.05487,-18.9925 l -18.3942,8.55429 z"
+         style="fill:url(#linearGradient2313-4);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-3"
+         d="m 285.37376,111.18717 3.55493,19.74959 0.395,-20.14458 -3.94993,0.39499 z"
+         style="fill:url(#linearGradient2311-60);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2317-51);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 252.63243,145.78642 c 3.74373,-2.80212 8.6721,-4.41962 10.52245,-9.1151 -4.98717,0.616 -4.10122,-4.94505 -12.54469,3.4416 l 2.02224,5.6735 z"
+         id="path2315-4" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2323-2);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 275.90904,158.73969 c 4.52758,-4.65513 3.6698,-1.5047 9.1842,-4.75421 -6.22985,-2.64371 -9.3526,-4.76073 -21.33907,-7.2533 -6.87611,5.80188 4.03709,7.20521 12.15487,12.00751 z"
+         id="path2321-1"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2333-9);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 327.24261,117.44142 c -4.83289,4.33732 -4.87137,5.05855 -8.33933,10.43822 -2.39182,-6.33083 -3.4659,-12.66167 -10.05487,-18.9925 l 18.3942,8.55428 z"
+         id="path2325-8"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2335-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 310.12936,111.06355 -3.55492,19.74959 -0.395,-20.14459 3.94992,0.395 z"
+         id="path2327-9" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2329-0"
+         d="m 343.02706,146.18141 c -3.74374,-2.80212 -8.67209,-4.41962 -10.52247,-9.1151 4.98717,0.61601 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         style="fill:url(#linearGradient2337-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2331-44"
+         d="m 319.35545,159.52967 c -4.52758,-4.65512 -3.66981,-1.5047 -9.1842,-4.75421 6.22985,-2.6437 9.3526,-4.76073 21.33905,-7.2533 6.87613,5.80189 -4.03707,7.20522 -12.15485,12.00751 z"
+         style="fill:url(#linearGradient2339-8);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2341-9"
+         d="m 283.0919,172.02496 c -11.01617,5.04821 -19.53647,12.43369 -27.5835,20.26233"
+         style="fill:none;stroke:url(#linearGradient11839);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2343-9"
+         d="m 279.71791,171.59424 c -11.82701,2.63859 -21.70076,8.08377 -31.20411,14.06112"
+         style="fill:none;stroke:url(#linearGradient11837);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11835);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 308.59307,164.67975 c 11.58423,-3.55611 22.85887,-3.7069 34.07484,-3.21198"
+         id="path2345-4"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2347-4"
+         d="m 317.39117,166.16627 c 12.02894,-1.46458 23.15456,0.36877 34.10889,2.82749"
+         style="fill:none;stroke:url(#linearGradient11833);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11851);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 310.68845,168.0744 c 12.09626,0.72165 23.89607,2.55015 34.22997,6.93799"
+         id="path2349-8"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11831);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 313.01242,171.62997 c 11.01618,5.0482 19.53647,12.43367 27.58349,20.26235"
+         id="path2351-1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11829);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 316.38642,171.19925 c 11.82701,2.63858 21.70074,8.08377 31.20411,14.06114"
+         id="path2353-6"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2363-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 250.88226,89.402527 c 0.83437,3.41704 4.19214,18.576223 6.31791,30.512893 2.16288,-5.72489 12.73174,-5.89326 18.69004,-11.61814 C 262.22225,86.305087 254.97846,89.949697 250.88226,89.402527 z"
+         id="path2361-5"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2365-0"
+         d="m 347.23372,87.115557 c -0.83438,3.41704 -2.0103,20.287073 -4.13608,32.223733 -2.16287,-5.72488 -14.40754,-5.89326 -20.36584,-11.61814 13.66796,-21.992183 19.25345,-20.058423 24.50192,-20.605593 z"
+         style="fill:url(#linearGradient2367-0);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccc"
+         id="path8557"
+         d="m 251.04636,50.660027 c 13.66601,3.079 26.90891,28.56336 33.69464,37.88533 -4.9684,-16.10222 -7.63917,-41.38174 -5.63534,-57.43726 4.13602,16.79435 10.61008,35.05667 17.60303,47.55704 4.16998,-8.13842 15.67827,-28.10239 17.38989,-45.7683 4.50713,17.69932 -2.56215,36.28008 -3.68455,53.30576 5.93352,-11.56222 17.64408,-29.95486 31.46238,-32.63382 -14.01705,20.03405 -21.82835,39.38184 -25.13556,54.208503 -12.35654,-1.83898 -24.71308,-2.05168 -37.06961,0.51982 -3.01171,-11.657883 -22.73307,-46.187573 -28.62488,-57.637073 z"
+         style="fill:url(#linearGradient9438);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11905);stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,225.80095,-10.292333)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path9446"
+         style="opacity:0.98999999;fill:url(#linearGradient10327);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11903);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient1334);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11901);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path1332"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,256.01105,-25.514562)" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,292.73562,-26.461352)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path1336"
+         style="opacity:0.98999999;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11899);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient1342);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11897);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path1340"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,321.3295,-7.6256727)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11855);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 306.47238,160.81689 c 0.64567,-3.87308 -3.1972,-6.81776 0.39089,-18.33807 3.35687,-10.77796 13.29634,-16.80041 24.16311,-9.31421 1.75456,1.20874 -1.46129,16.62814 -20.14465,7.92516"
+         id="path3250-15"
+         sodipodi:nodetypes="cssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 320.72939,132.58624 c -2.537,2.1557 -1.93535,4.76147 -0.67933,7.46107 1.12126,-2.01333 1.85609,-4.23124 0.67933,-7.46107 z"
+         id="path3252-8"
+         sodipodi:nodetypes="ccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscs"
+         id="path3254-6"
+         d="m 294.30268,152.14373 c -5.10249,-17.96854 -4.76166,-41.22186 4.11541,-41.09203 7.12026,0.10763 5.91194,28.5804 3.59188,42.8706 0,0 -4.77447,8.54941 -7.70729,-1.77857 z"
+         style="fill:url(#linearGradient3256-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient3260-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 340.58278,131.51573 c -3.74374,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.61601 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         id="path3258-0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3262-1"
+         d="m 255.89147,132.75025 c 3.74373,-2.80211 8.6721,-4.41961 10.52245,-9.11509 -4.98717,0.616 -4.10122,-4.94505 -12.54469,3.4416 l 2.02224,5.67349 z"
+         style="fill:url(#linearGradient3264-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect6707-79"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssss"
+         id="path3294-50"
+         d="M 686.75613,104.06305 C 675.29109,99.14012 674.81078,88.423 654.53253,84.23603 c -7.00697,-1.44679 1.73628,17.40764 2.96621,33.37314 1.23009,15.96764 -6.74674,29.94103 0.73829,42.79351 9.94711,17.08007 17.26241,18.75134 23.99596,24.99998 12.26417,11.38096 28.25241,10.48366 37.93001,1.26414 8.18731,-7.79975 19.68974,-11.69865 28.68994,-29.03669 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08654,-17.22162 6.26069,-36.5869 -0.8082,-35.42763 -21.61964,3.54555 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.20685,2.29811 -32.6329,-1.74932 z"
+         style="fill:url(#linearGradient3296-73);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3290-7);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient11981);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 686.75613,104.06305 C 675.29109,99.14012 674.81078,88.423 654.53253,84.23603 c -7.00697,-1.44679 1.73628,17.40764 2.96621,33.37314 1.23009,15.96764 -6.74674,29.94103 0.73829,42.79351 9.94711,17.08007 17.26241,18.75134 23.99596,24.99998 12.26417,11.38096 28.25241,10.48366 37.93001,1.26414 8.18731,-7.79975 19.68974,-11.69865 28.68994,-29.03669 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08654,-17.22162 6.26069,-36.5869 -0.8082,-35.42763 -21.61964,3.54555 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.20685,2.29811 -32.6329,-1.74932 z"
+         id="path3280-75"
+         sodipodi:nodetypes="cssssssssss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csc"
+         id="path3276-8"
+         d="m 713.65991,141.30915 c 3.35687,-10.77794 12.67966,-14.0408 22.06448,-6.93161 2.33863,1.77154 -3.24976,16.73419 -22.06448,6.93161 z"
+         style="fill:url(#linearGradient3278-2);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3274-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 691.5765,141.02111 c -3.35687,-10.77797 -12.67966,-14.04083 -22.06448,-6.93164 -2.33863,1.77157 3.24974,16.7342 22.06448,6.93164 z"
+         id="path3266-9"
+         sodipodi:nodetypes="csc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12017);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 693.20704,162.97338 c 0.49511,2.19205 4.86338,4.21056 6.63501,3.216 0.84652,5.30021 1.70659,2.87938 2.56805,2.7427 0.7631,-0.12108 1.9484,2.91113 2.04332,-2.71975 1.93406,0.31513 6.32098,-0.41004 6.6262,-3.25719 l 0.13965,-0.13963 c -5.62282,-0.70524 -13.50653,-0.62643 -18.01223,0.15787 z"
+         id="path2267-8"
+         sodipodi:nodetypes="ccscccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2281-7"
+         d="m 692.31625,165.46888 c -11.58423,-3.55614 -22.85887,-3.70693 -34.07484,-3.21198"
+         style="fill:none;stroke:url(#linearGradient12015);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12013);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 683.51815,166.95537 c -12.02894,-1.46455 -23.15456,0.3688 -34.10891,2.8275"
+         id="path2283-54"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2285-2"
+         d="m 690.22087,168.86351 c -12.09628,0.72164 -23.89607,2.55014 -34.22997,6.93798"
+         style="fill:none;stroke:url(#linearGradient12011);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12009);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 722.6971,178.00293 c -10.34921,3.75196 -21.01162,-1.14157 -19.91257,-5.78237 0.69976,-2.95479 -1.83252,-2.14892 -1.17807,-0.002 1.15017,3.77337 -13.07967,9.57262 -20.50007,5.69522"
+         id="path2289-11"
+         sodipodi:nodetypes="csss" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2291-0"
+         d="m 694.06604,161.74181 c -0.64567,-3.87309 3.1972,-6.81776 -0.39089,-18.33808 -3.35687,-10.77796 -13.29634,-16.80041 -24.1631,-9.31421 -1.75457,1.20873 1.46129,16.62813 20.14464,7.92516"
+         style="fill:none;stroke:url(#linearGradient11991);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2293-2"
+         d="m 679.11769,134.2025 c 2.53699,2.1557 1.93534,4.76146 0.67933,7.46107 -1.12127,-2.01332 -1.8561,-4.23124 -0.67933,-7.46107 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2299-0"
+         d="m 674.45639,117.04556 c 4.83289,4.33731 4.87135,5.05854 8.33933,10.43822 2.39182,-6.33083 3.4659,-12.66167 10.05487,-18.9925 l -18.3942,8.55428 z"
+         style="fill:url(#linearGradient2313-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-6"
+         d="m 690.17875,111.58129 3.55493,19.7496 0.395,-20.1446 -3.94993,0.395 z"
+         style="fill:url(#linearGradient2311-3);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2317-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 657.43742,146.18053 c 3.74373,-2.80212 8.6721,-4.41961 10.52245,-9.1151 -4.98717,0.61602 -4.10122,-4.94506 -12.54469,3.44162 l 2.02224,5.67348 z"
+         id="path2315-67" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2323-6);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 680.71403,159.13381 c 4.52758,-4.65513 3.66981,-1.5047 9.1842,-4.75421 -6.22985,-2.64371 -9.3526,-4.76073 -21.33906,-7.25331 -6.87612,5.80188 4.03708,7.20522 12.15486,12.00752 z"
+         id="path2321-51"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2333-7);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 732.04759,117.83553 c -4.83289,4.33732 -4.87136,5.05856 -8.33933,10.43824 -2.39182,-6.33084 -3.46588,-12.66167 -10.05486,-18.9925 l 18.39419,8.55426 z"
+         id="path2325-5"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2335-1);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 714.93436,111.45765 -3.55493,19.7496 -0.39499,-20.14459 3.94992,0.39499 z"
+         id="path2327-0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2329-8"
+         d="m 747.83205,146.57553 c -3.74375,-2.80213 -8.67209,-4.41961 -10.52247,-9.11511 4.98718,0.61602 8.01145,-0.47623 16.45493,7.91045 l -5.93246,1.20466 z"
+         style="fill:url(#linearGradient2337-0);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2331-9"
+         d="m 724.16044,159.92378 c -4.52757,-4.65511 -3.66981,-1.50469 -9.18421,-4.75419 6.22985,-2.64371 9.3526,-4.76074 21.33907,-7.25331 6.87613,5.80188 -4.03708,7.20521 -12.15486,12.0075 z"
+         style="fill:url(#linearGradient2339-07);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2341-48"
+         d="m 687.89689,172.41907 c -11.01617,5.04823 -19.53647,12.43369 -27.5835,20.26236"
+         style="fill:none;stroke:url(#linearGradient12007);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2343-8"
+         d="m 684.52291,171.98835 c -11.82702,2.63861 -21.70077,8.08377 -31.20412,14.06114"
+         style="fill:none;stroke:url(#linearGradient12005);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient12003);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 713.39806,165.07388 c 11.58423,-3.55613 22.85888,-3.70692 34.07484,-3.21197"
+         id="path2345-45"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2347-8"
+         d="m 722.19616,166.56037 c 12.02894,-1.46454 23.15456,0.3688 34.1089,2.8275"
+         style="fill:none;stroke:url(#linearGradient12001);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11999);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 715.49344,168.46851 c 12.09626,0.72167 23.89607,2.55015 34.22997,6.93799"
+         id="path2349-1"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11997);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 717.8174,172.02408 c 11.01618,5.0482 19.53648,12.43369 27.5835,20.26235"
+         id="path2351-6"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11995);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 721.19141,171.59336 c 11.82702,2.6386 21.70075,8.08377 31.20411,14.06114"
+         id="path2353-7"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2363-15);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 655.68725,89.79665 c 0.83437,3.41705 4.19214,18.57623 6.31791,30.51289 2.16288,-5.72489 12.73174,-5.89326 18.69004,-11.61815 C 667.02724,86.69921 659.78345,90.34383 655.68725,89.79665 z"
+         id="path2361-8"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2365-66"
+         d="m 752.0387,87.50968 c -0.83438,3.41703 -2.01028,20.28706 -4.13607,32.22372 -2.16288,-5.72487 -14.40754,-5.89325 -20.36585,-11.61812 13.66796,-21.99219 19.25346,-20.05843 24.50192,-20.6056 z"
+         style="fill:url(#linearGradient2367-5);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient7571);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11987);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 673.48081,112.53278 c -3.41322,-22.47251 -8.69931,-22.61847 23.45933,-58.77603 44.83561,26.80833 31.22624,35.73948 34.11899,58.62617 -27.40816,-2.72369 -34.20891,-2.20629 -57.57832,0.14986 z"
+         id="path7569"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:url(#linearGradient11993);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 711.27738,161.21103 c 0.64566,-3.8731 -3.19722,-6.81779 0.39088,-18.33808 3.35686,-10.77797 13.29634,-16.80042 24.1631,-9.31422 1.75456,1.20873 -1.46128,16.62814 -20.14464,7.92516"
+         id="path3250-8"
+         sodipodi:nodetypes="cssc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 725.53438,132.98035 c -2.537,2.1557 -1.93536,4.76149 -0.67934,7.46108 1.12126,-2.01333 1.8561,-4.23125 0.67934,-7.46108 z"
+         id="path3252-5"
+         sodipodi:nodetypes="ccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscs"
+         id="path3254-3"
+         d="m 699.10768,152.53784 c -5.1025,-17.96853 -4.76167,-41.22185 4.11541,-41.09203 7.12025,0.10764 5.91193,28.58042 3.59186,42.87061 0,0 -4.77445,8.54942 -7.70727,-1.77858 z"
+         style="fill:url(#linearGradient3256-2);fill-opacity:1.0;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient7567);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11983);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 735.66525,96.27197 c 14.22553,-29.85909 7.92426,-56.59578 -16.44186,-81.84056 -15.47869,9.5886 -44.41537,48.69093 -46.3912,74.07598 25.60463,-4.31574 37.44941,2.34431 62.83306,7.76458 z"
+         id="path7565"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5801"
+         d="M 669.54853,101.54436 C 649.96109,80.54255 664.209,40.71898 686.80571,12.90233 c 36.32837,28.6565 56.65216,60.22243 48.00232,88.5946 -25.60462,-4.31575 -39.87584,-5.37283 -65.2595,0.0474 z"
+         style="fill:url(#linearGradient3939);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12019);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect3643"
+         d="m 693.92972,54.73325 c -2.82401,-0.0674 -5.28015,2.29084 -5.06209,4.69782 -0.0313,1.38583 -0.10156,2.7707 -0.1625,4.1557 -1.8934,-0.10047 -3.81853,-0.47805 -5.70421,-0.17375 -2.49935,0.57203 -4.35267,2.9378 -3.73407,5.15897 0.4628,2.03468 2.76973,3.59601 5.16584,3.5163 1.65766,0.0743 3.31079,0.20662 4.96401,0.33242 0.41474,3.56237 1.20592,7.08986 2.25234,10.55173 0.42188,2.2784 3.12417,4.12346 5.80468,3.7083 2.71727,-0.31974 4.82957,-2.78584 4.27604,-5.12891 -0.23714,-1.17073 -0.72441,-2.2929 -0.95,-3.46708 -0.49223,-1.95628 -0.91168,-3.93142 -1.14173,-5.92203 2.02591,-0.17405 4.16416,-0.0229 6.06355,-0.75603 2.15624,-0.9513 3.4081,-3.33329 2.52736,-5.33342 -0.76069,-1.94103 -3.19492,-3.21973 -5.54102,-2.97346 -1.28045,0.0433 -2.55293,0.18191 -3.83027,0.26326 0.0297,-0.5203 -0.0374,-1.05425 0.014,-1.58051 0.0252,-1.13656 0.2156,-2.27782 0.12496,-3.41179 -0.47168,-2.00564 -2.63578,-3.72099 -5.06684,-3.63752 z"
+         style="opacity:0.98999999;fill:url(#linearGradient3723);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11985);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path3941"
+         d="m 696.71089,102.46716 c -2.20923,4.97345 10.87584,6.35628 9.7116,0.0753"
+         style="fill:none;stroke:url(#linearGradient11989);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient3260-8);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 745.38778,131.90984 c -3.74375,-2.80211 -8.6721,-4.41961 -10.52247,-9.11509 4.98715,0.616 8.01145,-0.47623 16.4549,7.91042 l -5.93243,1.20467 z"
+         id="path3258-4" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3262-7"
+         d="m 660.69646,133.14437 c 3.74373,-2.80212 8.6721,-4.41961 10.52245,-9.1151 -4.98717,0.61602 -4.10122,-4.94506 -12.54469,3.44162 l 2.02224,5.67348 z"
+         style="fill:url(#linearGradient3264-7);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10254"
+         width="200"
+         height="200"
+         x="0"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10669);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 82.217286,304.05189 c -11.46504,-4.92294 -11.94534,-15.64005 -32.2236,-19.82703 -7.00697,-1.44678 1.73629,17.40764 2.96621,33.37314 1.2301,15.96763 -6.74674,29.94104 0.7383,42.79351 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38095 28.252404,10.48366 37.930014,1.26414 8.1873,-7.79977 19.68974,-11.69866 28.68993,-29.0367 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08655,-17.22162 6.2607,-36.5869 -0.80819,-35.42763 -21.61965,3.54556 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.206864,2.29811 -32.632914,-1.74931 z"
+         id="path10256"
+         sodipodi:nodetypes="cssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssssssss"
+         id="path10258"
+         d="m 82.217286,304.05189 c -11.46504,-4.92294 -11.94534,-15.64005 -32.2236,-19.82703 -7.00697,-1.44678 1.73629,17.40764 2.96621,33.37314 1.2301,15.96763 -6.74674,29.94104 0.7383,42.79351 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38095 28.252404,10.48366 37.930014,1.26414 8.1873,-7.79977 19.68974,-11.69866 28.68993,-29.0367 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08655,-17.22162 6.2607,-36.5869 -0.80819,-35.42763 -21.61965,3.54556 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.206864,2.29811 -32.632914,-1.74931 z"
+         style="fill:url(#linearGradient10671);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12377);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10673);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 109.12107,341.29799 c 3.35687,-10.77795 12.67966,-14.04082 22.06448,-6.93162 2.33863,1.77155 -3.24974,16.73419 -22.06448,6.93162 z"
+         id="path10260"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csc"
+         id="path10262"
+         d="m 87.037656,341.00993 c -3.35687,-10.77795 -12.67966,-14.04082 -22.06448,-6.93163 -2.33863,1.77156 3.24974,16.7342 22.06448,6.93163 z"
+         style="fill:url(#linearGradient10675);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscccc"
+         id="path10264"
+         d="m 88.668196,362.96222 c 0.49511,2.19203 4.86339,4.21055 6.63502,3.216 0.84652,5.30019 1.70659,2.87938 2.56804,2.74269 0.76311,-0.12108 1.94841,2.91112 2.04333,-2.71976 1.934044,0.31514 6.320974,-0.41003 6.626204,-3.25717 l 0.13965,-0.13965 c -5.62283,-0.70522 -13.506544,-0.62641 -18.012244,0.15789 z"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12405);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12403);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 87.777416,365.4577 c -11.58423,-3.55613 -22.85888,-3.70692 -34.07485,-3.21197"
+         id="path10266"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10268"
+         d="m 78.979316,366.9442 c -12.02894,-1.46456 -23.15457,0.36879 -34.10891,2.82749"
+         style="fill:none;stroke:url(#linearGradient12401);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12399);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 85.682026,368.85233 c -12.09628,0.72166 -23.89607,2.55016 -34.22996,6.93799"
+         id="path10270"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path10272"
+         d="m 118.15827,377.99176 c -10.3492,3.75196 -21.011634,-1.14157 -19.912584,-5.78236 0.69977,-2.9548 -1.83251,-2.14893 -1.17807,-0.002 1.15018,3.77338 -13.07966,9.57264 -20.50007,5.69524"
+         style="fill:none;stroke:url(#linearGradient12397);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12381);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 89.527196,361.73065 c -0.64567,-3.8731 3.19721,-6.81777 -0.39089,-18.33809 -3.35687,-10.77796 -13.29633,-16.8004 -24.1631,-9.3142 -1.75457,1.20873 1.46129,16.62814 20.14464,7.92515"
+         id="path10274"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 74.578846,334.19133 c 2.537,2.1557 1.93535,4.76147 0.67933,7.46107 -1.12126,-2.01333 -1.85609,-4.23124 -0.67933,-7.46107 z"
+         id="path10276"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10677);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 69.917546,317.03439 c 4.8329,4.33731 4.87135,5.05854 8.33934,10.43821 2.39182,-6.33083 3.46589,-12.66166 10.05486,-18.9925 l -18.3942,8.55429 z"
+         id="path10278"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10679);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 85.639916,311.57012 3.55492,19.74959 0.395,-20.14459 -3.94992,0.395 z"
+         id="path10280"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10282"
+         d="m 52.898576,346.16936 c 3.74373,-2.80211 8.6721,-4.41961 10.52246,-9.11509 -4.98717,0.616 -4.10123,-4.94505 -12.5447,3.4416 l 2.02224,5.67349 z"
+         style="fill:url(#linearGradient10681);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10284"
+         d="m 76.175186,359.12264 c 4.52758,-4.65513 3.66981,-1.50471 9.1842,-4.75421 -6.22985,-2.64371 -9.35259,-4.76073 -21.33906,-7.2533 -6.87612,5.80188 4.03709,7.20521 12.15486,12.00751 z"
+         style="fill:url(#linearGradient10683);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10286"
+         d="m 127.50877,317.82437 c -4.8329,4.33732 -4.87137,5.05855 -8.33934,10.43822 -2.39182,-6.33083 -3.46589,-12.66167 -10.05486,-18.9925 l 18.3942,8.55428 z"
+         style="fill:url(#linearGradient10685);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10288"
+         d="m 110.39552,311.44649 -3.55492,19.7496 -0.39501,-20.14459 3.94993,0.39499 z"
+         style="fill:url(#linearGradient10687);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10689);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 143.29322,346.56436 c -3.74375,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.616 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         id="path10290"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10691);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 119.62161,359.91262 c -4.52758,-4.65512 -3.66981,-1.5047 -9.1842,-4.75421 6.22985,-2.64371 9.35259,-4.76073 21.33904,-7.2533 6.87614,5.80189 -4.03707,7.20522 -12.15484,12.00751 z"
+         id="path10292"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12395);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 83.358046,372.4079 c -11.01617,5.04822 -19.53647,12.43369 -27.58349,20.26235"
+         id="path10294"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12393);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 79.984066,371.97718 c -11.82702,2.6386 -21.70077,8.08378 -31.20411,14.06114"
+         id="path10296"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10298"
+         d="m 108.85922,365.0627 c 11.58423,-3.55612 22.85888,-3.70691 34.07485,-3.21197"
+         style="fill:none;stroke:url(#linearGradient12391);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12389);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 117.65732,366.54921 c 12.02894,-1.46456 23.15457,0.36879 34.1089,2.82749"
+         id="path10300"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10302"
+         d="m 110.95461,368.45734 c 12.09626,0.72166 23.89607,2.55016 34.22996,6.93799"
+         style="fill:none;stroke:url(#linearGradient12387);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10304"
+         d="m 113.27857,372.01291 c 11.01619,5.04821 19.53647,12.43368 27.58349,20.26236"
+         style="fill:none;stroke:url(#linearGradient12385);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10306"
+         d="m 116.65257,371.58219 c 11.82702,2.6386 21.70075,8.08377 31.20411,14.06114"
+         style="fill:none;stroke:url(#linearGradient12383);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10308"
+         d="m 51.148406,289.78548 c 0.83437,3.41704 4.19214,18.57622 6.31791,30.51289 2.16288,-5.72489 12.73174,-5.89326 18.69005,-11.61814 -13.66796,-21.99219 -20.91175,-18.34758 -25.00796,-18.89475 z"
+         style="fill:url(#linearGradient10693);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10695);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 147.49987,287.49851 c -0.83437,3.41704 -2.0103,20.28707 -4.13607,32.22373 -2.16288,-5.72488 -14.40755,-5.89326 -20.36585,-11.61814 13.66796,-21.99218 19.25346,-20.05842 24.50192,-20.60559 z"
+         id="path10310"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccccc"
+         id="path10312"
+         d="m 99.594816,215.89681 c -2.36026,0.19298 -5.08426,0.0555 -6.97516,1.69553 -0.92618,2.50049 0.22557,5.11484 0.60947,7.60777 0.46812,1.94334 0.99164,3.87981 1.01302,5.88866 -5.40584,-0.90163 -10.98618,-2.35595 -16.44926,-1.18948 -1.99901,1.0799 -2.10615,3.67772 -2.2916,5.67078 -0.057,2.70372 0.365,5.64101 2.06205,7.81001 3.16684,1.18659 6.57725,0.13609 9.75665,-0.44497 2.07282,-0.44604 4.26666,-1.16996 6.30655,-1.15666 0.0734,4.82559 -0.32046,9.76576 -1.32324,14.41771 -0.12015,0.76604 -2.42694,7.76203 -1.58332,7.76164 2.07582,0.36095 11.131464,0.54592 13.222644,0.73175 1.49006,-0.0297 -1.65555,-11.04593 -1.72458,-12.69617 -0.6991,-3.45316 -1.10789,-7.01589 -0.43729,-10.53838 5.33735,-0.15901 10.62655,1.8163 15.95365,0.87646 2.08818,-1.02162 2.43666,-3.6171 2.83284,-5.65526 0.25974,-2.65187 0.0341,-5.65047 -1.72161,-7.76292 -2.79458,-0.88045 -5.70239,0.14481 -8.49853,0.45909 -2.20584,0.39659 -4.39678,0.87701 -6.60997,1.23122 1.36236,-4.06985 3.95544,-7.75836 4.48664,-12.09827 -0.45096,-1.88998 -2.78691,-2.04544 -4.35099,-2.36331 -1.4045,-0.21627 -2.84841,-0.26746 -4.277964,-0.2452 z"
+         style="fill:url(#linearGradient10697);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12369);stroke-width:3.6571424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient10699);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12371);stroke-width:79.32309723;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path10314"
+         sodipodi:cx="711.47321"
+         sodipodi:cy="546.96198"
+         sodipodi:rx="355.19348"
+         sodipodi:ry="304.1412"
+         d="m 1066.6667,546.96198 a 355.19348,304.1412 0 1 1 -710.38698,0 355.19348,304.1412 0 1 1 710.38698,0 z"
+         transform="matrix(0.04057623,0,0,0.0523856,68.913356,244.72503)" />
+      <path
+         style="fill:url(#linearGradient10701);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12375);stroke-width:3.65714502;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 74.718606,309.58378 c 4.24696,-17.05397 -19.71515,-18.39267 -19.19344,-34.25988 0.46598,-14.17251 7.1295,-18.96951 19.50454,-20.14579 16.26869,-1.54638 21.02302,22.54195 23.33729,22.00859 2.575144,-0.59348 9.533184,-22.30528 20.778294,-22.15706 12.89041,0.16991 22.83556,5.2253 22.39163,21.41604 -0.40119,15.08103 -24.44855,15.88082 -20.44703,31.9191 -16.77576,-2.06806 -31.013664,-1.26269 -46.371284,1.219 z"
+         id="path10316"
+         sodipodi:nodetypes="cssssscc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssc"
+         id="path10318"
+         d="m 106.73854,361.19985 c 0.64567,-3.8731 -3.1972,-6.81777 0.39089,-18.33808 3.35687,-10.77796 13.29633,-16.80041 24.1631,-9.31421 1.75457,1.20874 -1.46129,16.62814 -20.14464,7.92516"
+         style="fill:none;stroke:url(#linearGradient12379);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path10320"
+         d="m 120.99554,332.96919 c -2.53699,2.1557 -1.93534,4.76147 -0.67933,7.46107 1.12127,-2.01333 1.8561,-4.23124 0.67933,-7.46107 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10703);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 94.568836,352.52668 c -5.10249,-17.96854 -4.76166,-41.22186 4.11541,-41.09203 7.120264,0.10762 5.911934,28.5804 3.591884,42.8706 0,0 -4.774474,8.54942 -7.707294,-1.77857 z"
+         id="path10322"
+         sodipodi:nodetypes="cscs"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10324"
+         d="m 140.84894,331.89868 c -3.74375,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.616 8.01144,-0.47623 16.45492,7.91042 l -5.93245,1.20468 z"
+         style="fill:url(#linearGradient10705);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10707);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 56.157616,333.1332 c 3.74373,-2.80211 8.6721,-4.41961 10.52246,-9.11509 -4.98717,0.616 -4.10123,-4.94505 -12.5447,3.4416 l 2.02224,5.67349 z"
+         id="path10326"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12373);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 83.918156,298.08756 c 8.79869,-1.09303 17.888144,-1.89532 29.296864,-0.37832"
+         id="path10328"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10330"
+         width="200"
+         height="200"
+         x="1000"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10709);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 1087.2776,301.32468 c -10.7773,-4.62761 -11.2288,-14.70179 -30.2905,-18.63759 -6.5866,-1.35998 1.6321,16.36334 2.7883,31.37106 1.1563,15.00971 -6.342,28.14484 0.694,40.22628 9.3503,16.05541 16.2268,17.62644 22.5564,23.50021 11.5284,10.69819 26.5575,9.85474 35.6545,1.1883 7.6962,-7.33184 18.5086,-10.99684 26.9689,-27.29475 6.7693,-13.04054 2.7152,-22.81753 3.5907,-36.69531 1.0214,-16.18848 5.8852,-34.39202 -0.7597,-33.30229 -20.3226,3.33285 -21.5387,18.63106 -30.5274,21.28846 -9.5769,2.83127 -21.8147,2.16023 -30.6752,-1.64437 z"
+         id="path10332"
+         sodipodi:nodetypes="cssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssssssss"
+         id="path10334"
+         d="m 1087.2776,301.32468 c -10.7773,-4.62761 -11.2288,-14.70179 -30.2905,-18.63759 -6.5866,-1.35998 1.6321,16.36334 2.7883,31.37106 1.1563,15.00971 -6.342,28.14484 0.694,40.22628 9.3503,16.05541 16.2268,17.62644 22.5564,23.50021 11.5284,10.69819 26.5575,9.85474 35.6545,1.1883 7.6962,-7.33184 18.5086,-10.99684 26.9689,-27.29475 6.7693,-13.04054 2.7152,-22.81753 3.5907,-36.69531 1.0214,-16.18848 5.8852,-34.39202 -0.7597,-33.30229 -20.3226,3.33285 -21.5387,18.63106 -30.5274,21.28846 -9.5769,2.83127 -21.8147,2.16023 -30.6752,-1.64437 z"
+         style="fill:url(#linearGradient10711);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12187);stroke-width:3.65715121999999981;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10713);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1112.5673,336.33629 c 3.1555,-10.13137 11.919,-13.19849 20.7409,-6.51579 2.1983,1.66528 -3.0548,15.73029 -20.7409,6.51579 z"
+         id="path10336"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csc"
+         id="path10338"
+         d="m 1091.8087,336.06551 c -3.1555,-10.13137 -11.919,-13.19849 -20.7408,-6.51579 -2.1983,1.66528 3.0548,15.73028 20.7408,6.51579 z"
+         style="fill:url(#linearGradient10715);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscccc"
+         id="path10340"
+         d="m 1093.3415,356.70092 c 0.4654,2.06052 4.5716,3.95795 6.237,3.02307 0.7957,4.98222 1.6042,2.70664 2.4139,2.57815 0.7174,-0.11382 1.8316,2.73648 1.9208,-2.55659 1.818,0.29622 5.9418,-0.38544 6.2287,-3.06178 l 0.1313,-0.13127 c -5.2856,-0.66291 -12.6963,-0.58883 -16.9317,0.14842 z"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12175);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12173);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1092.5041,359.04669 c -10.8892,-3.34279 -21.4875,-3.48453 -32.0306,-3.01928"
+         id="path10342"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10344"
+         d="m 1084.2338,360.44402 c -11.3073,-1.3767 -21.7655,0.34666 -32.0626,2.65787"
+         style="fill:none;stroke:url(#linearGradient12171);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12169);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1090.5345,362.23768 c -11.3707,0.67836 -22.4626,2.39717 -32.1765,6.52177"
+         id="path10346"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path10348"
+         d="m 1121.0624,370.82882 c -9.7283,3.52688 -19.7511,-1.07309 -18.718,-5.43547 0.6578,-2.77754 -1.7226,-2.02001 -1.1074,-0.002 1.0812,3.54701 -12.295,8.99836 -19.2702,5.35357"
+         style="fill:none;stroke:url(#linearGradient12167);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12183);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1094.1489,355.54323 c -0.6069,-3.64075 3.0055,-6.40877 -0.3674,-17.23797 -3.1555,-10.13137 -12.4987,-15.79253 -22.7135,-8.75543 -1.6493,1.13622 1.3736,15.6306 18.9361,7.44972"
+         id="path10350"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1080.0974,329.65602 c 2.3848,2.02638 1.8192,4.47583 0.6385,7.01348 -1.054,-1.89255 -1.7447,-3.97741 -0.6385,-7.01348 z"
+         id="path10352"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10717);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1075.7157,313.52829 c 4.5429,4.07712 4.5791,4.75508 7.839,9.81201 2.2484,-5.95103 3.258,-11.90207 9.4517,-17.85311 l -17.2907,8.0411 z"
+         id="path10354"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10719);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1090.4948,308.39183 3.3417,18.56479 0.3713,-18.93609 -3.713,0.3713 z"
+         id="path10356"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10358"
+         d="m 1059.7177,340.91542 c 3.5191,-2.63401 8.1518,-4.15447 9.8912,-8.56827 -4.688,0.57905 -3.8552,-4.64839 -11.7921,3.23514 l 1.9009,5.33313 z"
+         style="fill:url(#linearGradient10721);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10360"
+         d="m 1081.5979,353.0916 c 4.256,-4.37585 3.4497,-1.41443 8.6332,-4.46899 -5.8561,-2.48511 -8.7915,-4.47512 -20.0589,-6.81817 -6.4636,5.45383 3.7949,6.77297 11.4257,11.28716 z"
+         style="fill:url(#linearGradient10723);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10362"
+         d="m 1129.852,314.27088 c -4.5431,4.07712 -4.5792,4.75508 -7.8391,9.81202 -2.2484,-5.95104 -3.258,-11.90208 -9.4517,-17.85312 l 17.2908,8.0411 z"
+         style="fill:url(#linearGradient10725);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10364"
+         d="m 1113.7653,308.27562 -3.3417,18.56479 -0.3713,-18.93608 3.713,0.37129 z"
+         style="fill:url(#linearGradient10727);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10729);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1144.6895,341.28672 c -3.5192,-2.63402 -8.1519,-4.15448 -9.8912,-8.56828 4.6879,0.57905 7.5308,-0.44765 15.4677,7.43588 l -5.5765,1.1324 z"
+         id="path10366"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10731);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1122.4379,353.8342 c -4.256,-4.37586 -3.4496,-1.41443 -8.6332,-4.469 5.8561,-2.48511 8.7915,-4.47513 20.0589,-6.81817 6.4636,5.45383 -3.7949,6.77297 -11.4257,11.28717 z"
+         id="path10368"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12165);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1088.3499,365.57995 c -10.3553,4.74537 -18.3645,11.68778 -25.9287,19.04679"
+         id="path10370"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12163);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1085.1783,365.17507 c -11.1175,2.4803 -20.3989,7.59882 -29.3321,13.21759"
+         id="path10372"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10374"
+         d="m 1112.3212,358.67539 c 10.8893,-3.34279 21.4876,-3.48453 32.0307,-3.01928"
+         style="fill:none;stroke:url(#linearGradient12161);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12159);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1120.5915,360.07272 c 11.3074,-1.3767 21.7656,0.34667 32.0627,2.65787"
+         id="path10376"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10378"
+         d="m 1114.2909,361.86638 c 11.3706,0.67837 22.4626,2.39717 32.1765,6.52177"
+         style="fill:none;stroke:url(#linearGradient12157);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10380"
+         d="m 1116.4755,365.20865 c 10.3553,4.74536 18.3645,11.68777 25.9287,19.0468"
+         style="fill:none;stroke:url(#linearGradient12155);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10382"
+         d="m 1119.647,364.80377 c 11.1176,2.4803 20.399,7.59882 29.3322,13.2176"
+         style="fill:none;stroke:url(#linearGradient12153);stroke-width:3.65715146;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10384"
+         d="m 1058.0725,287.91409 c 0.7843,3.21204 3.9407,17.4618 5.9389,28.68237 2.0331,-5.38144 11.968,-5.53971 17.5688,-10.92115 -12.848,-20.67285 -19.6572,-17.24688 -23.5077,-17.76122 z"
+         style="fill:url(#linearGradient10733);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10735);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1148.6438,285.76432 c -0.7844,3.21204 -1.8897,19.07001 -3.888,30.29058 -2.0331,-5.38144 -13.5432,-5.53972 -19.1441,-10.92115 12.8481,-20.67285 18.0985,-18.8551 23.0321,-19.36943 z"
+         id="path10386"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssc"
+         id="path10388"
+         d="m 1110.3278,355.04428 c 0.6069,-3.64075 -3.0054,-6.40877 0.3674,-17.23797 3.1555,-10.13138 12.4987,-15.79253 22.7136,-8.75544 1.6493,1.13623 -1.3736,15.63061 -18.9362,7.44972"
+         style="fill:none;stroke:url(#linearGradient12185);stroke-width:3.65715122;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path10390"
+         d="m 1123.7295,328.5072 c -2.3848,2.02637 -1.8193,4.47582 -0.6386,7.01348 1.054,-1.89255 1.7447,-3.97741 0.6386,-7.01348 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10737);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1098.8881,346.89135 c -4.7964,-16.89058 -4.476,-38.7489 3.8685,-38.62686 6.6931,0.10117 5.5573,26.86582 3.3764,40.29873 0,0 -4.488,8.03652 -7.2449,-1.67187 z"
+         id="path10392"
+         sodipodi:nodetypes="cscs"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10394"
+         d="m 1142.3918,327.50085 c -3.5191,-2.63401 -8.1518,-4.15448 -9.8912,-8.56827 4.688,0.57905 7.5308,-0.44766 15.4678,7.43587 l -5.5766,1.1324 z"
+         style="fill:url(#linearGradient10739);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10741);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 1062.7812,328.66131 c 3.5192,-2.634 8.1519,-4.15446 9.8912,-8.56826 -4.688,0.57905 -3.8552,-4.64839 -11.7921,3.23513 l 1.9009,5.33313 z"
+         id="path10396"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10398"
+         width="200"
+         height="200"
+         x="400"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10743);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12301);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 408.555,308.64194 c 7.30754,19.35518 61.04822,45.94985 106.97649,41.31372 45.92827,-4.63613 83.89895,-36.17064 77.87945,-58.50172 -4.11158,-15.25308 -97.84687,-38.21189 -114.44316,-36.75942 -9.58326,0.83871 -75.31984,40.95029 -70.41278,53.94742 z"
+         id="path10400"
+         sodipodi:nodetypes="cssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10745);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12303);stroke-width:3.65714287999999987;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 431.90796,309.34111 c 1.80885,-7.82894 13.32751,-13.10603 18.66667,-19.44334 2.85748,-3.39169 10.6018,-6.78256 13.71428,-6.78256 2.22581,0 1.17427,4.37255 2.28572,-0.90434 1.02792,-4.88037 5.57406,-8.59124 9.52381,-8.59124 4.14669,0 8.12835,1.65755 12.19047,0.45217 2.23433,-0.66301 2.49795,1.28062 4.95238,-0.90435 3.57347,-3.18113 8.01694,0.54429 10.66667,3.1652 4.1466,4.1015 8.39685,6.33039 13.71429,6.33039 6.47619,0 12.95238,0 19.42857,0 6.02288,0 11.11028,6.13576 14.85714,9.94775 1.77512,1.80598 2.18718,1.04663 4.19048,0.45217 2.35736,-0.69951 3.06507,-1.35651 5.71428,-1.35651 2.04126,0 2.50398,1.1952 4.57143,1.80868 1.77404,0.52643 2.28572,1.61245 2.28572,4.06954 0,2.49963 -0.48351,1.68695 0.7619,3.1652 -0.25397,0.60289 -1.16346,1.33205 -0.7619,1.80868 0.66604,0.79056 1.90476,2.75587 1.90476,4.52171 0,2.59585 6.05285,3.94812 7.85806,3.77252 6.74121,-0.65575 -1.93799,2.81162 -2.66666,4.97388 -0.70246,2.08446 -1.90477,3.36554 -1.90477,6.78256 0,5.12649 -0.14736,8.66381 -1.52381,13.56512 -1.30472,4.64591 -22.01777,20.64469 -26.90568,20.64469 -0.25397,0 -0.55873,-0.18087 -0.7619,0 -6.0286,5.36672 -19.33151,0.6413 -25.52381,-1.80868 -4.13181,-1.63475 -54.53753,-15.2774 -74.24743,-15.2774 -0.60557,0 -10.53047,-9.62995 -11.08591,-10.9485 -0.59189,-1.4051 -1.20905,-4.12889 -0.7619,-6.78256 0.47681,-2.82974 -1.14286,-10.15297 -1.14286,-12.66078 z"
+         id="path10403"
+         sodipodi:nodetypes="csssssssssssssscssssssssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12307);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 449.31226,318.94641 c -2.00812,-2.38353 0.99301,-7.96121 3.04762,-10.39993 2.71092,-3.21772 6.95081,-9.04341 11.04762,-9.04341 3.06356,0 5.33272,1.1755 8,1.80868 3.23693,0.76841 3.84868,1.23819 6.85714,-0.90434 2.89553,-2.0621 4.34776,-7.15594 5.71429,-10.39992 0.77436,-1.83826 4.76625,-0.67723 5.71428,-0.45217 1.43571,0.34082 1.82772,3.5945 3.42857,4.06953 1.77698,0.5273 3.26945,0.45217 5.33334,0.45217 1.52381,0 3.04762,0 4.57143,0"
+         id="path10405"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12305);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 493.61103,332.01391 c 1.80187,0 9.40336,-17.87237 11.80953,-22.15636 2.17201,-3.8671 5.42531,-7.53102 7.23809,-10.39993 1.1663,-1.84578 1.89144,-2.22922 2.66667,-4.06953 0.86724,-2.05873 2.51933,-1.85241 4.19048,-1.35652 2.57145,0.76305 4.46778,2.73381 6.47618,4.52171 1.55589,1.38507 2.25327,1.80869 4.57143,1.80869 3.30159,0 6.60318,0 9.90477,0 3.89105,0 11.68717,3.47214 13.71428,5.87821 1.25808,1.49327 1.40226,2.58808 1.90476,4.97388 0.22218,1.05486 0.47553,1.41106 0.76191,2.26085"
+         id="path10407"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10747);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12315);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 407.66238,308.67408 c 0,0 8.29209,29.56 9.30065,44.36185 0.83541,12.26069 99.57633,34.77574 112.9847,32.30681 17.21624,-3.1701 53.5194,-37.42698 54.78581,-44.99078 2.30538,-13.76918 10.81543,-38.33534 9.04462,-45.1388 -3.46965,13.60776 -42.09469,49.47176 -69.08141,49.61669 -40.03795,0.21503 -115.99327,-26.26986 -117.03437,-36.15577 z"
+         id="path10409"
+         sodipodi:nodetypes="cssscsc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10411"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10749);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 281.95114,303.66894 c -11.46505,-4.92294 -11.94535,-15.64005 -32.2236,-19.82703 -7.00697,-1.44678 1.73628,17.40764 2.9662,33.37315 1.2301,15.96762 -6.74673,29.94103 0.7383,42.7935 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38094 28.2524,10.48366 37.93001,1.26414 8.18731,-7.79977 19.68974,-11.69865 28.68994,-29.0367 7.20137,-13.87277 2.88845,-24.27373 3.81992,-39.03719 1.08656,-17.22162 6.2607,-36.5869 -0.80818,-35.42763 -21.61965,3.54556 -22.91326,19.8201 -32.47565,22.64709 -10.18804,3.01195 -23.20685,2.2981 -32.6329,-1.74932 z"
+         id="path10413"
+         sodipodi:nodetypes="cssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssssssss"
+         id="path10415"
+         d="m 281.95114,303.66894 c -11.46505,-4.92294 -11.94535,-15.64005 -32.2236,-19.82703 -7.00697,-1.44678 1.73628,17.40764 2.9662,33.37315 1.2301,15.96762 -6.74673,29.94103 0.7383,42.7935 9.94711,17.08006 17.2624,18.75135 23.99596,24.99999 12.26417,11.38094 28.2524,10.48366 37.93001,1.26414 8.18731,-7.79977 19.68974,-11.69865 28.68994,-29.0367 7.20137,-13.87277 2.88845,-24.27373 3.81992,-39.03719 1.08656,-17.22162 6.2607,-36.5869 -0.80818,-35.42763 -21.61965,3.54556 -22.91326,19.8201 -32.47565,22.64709 -10.18804,3.01195 -23.20685,2.2981 -32.6329,-1.74932 z"
+         style="fill:url(#linearGradient10751);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12337);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10753);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 308.85491,340.91504 c 3.35687,-10.77795 12.67966,-14.04082 22.06449,-6.93162 2.33862,1.77156 -3.24975,16.73419 -22.06449,6.93162 z"
+         id="path10417"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csc"
+         id="path10419"
+         d="m 286.77151,340.62698 c -3.35687,-10.77795 -12.67966,-14.04082 -22.06449,-6.93162 -2.33862,1.77155 3.24975,16.73419 22.06449,6.93162 z"
+         style="fill:url(#linearGradient10755);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscccc"
+         id="path10421"
+         d="m 288.40205,362.57927 c 0.49511,2.19202 4.86338,4.21056 6.63501,3.216 0.84652,5.30018 1.70659,2.87938 2.56804,2.7427 0.76311,-0.1211 1.94841,2.91111 2.04333,-2.71977 1.93405,0.31513 6.32097,-0.41004 6.6262,-3.25717 l 0.13966,-0.13966 c -5.62284,-0.70521 -13.50654,-0.6264 -18.01224,0.1579 z"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12361);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12359);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 287.51126,365.07475 c -11.58423,-3.55612 -22.85887,-3.70691 -34.07484,-3.21198"
+         id="path10423"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10425"
+         d="m 278.71316,366.56126 c -12.02894,-1.46457 -23.15456,0.36878 -34.10891,2.82747"
+         style="fill:none;stroke:url(#linearGradient12357);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12355);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 285.41588,368.46937 c -12.09628,0.72167 -23.89607,2.55018 -34.22997,6.93799"
+         id="path10427"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path10429"
+         d="m 317.89212,377.6088 c -10.34921,3.75198 -21.01163,-1.14155 -19.91258,-5.78235 0.69976,-2.95479 -1.83252,-2.14894 -1.17807,-0.002 1.15017,3.77337 -13.07967,9.57264 -20.50007,5.69524"
+         style="fill:none;stroke:url(#linearGradient12353);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12333);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 289.26105,361.34771 c -0.64567,-3.87311 3.1972,-6.81778 -0.39089,-18.3381 -3.35687,-10.77796 -13.29634,-16.8004 -24.16311,-9.3142 -1.75456,1.20873 1.4613,16.62814 20.14465,7.92515"
+         id="path10431"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 274.3127,333.80838 c 2.53699,2.1557 1.93534,4.76147 0.67933,7.46108 -1.12127,-2.01334 -1.8561,-4.23125 -0.67933,-7.46108 z"
+         id="path10433"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10757);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 269.6514,316.65144 c 4.83289,4.33731 4.87135,5.05855 8.33933,10.43821 2.39182,-6.33083 3.4659,-12.66166 10.05487,-18.9925 l -18.3942,8.55429 z"
+         id="path10435"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10759);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 285.37376,311.18717 3.55493,19.74959 0.395,-20.14458 -3.94993,0.39499 z"
+         id="path10437"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10439"
+         d="m 252.63243,345.78642 c 3.74373,-2.80212 8.6721,-4.41962 10.52245,-9.1151 -4.98717,0.616 -4.10122,-4.94505 -12.54469,3.4416 l 2.02224,5.6735 z"
+         style="fill:url(#linearGradient10761);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10441"
+         d="m 275.90904,358.73969 c 4.52758,-4.65513 3.6698,-1.5047 9.1842,-4.75421 -6.22985,-2.64371 -9.3526,-4.76073 -21.33907,-7.2533 -6.87611,5.80188 4.03709,7.20521 12.15487,12.00751 z"
+         style="fill:url(#linearGradient10763);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10443"
+         d="m 327.24261,317.44142 c -4.83289,4.33732 -4.87137,5.05855 -8.33933,10.43822 -2.39182,-6.33083 -3.4659,-12.66167 -10.05487,-18.9925 l 18.3942,8.55428 z"
+         style="fill:url(#linearGradient10765);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10445"
+         d="m 310.12936,311.06355 -3.55492,19.74959 -0.395,-20.14459 3.94992,0.395 z"
+         style="fill:url(#linearGradient10767);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10769);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 343.02706,346.18141 c -3.74374,-2.80212 -8.67209,-4.41962 -10.52247,-9.1151 4.98717,0.61601 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         id="path10447"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10771);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 319.35545,359.52967 c -4.52758,-4.65512 -3.66981,-1.5047 -9.1842,-4.75421 6.22985,-2.6437 9.3526,-4.76073 21.33905,-7.2533 6.87613,5.80189 -4.03707,7.20522 -12.15485,12.00751 z"
+         id="path10449"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12351);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 283.0919,372.02496 c -11.01617,5.04821 -19.53647,12.43369 -27.5835,20.26233"
+         id="path10451"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12349);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 279.71791,371.59424 c -11.82701,2.63859 -21.70076,8.08377 -31.20411,14.06112"
+         id="path10453"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10455"
+         d="m 308.59307,364.67975 c 11.58423,-3.55611 22.85887,-3.7069 34.07484,-3.21198"
+         style="fill:none;stroke:url(#linearGradient12347);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12345);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 317.39117,366.16627 c 12.02894,-1.46458 23.15456,0.36877 34.10889,2.82749"
+         id="path10457"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10459"
+         d="m 310.68845,368.0744 c 12.09626,0.72165 23.89607,2.55015 34.22997,6.93799"
+         style="fill:none;stroke:url(#linearGradient12343);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10461"
+         d="m 313.01242,371.62997 c 11.01618,5.0482 19.53647,12.43367 27.58349,20.26235"
+         style="fill:none;stroke:url(#linearGradient12341);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10463"
+         d="m 316.38642,371.19925 c 11.82701,2.63858 21.70074,8.08377 31.20411,14.06114"
+         style="fill:none;stroke:url(#linearGradient12339);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10465"
+         d="m 250.88226,289.40253 c 0.83437,3.41704 4.19214,18.57622 6.31791,30.51289 2.16288,-5.72489 12.73174,-5.89326 18.69004,-11.61814 -13.66796,-21.99219 -20.91175,-18.34758 -25.00795,-18.89475 z"
+         style="fill:url(#linearGradient10773);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10775);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 347.23372,287.11556 c -0.83438,3.41704 -2.0103,20.28707 -4.13608,32.22373 -2.16287,-5.72488 -14.40754,-5.89326 -20.36584,-11.61814 13.66796,-21.99218 19.25345,-20.05842 24.50192,-20.60559 z"
+         id="path10467"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10777);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12331);stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 251.04636,250.66003 c 13.66601,3.079 26.90891,28.56336 33.69464,37.88533 -4.9684,-16.10222 -7.63917,-41.38174 -5.63534,-57.43726 4.13602,16.79435 10.61008,35.05667 17.60303,47.55704 4.16998,-8.13842 15.67827,-28.10239 17.38989,-45.7683 4.50713,17.69932 -2.56215,36.28008 -3.68455,53.30576 5.93352,-11.56222 17.64408,-29.95486 31.46238,-32.63382 -14.01705,20.03405 -21.82835,39.38184 -25.13556,54.2085 -12.35654,-1.83898 -24.71308,-2.05168 -37.06961,0.51982 -3.01171,-11.65788 -22.73307,-46.18757 -28.62488,-57.63707 z"
+         id="path10469"
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient10779);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12329);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path10471"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,225.80095,189.70767)" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,256.01105,174.48544)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path10473"
+         style="opacity:0.98999999;fill:url(#linearGradient10781);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12327);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient10783);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12325);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path10475"
+         sodipodi:cx="86.666664"
+         sodipodi:cy="245.83333"
+         sodipodi:rx="46.666668"
+         sodipodi:ry="50.833332"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         transform="matrix(0.26799566,0,0,0.2426592,292.73562,173.53865)" />
+      <path
+         transform="matrix(0.26799566,0,0,0.2426592,321.3295,192.37433)"
+         d="m 133.33333,245.83333 a 46.666668,50.833332 0 1 1 -93.333334,0 46.666668,50.833332 0 1 1 93.333334,0 z"
+         sodipodi:ry="50.833332"
+         sodipodi:rx="46.666668"
+         sodipodi:cy="245.83333"
+         sodipodi:cx="86.666664"
+         id="path10477"
+         style="opacity:0.98999999;fill:url(#linearGradient10785);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12323);stroke-width:14.34101582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="cssc"
+         id="path10479"
+         d="m 306.47238,360.81689 c 0.64567,-3.87308 -3.1972,-6.81776 0.39089,-18.33807 3.35687,-10.77796 13.29634,-16.80041 24.16311,-9.31421 1.75456,1.20874 -1.46129,16.62814 -20.14465,7.92516"
+         style="fill:none;stroke:url(#linearGradient12335);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path10481"
+         d="m 320.72939,332.58624 c -2.537,2.1557 -1.93535,4.76147 -0.67933,7.46107 1.12126,-2.01333 1.85609,-4.23124 0.67933,-7.46107 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10787);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 294.30268,352.14373 c -5.10249,-17.96854 -4.76166,-41.22186 4.11541,-41.09203 7.12026,0.10763 5.91194,28.5804 3.59188,42.8706 0,0 -4.77447,8.54941 -7.70729,-1.77857 z"
+         id="path10483"
+         sodipodi:nodetypes="cscs"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10485"
+         d="m 340.58278,331.51573 c -3.74374,-2.80212 -8.6721,-4.41962 -10.52247,-9.1151 4.98717,0.61601 8.01145,-0.47623 16.45492,7.91043 l -5.93245,1.20467 z"
+         style="fill:url(#linearGradient10789);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10791);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 255.89147,332.75025 c 3.74373,-2.80211 8.6721,-4.41961 10.52245,-9.11509 -4.98717,0.616 -4.10122,-4.94505 -12.54469,3.4416 l 2.02224,5.67349 z"
+         id="path10487"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10591"
+         width="200"
+         height="200"
+         x="600"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10855);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 686.75613,304.06305 c -11.46504,-4.92293 -11.94535,-15.64005 -32.2236,-19.82702 -7.00697,-1.44679 1.73628,17.40764 2.96621,33.37314 1.23009,15.96764 -6.74674,29.94103 0.73829,42.79351 9.94711,17.08007 17.26241,18.75134 23.99596,24.99998 12.26417,11.38096 28.25241,10.48366 37.93001,1.26414 8.18731,-7.79975 19.68974,-11.69865 28.68994,-29.03669 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08654,-17.22162 6.26069,-36.5869 -0.8082,-35.42763 -21.61964,3.54555 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.20685,2.29811 -32.6329,-1.74932 z"
+         id="path10593"
+         sodipodi:nodetypes="cssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssssssss"
+         id="path10595"
+         d="m 686.75613,304.06305 c -11.46504,-4.92293 -11.94535,-15.64005 -32.2236,-19.82702 -7.00697,-1.44679 1.73628,17.40764 2.96621,33.37314 1.23009,15.96764 -6.74674,29.94103 0.73829,42.79351 9.94711,17.08007 17.26241,18.75134 23.99596,24.99998 12.26417,11.38096 28.25241,10.48366 37.93001,1.26414 8.18731,-7.79975 19.68974,-11.69865 28.68994,-29.03669 7.20137,-13.87278 2.88846,-24.27374 3.81993,-39.03719 1.08654,-17.22162 6.26069,-36.5869 -0.8082,-35.42763 -21.61964,3.54555 -22.91326,19.82009 -32.47564,22.64708 -10.18804,3.01196 -23.20685,2.29811 -32.6329,-1.74932 z"
+         style="fill:url(#linearGradient10857);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12293);stroke-width:3.65714930999999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10859);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 713.65991,341.30915 c 3.35687,-10.77794 12.67966,-14.0408 22.06448,-6.93161 2.33863,1.77154 -3.24976,16.73419 -22.06448,6.93161 z"
+         id="path10597"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csc"
+         id="path10599"
+         d="m 691.5765,341.02111 c -3.35687,-10.77797 -12.67966,-14.04083 -22.06448,-6.93164 -2.33863,1.77157 3.24974,16.7342 22.06448,6.93164 z"
+         style="fill:url(#linearGradient10861);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscccc"
+         id="path10601"
+         d="m 693.20704,362.97338 c 0.49511,2.19205 4.86338,4.21056 6.63501,3.216 0.84652,5.30021 1.70659,2.87938 2.56805,2.7427 0.7631,-0.12108 1.9484,2.91113 2.04332,-2.71975 1.93406,0.31513 6.32098,-0.41004 6.6262,-3.25719 l 0.13965,-0.13963 c -5.62282,-0.70524 -13.50653,-0.62643 -18.01223,0.15787 z"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12271);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12269);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 692.31625,365.46888 c -11.58423,-3.55614 -22.85887,-3.70693 -34.07484,-3.21198"
+         id="path10603"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10605"
+         d="m 683.51815,366.95537 c -12.02894,-1.46455 -23.15456,0.3688 -34.10891,2.8275"
+         style="fill:none;stroke:url(#linearGradient12267);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12265);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 690.22087,368.86351 c -12.09628,0.72164 -23.89607,2.55014 -34.22997,6.93798"
+         id="path10607"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path10609"
+         d="m 722.6971,378.00293 c -10.34921,3.75196 -21.01162,-1.14157 -19.91257,-5.78237 0.69976,-2.95479 -1.83252,-2.14892 -1.17807,-0.002 1.15017,3.77337 -13.07967,9.57262 -20.50007,5.69522"
+         style="fill:none;stroke:url(#linearGradient12263);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12289);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 694.06604,361.74181 c -0.64567,-3.87309 3.1972,-6.81776 -0.39089,-18.33808 -3.35687,-10.77796 -13.29634,-16.80041 -24.1631,-9.31421 -1.75457,1.20873 1.46129,16.62813 20.14464,7.92516"
+         id="path10611"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 679.11769,334.2025 c 2.53699,2.1557 1.93534,4.76146 0.67933,7.46107 -1.12127,-2.01332 -1.8561,-4.23124 -0.67933,-7.46107 z"
+         id="path10613"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10863);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 674.45639,317.04556 c 4.83289,4.33731 4.87135,5.05854 8.33933,10.43822 2.39182,-6.33083 3.4659,-12.66167 10.05487,-18.9925 l -18.3942,8.55428 z"
+         id="path10615"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10865);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 690.17875,311.58129 3.55493,19.7496 0.395,-20.1446 -3.94993,0.395 z"
+         id="path10617"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10619"
+         d="m 657.43742,346.18053 c 3.74373,-2.80212 8.6721,-4.41961 10.52245,-9.1151 -4.98717,0.61602 -4.10122,-4.94506 -12.54469,3.44162 l 2.02224,5.67348 z"
+         style="fill:url(#linearGradient10867);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10621"
+         d="m 680.71403,359.13381 c 4.52758,-4.65513 3.66981,-1.5047 9.1842,-4.75421 -6.22985,-2.64371 -9.3526,-4.76073 -21.33906,-7.25331 -6.87612,5.80188 4.03708,7.20522 12.15486,12.00752 z"
+         style="fill:url(#linearGradient10869);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10623"
+         d="m 732.04759,317.83553 c -4.83289,4.33732 -4.87136,5.05856 -8.33933,10.43824 -2.39182,-6.33084 -3.46588,-12.66167 -10.05486,-18.9925 l 18.39419,8.55426 z"
+         style="fill:url(#linearGradient10871);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10625"
+         d="m 714.93436,311.45765 -3.55493,19.7496 -0.39499,-20.14459 3.94992,0.39499 z"
+         style="fill:url(#linearGradient10873);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10875);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 747.83205,346.57553 c -3.74375,-2.80213 -8.67209,-4.41961 -10.52247,-9.11511 4.98718,0.61602 8.01145,-0.47623 16.45493,7.91045 l -5.93246,1.20466 z"
+         id="path10627"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10877);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 724.16044,359.92378 c -4.52757,-4.65511 -3.66981,-1.50469 -9.18421,-4.75419 6.22985,-2.64371 9.3526,-4.76074 21.33907,-7.25331 6.87613,5.80188 -4.03708,7.20521 -12.15486,12.0075 z"
+         id="path10629"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12261);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 687.89689,372.41907 c -11.01617,5.04823 -19.53647,12.43369 -27.5835,20.26236"
+         id="path10631"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12259);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 684.52291,371.98835 c -11.82702,2.63861 -21.70077,8.08377 -31.20412,14.06114"
+         id="path10633"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10635"
+         d="m 713.39806,365.07388 c 11.58423,-3.55613 22.85888,-3.70692 34.07484,-3.21197"
+         style="fill:none;stroke:url(#linearGradient12257);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12255);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 722.19616,366.56037 c 12.02894,-1.46454 23.15456,0.3688 34.1089,2.8275"
+         id="path10637"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10639"
+         d="m 715.49344,368.46851 c 12.09626,0.72167 23.89607,2.55015 34.22997,6.93799"
+         style="fill:none;stroke:url(#linearGradient12253);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10641"
+         d="m 717.8174,372.02408 c 11.01618,5.0482 19.53648,12.43369 27.5835,20.26235"
+         style="fill:none;stroke:url(#linearGradient12251);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10643"
+         d="m 721.19141,371.59336 c 11.82702,2.6386 21.70075,8.08377 31.20411,14.06114"
+         style="fill:none;stroke:url(#linearGradient12249);stroke-width:3.65714979;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10645"
+         d="m 655.68725,289.79665 c 0.83437,3.41705 4.19214,18.57623 6.31791,30.51289 2.16288,-5.72489 12.73174,-5.89326 18.69004,-11.61815 -13.66796,-21.99218 -20.91175,-18.34756 -25.00795,-18.89474 z"
+         style="fill:url(#linearGradient10879);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10881);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 752.0387,287.50968 c -0.83438,3.41703 -2.01028,20.28706 -4.13607,32.22372 -2.16288,-5.72487 -14.40754,-5.89325 -20.36585,-11.61812 13.66796,-21.99219 19.25346,-20.05843 24.50192,-20.6056 z"
+         id="path10647"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10649"
+         d="m 673.48081,312.53278 c -3.41322,-22.47251 -8.69931,-22.61847 23.45933,-58.77603 44.83561,26.80833 31.22624,35.73948 34.11899,58.62617 -27.40816,-2.72369 -34.20891,-2.20629 -57.57832,0.14986 z"
+         style="fill:url(#linearGradient10883);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12285);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssc"
+         id="path10651"
+         d="m 711.27738,361.21103 c 0.64566,-3.8731 -3.19722,-6.81779 0.39088,-18.33808 3.35686,-10.77797 13.29634,-16.80042 24.1631,-9.31422 1.75456,1.20873 -1.46128,16.62814 -20.14464,7.92516"
+         style="fill:none;stroke:url(#linearGradient12291);stroke-width:3.65714931;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path10653"
+         d="m 725.53438,332.98035 c -2.537,2.1557 -1.93536,4.76149 -0.67934,7.46108 1.12126,-2.01333 1.8561,-4.23125 0.67934,-7.46108 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10885);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 699.10768,352.53784 c -5.1025,-17.96853 -4.76167,-41.22185 4.11541,-41.09203 7.12025,0.10764 5.91193,28.58042 3.59186,42.87061 0,0 -4.77445,8.54942 -7.70727,-1.77858 z"
+         id="path10655"
+         sodipodi:nodetypes="cscs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10657"
+         d="m 735.66525,296.27197 c 14.22553,-29.85909 7.92426,-56.59578 -16.44186,-81.84056 -15.47869,9.5886 -44.41537,48.69093 -46.3912,74.07598 25.60463,-4.31574 37.44941,2.34431 62.83306,7.76458 z"
+         style="fill:url(#linearGradient10887);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12279);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12281);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 669.54853,301.54436 c -19.58744,-21.00181 -5.33953,-60.82538 17.25718,-88.64203 36.32837,28.6565 56.65216,60.22243 48.00232,88.5946 -25.60462,-4.31575 -39.87584,-5.37283 -65.2595,0.0474 z"
+         id="path10659"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient10891);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12283);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 693.92972,254.73325 c -2.82401,-0.0674 -5.28015,2.29084 -5.06209,4.69782 -0.0313,1.38583 -0.10156,2.7707 -0.1625,4.1557 -1.8934,-0.10047 -3.81853,-0.47805 -5.70421,-0.17375 -2.49935,0.57203 -4.35267,2.9378 -3.73407,5.15897 0.4628,2.03468 2.76973,3.59601 5.16584,3.5163 1.65766,0.0743 3.31079,0.20662 4.96401,0.33242 0.41474,3.56237 1.20592,7.08986 2.25234,10.55173 0.42188,2.2784 3.12417,4.12346 5.80468,3.7083 2.71727,-0.31974 4.82957,-2.78584 4.27604,-5.12891 -0.23714,-1.17073 -0.72441,-2.2929 -0.95,-3.46708 -0.49223,-1.95628 -0.91168,-3.93142 -1.14173,-5.92203 2.02591,-0.17405 4.16416,-0.0229 6.06355,-0.75603 2.15624,-0.9513 3.4081,-3.33329 2.52736,-5.33342 -0.76069,-1.94103 -3.19492,-3.21973 -5.54102,-2.97346 -1.28045,0.0433 -2.55293,0.18191 -3.83027,0.26326 0.0297,-0.5203 -0.0374,-1.05425 0.014,-1.58051 0.0252,-1.13656 0.2156,-2.27782 0.12496,-3.41179 -0.47168,-2.00564 -2.63578,-3.72099 -5.06684,-3.63752 z"
+         id="path10661"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12287);stroke-width:3.65714598;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 696.71089,302.46716 c -2.20923,4.97345 10.87584,6.35628 9.7116,0.0753"
+         id="path10663"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10665"
+         d="m 745.38778,331.90984 c -3.74375,-2.80211 -8.6721,-4.41961 -10.52247,-9.11509 4.98715,0.616 8.01145,-0.47623 16.4549,7.91042 l -5.93243,1.20467 z"
+         style="fill:url(#linearGradient10893);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10895);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 660.69646,333.14437 c 3.74373,-2.80212 8.6721,-4.41961 10.52245,-9.1151 -4.98717,0.61602 -4.10122,-4.94506 -12.54469,3.44162 l 2.02224,5.67348 z"
+         id="path10667"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect10489"
+         width="200"
+         height="200"
+         x="800"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient10793);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 944.8643,247.06429 c -4.63777,2.7483 -7.74595,9.22953 1.01428,26.75 7.21799,14.43597 7.53592,25.81459 7,35.02142 -9.71632,-18.21423 -11.9886,-16.31365 -25.77143,-31.25714 -8.61163,-9.33682 -26.82606,-17.5719 -34.62933,-21.27284 -14.74431,5.42428 -40.09131,30.63037 -49.89924,27.12998 0,0 -3.76905,8.24282 -1.36428,22.67143 2.40476,14.42862 4.35305,11.06151 6.41428,30.47143 2.06123,19.40992 0.85443,16.78806 -1.37857,30.01429 -2.233,13.22623 -2.42515,17.15072 10.30714,15.12143 14.17209,-2.25878 10.70681,-19.44269 9.62143,-28.65 -3.93017,-33.33976 13.99452,-42.85261 17.63572,0.69285 0.27699,5.96266 -1.35057,11.89954 -3.06072,17.85358 l -5.55714,3.24285 -5.7,7.21786 -0.22143,7.39643 6.23214,3.34285 15.08572,-7.26071 c 6.6036,0.79289 9.40082,-1.44699 10.74285,-5.62143 L 916.29287,371.4 c 0.90439,0.41414 7.81974,3.57285 8.98571,3.74286 8.61109,1.25553 -20.30944,4.96575 -21.06428,15.32857 -0.67412,9.25452 20.85772,1.68065 37.72142,-4.68572 12.32673,-3.08722 40.28463,-15.11896 18.9,-22.28571 6.06314,-13.82423 1.7723,-25.20943 3.07858,-33.52857 1.02295,-6.5148 7.59653,-11.01426 6.77142,-20.50714 -2.92007,-29.54431 -11.17108,-45.57971 -12.83205,-48.66437 -3.82263,-4.62185 -6.26113,-17.61129 -12.98937,-13.73563 z"
+         id="path10491"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscsccssssscccccccccssccsccc" />
+      <path
+         sodipodi:nodetypes="csccssssccccccscccscsc"
+         id="path10493"
+         d="m 842.77161,281.41393 c 0,0 -3.05092,10.26522 -0.64615,24.69384 2.40477,14.42861 3.44083,12.431 5.50206,31.84092 2.06124,19.40992 0.85885,15.87728 -1.37415,29.10351 -2.233,13.22623 -2.43901,17.06254 10.30615,15.11569 14.34209,-2.19077 12.25003,-17.64658 9.61908,-27.72936 -7.5641,-28.98841 12.25451,-47.13358 18.55107,0.68708 1.23938,9.41268 -8.22179,27.15894 1.37416,29.55793 17.864,4.466 15.11569,-4.99493 17.17692,-19.93885 3.77032,-15.81532 4.87547,-6.55259 8.52875,3.35283 2.87155,7.78585 16.83649,4.00136 29.59486,5.49617 -11.46796,2.82894 -35.11422,6.17494 -35.86907,16.53776 0.0835,11.7799 21.30783,0.96313 38.17153,-3.26037 37.58054,-17.22936 22.23986,-20.3798 16.94679,-23.61273 7.90162,-16.02432 -0.78537,-23.88848 3.65757,-32.51996 4.92491,-9.56785 7.26391,-18.88217 6.27622,-30.24568 -2.92008,-29.54431 -9.76252,-33.90722 -11.42349,-36.99188 -3.736,-4.63764 -7.54112,-19.69574 -14.13068,-15.8992 -4.63777,2.74831 -7.91394,8.69306 0.84628,26.21353 7.21799,14.43597 7.53744,25.45585 7.00152,34.66268 -8.46632,-18.3928 -10.46967,-12.60989 -24.2525,-27.55338 -16.31808,-17.69223 -40.18289,-21.40774 -36.14228,-23.17551"
+         style="fill:url(#linearGradient10795);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10527"
+         d="m 918.14639,275.92587 c -22.12676,28.63087 -24.08243,20.42612 -28.02241,9.97772 7.68307,-9.18108 23.66362,-11.37164 18.02718,-16.51249 z"
+         style="fill:url(#linearGradient13612);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient13614);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 932.8572,289.18405 c 3.23671,2.16096 -9.62489,15.04688 -23.48375,16.44014 -2.69739,-11.50776 -9.77254,4.42878 14.68137,-23.91063 z"
+         id="path10565"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10567"
+         d="m 943.42876,302.94778 c -2.96316,4.74031 -20.07863,22.4737 -25.58576,14.48225 1.20153,-15.86008 6.43192,-1.00072 19.66418,-22.22771 z"
+         style="fill:url(#linearGradient13616);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10835);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 953.11288,322.11592 c -4.27441,2.19379 -21.39275,15.77653 -23.1041,9.49566 -2.09424,-12.49871 21.25374,-13.41164 17.73079,-19.18166 z"
+         id="path10569"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10571"
+         d="m 959.26554,340.61074 c -8.00263,-1.00921 -15.08204,5.64775 -18.19622,1.75585 -0.87167,-12.64293 16.95083,-6.13467 14.00434,-12.21928 z"
+         style="fill:url(#linearGradient10837);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient13606);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 851.89165,334.59957 c 0.61732,2.52814 0.3533,4.81186 1.92608,13.64335 1.60023,-4.23563 5.16124,0.1194 8.19541,-13.04822 -8.05119,-3.90382 -7.09086,-3.62569 -10.12149,-0.59513 z"
+         id="path10573"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10575"
+         d="m 851.20457,354.5248 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60024,-4.23562 6.67144,4.5718 9.70561,-8.59583 -8.05118,-3.90382 -8.60106,-3.26854 -11.63169,-0.23798 z"
+         style="fill:url(#linearGradient13604);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10577"
+         d="m 887.34413,339.85808 c 0.61732,2.52814 -0.004,1.95471 1.56894,10.7862 1.60023,-4.23562 7.30409,2.6194 10.33827,-10.54822 -8.05119,-3.90382 -8.87658,-3.26854 -11.90721,-0.23798 z"
+         style="fill:url(#linearGradient13610);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient13608);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 888.30672,357.72208 c 0.61732,2.52814 -1.07527,-2.14055 0.49751,6.69095 1.60024,-4.23563 8.10001,6.71465 11.13418,-6.45297 -8.05118,-3.90382 -8.60106,-3.26854 -11.63169,-0.23798 z"
+         id="path10579"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10847);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 957.01441,298.63347 c 0.61732,2.52814 -0.36099,0.52613 1.21179,9.35763 1.60024,-4.23563 6.16396,2.02767 9.19813,-11.13995 -8.05118,-3.90382 -7.37929,-1.24824 -10.40992,1.78232 z"
+         id="path10581"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10583"
+         d="m 952.89195,277.33408 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60023,-4.23562 6.67143,4.5718 9.70561,-8.59582 -8.05119,-3.90382 -8.60106,-3.26855 -11.63169,-0.23799 z"
+         style="fill:url(#linearGradient10849);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10851);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 944.64703,260.84424 c 0.61732,2.52814 0.3533,0.002 1.92608,8.83381 1.60023,-4.23563 6.67143,4.57179 9.7056,-8.59583 -8.05118,-3.90382 -8.60105,-3.26854 -11.63168,-0.23798 z"
+         id="path10585"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12231);stroke-width:3.6114285;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 912.32144,369.91071 c 0,0 5.21006,1.2788 2.8027,3.01643 -2.11289,1.52508 -10.10558,4.26189 -13.359,6.37506 m -12.08237,6.492 c -4.89339,2.44329 -8.12948,5.29505 -12.2399,5.87009 -2.47449,0.34617 -5.83373,0.40025 -7.32143,-1.60715 -1.79329,-2.41973 -0.92442,-6.30088 0.71428,-9.00714 2.3496,-3.88027 3.80908,-6.13158 10.95,-9.3"
+         id="path10589"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccsasc" />
+      <path
+         style="fill:url(#linearGradient10853);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 971.48207,301.76269 c 2.0798,0.24349 -7.28533,17.28995 -8.2813,32.95919 -0.77634,12.21393 7.40865,12.97676 -3.15317,27.61465 32.80654,13.82897 -53.37596,36.11021 -49.17959,29.31131 21.09579,-23.24283 21.98268,-97.87707 60.61406,-89.88515 z"
+         id="path10587"
+         sodipodi:nodetypes="csccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12229);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 843.78178,276.62861 c 0,0 -4.06108,17.3363 -1.6563,31.76492 2.40476,14.42862 3.44083,13.34529 5.50206,32.75522 2.06123,19.40993 1.31599,10.39158 -0.91701,23.61781 -2.233,13.22624 -2.42614,17.145 10.30616,15.1157 14.17209,-2.25878 12.4804,-19.5297 9.16193,-28.18652 -7.54184,-19.67425 10.28828,-48.20503 17.17966,0.68708 1.32508,9.40101 -7.30752,29.44467 2.28844,31.84366 17.86401,4.466 17.4622,-7.14187 17.17693,-22.22458 -0.39065,-20.65424 -4.95868,-28.8039 -3.46855,-38.52929 m 55.03371,38.86653 c 3.38814,0.22806 14.80761,3.17619 14.71265,8.09958 -4.15865,8.59636 -15.43745,11.94124 -27.16235,16.01036 -11.7249,4.06911 -37.19301,16.46873 -37.02396,5.1939 0.14953,-9.97332 11.02771,-11.06323 35.2637,-18.46211 -18.17599,5.60929 -33.51582,-8.5481 -25.9567,-23.03129"
+         id="path10563"
+         sodipodi:nodetypes="cssssssssccczscs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12241);stroke-width:3.65714407;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 889.78481,255.572 c 0,0 21.31596,7.67645 37.926,25.09488 7.47925,7.84325 17.13815,12.03748 30.53615,40.55118 4.79198,10.19832 4.8271,14.3306 6.41872,20.12968 2.85844,10.4147 -3.46661,20.12414 -3.46661,20.12414 m 1.77974,-26.38001 c -1.6159,-6.79699 5.45957,-12.56949 6.33309,-23.73998 2.31455,-29.59791 -7.11553,-42.48066 -8.7765,-45.56532 -4.80954,-8.93201 -11.17863,-21.29394 -15.8164,-18.54563 -4.41176,2.61437 -2.11599,22.921 2.19432,28.63799 4.31032,5.71699 7.56162,32.66826 4.7875,33.0648"
+         id="path10495"
+         sodipodi:nodetypes="csssccssszc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10797);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 851.4547,228.40453 c -7.18404,-3.98844 -6.78547,-11.04205 -19.79274,-15.13486 -4.49454,-1.41424 -0.021,11.5207 -0.27768,22.06285 -0.25676,10.54355 -6.41299,19.16778 -2.36431,28.08662 5.38042,11.85253 10.06203,13.43439 14.05786,17.97651 7.27782,8.27279 17.81272,8.74898 24.76689,3.35259 5.88326,-4.56536 13.67891,-6.35432 20.72957,-17.11488 5.64147,-8.6099 3.50795,-15.71145 5.10078,-25.32219 1.85804,-11.21096 6.53686,-23.55437 1.82831,-23.26529 -14.40075,0.88414 -16.33142,11.4608 -22.78465,12.67658 -6.87547,1.29534 -15.35763,-0.0388 -21.26403,-3.31793 z"
+         id="path10497"
+         sodipodi:nodetypes="cssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssssssssss"
+         id="path10499"
+         d="m 851.4547,228.40453 c -7.18404,-3.98844 -6.78547,-11.04205 -19.79274,-15.13486 -4.49454,-1.41424 -0.021,11.5207 -0.27768,22.06285 -0.25676,10.54355 -6.41299,19.16778 -2.36431,28.08662 5.38042,11.85253 10.06203,13.43439 14.05786,17.97651 7.27782,8.27279 17.81272,8.74898 24.76689,3.35259 5.88326,-4.56536 13.67891,-6.35432 20.72957,-17.11488 5.64147,-8.6099 3.50795,-15.71145 5.10078,-25.32219 1.85804,-11.21096 6.53686,-23.55437 1.82831,-23.26529 -14.40075,0.88414 -16.33142,11.4608 -22.78465,12.67658 -6.87547,1.29534 -15.35763,-0.0388 -21.26403,-3.31793 z"
+         style="fill:url(#linearGradient10799);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient12195);stroke-width:3.25523066999999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10801);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 866.6027,254.59798 c 2.91665,-6.83809 9.24192,-8.35541 14.91754,-3.07301 1.41432,1.31633 -3.24288,10.74764 -14.91754,3.07301 z"
+         id="path10501"
+         sodipodi:nodetypes="csc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csc"
+         id="path10503"
+         d="m 852.15324,252.93953 c -1.48205,-7.28491 -7.37301,-10.04315 -13.9949,-6.00992 -1.65013,1.00504 1.01546,11.1802 13.9949,6.00992 z"
+         style="fill:url(#linearGradient10803);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscccc"
+         id="path10505"
+         d="m 849.93198,267.43078 c 0.1785,1.46912 2.90617,3.08235 4.1331,2.54864 0.20188,3.52892 0.92649,2.00009 1.5,1.96787 0.50803,-0.0285 1.08281,2.03698 1.51976,-1.64595 1.24617,0.33519 4.16866,0.15203 4.55813,-1.69304 l 0.10079,-0.0822 c -3.63704,-0.83626 -8.80753,-1.30931 -11.81178,-1.09532 z"
+         style="fill:#c1856e;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient12221);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12233);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 850.09656,269.00648 c -7.35309,-3.10086 -14.72999,-3.95002 -22.11141,-4.37221"
+         id="path10507"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10509"
+         d="m 844.23328,269.39488 c -7.78366,-1.76013 -15.19497,-1.29939 -22.53567,-0.41755"
+         style="fill:none;stroke:url(#linearGradient12219);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12217);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 848.49778,271.09112 c -7.97328,-0.33222 -15.82597,0.0805 -22.88856,2.26753"
+         id="path10511"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csss"
+         id="path10513"
+         d="m 869.16734,279.24049 c -7.03031,1.76945 -13.69045,-2.14631 -12.66151,-5.11373 0.65512,-1.88935 -1.05761,-1.5299 -0.77173,-0.0797 0.50245,2.54879 -9.20663,5.40132 -13.81028,2.36707"
+         style="fill:none;stroke:url(#linearGradient12215);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12197);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 850.57675,266.68105 c -0.16527,-2.58056 3.46277,-4.2541 1.87863,-12.04078 -1.48205,-7.28492 -6.6791,-11.89222 -14.29702,-7.71062 -1.23001,0.67517 -0.14925,10.99169 12.67094,6.5331"
+         id="path10515"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.25522757;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 843.98713,247.64295 c 1.51872,1.58122 0.95111,3.24843 -0.0515,4.93357 -0.60065,-1.39372 -0.93448,-2.89576 0.0515,-4.93357 z"
+         id="path10517"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10805);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 842.53212,236.09182 c 2.87776,3.16337 2.85495,3.63847 4.76908,7.39393 1.98841,-3.98866 3.11345,-8.06502 7.85176,-11.77434 l -12.62084,4.38041 z"
+         id="path10519"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10807);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 853.19677,233.55811 1.01473,13.17614 1.59947,-13.17205 -2.6142,-0.004 z"
+         id="path10521"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10523"
+         d="m 829.4426,254.04784 c 2.63931,-1.58674 5.97593,-2.31849 7.50074,-5.27174 -3.30849,0.0717 -2.35793,-3.51285 -8.44809,1.41999 l 0.94735,3.85175 z"
+         style="fill:url(#linearGradient10809);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10525"
+         d="m 843.83091,264.0837 c 3.27619,-2.74863 2.50453,-0.74162 6.33371,-2.50363 -3.90573,-2.14672 -5.8108,-3.74158 -13.49821,-6.1724 -4.89123,3.34366 2.16549,4.9894 7.1645,8.67603 z"
+         style="fill:url(#linearGradient10811);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10529"
+         d="m 869.4244,235.12467 -3.64352,12.70296 1.08189,-13.22463 2.56163,0.52167 z"
+         style="fill:url(#linearGradient10815);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10817);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 888.64114,260.32266 c -2.26634,-2.08505 -5.38766,-3.4728 -6.28749,-6.67234 3.2265,0.7355 5.28064,0.22117 10.25449,6.27789 l -3.967,0.39445 z"
+         id="path10531"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10819);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 872.24358,267.49277 c -2.65656,-3.35127 -2.30424,-1.23009 -5.7009,-3.7261 4.25763,-1.31749 6.44448,-2.4967 14.46366,-3.33205 4.11898,4.25891 -3.12454,4.45204 -8.76276,7.05815 z"
+         id="path10533"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12213);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 846.73852,273.26601 c -7.55356,2.57432 -13.62742,6.8461 -19.42069,11.43972"
+         id="path10535"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12211);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 844.55662,272.75926 c -7.92444,0.94163 -14.75593,3.85208 -21.38015,7.13585"
+         id="path10537"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10539"
+         d="m 863.93524,270.15074 c 7.82644,-1.55893 15.22341,-0.90736 22.53895,0.16336"
+         style="fill:none;stroke:url(#linearGradient12209);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient12207);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 869.60066,271.71022 c 7.9786,-0.159 15.14588,1.78262 22.15931,4.12257"
+         id="path10541"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10543"
+         d="m 865.08218,272.51431 c 7.87721,1.27785 15.48652,3.26116 21.96507,6.82374"
+         style="fill:none;stroke:url(#linearGradient12205);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10545"
+         d="m 866.36816,274.99851 c 6.88162,4.04065 11.97241,9.44651 16.72365,15.11127"
+         style="fill:none;stroke:url(#linearGradient12201);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path10547"
+         d="m 868.60741,274.94086 c 7.57322,2.51587 13.67991,6.74058 19.50852,11.28932"
+         style="fill:none;stroke:url(#linearGradient12203);stroke-width:3.25523162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path10549"
+         d="m 832.04844,216.98972 c 0.31924,2.29431 1.5103,12.44978 2.10864,20.41193 1.79809,-3.60688 8.73381,-3.01381 13.01859,-6.3681 -7.49135,-15.3185 -12.4799,-13.41272 -15.12723,-14.04383 z"
+         style="fill:url(#linearGradient10821);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10823);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 895.32826,221.90382 c -0.77408,2.18325 -2.66727,13.1579 -4.85446,20.8371 -1.03607,-3.89478 -9.04733,-4.82002 -12.57009,-8.96739 10.41863,-13.49922 13.94944,-11.86052 17.42455,-11.86971 z"
+         id="path10551"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cssc"
+         id="path10553"
+         d="m 862.34575,267.47873 c 0.6808,-2.4946 -1.18386,-4.67964 1.9337,-11.98874 2.91666,-6.8381 9.82962,-10.12239 16.45109,-4.49436 1.06912,0.90872 -2.06406,10.79719 -13.72583,3.85173"
+         style="fill:none;stroke:url(#linearGradient12199);stroke-width:3.25523067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccc"
+         id="path10555"
+         d="m 873.5655,249.9314 c -1.80566,1.24353 -1.58489,2.99082 -0.94164,4.84314 0.86863,-1.24447 1.49768,-2.6487 0.94164,-4.84314 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:3.25522757;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient10825);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 856.32105,260.9863 c -2.1472,-12.11222 -0.37631,-27.32467 5.43114,-26.64881 4.65789,0.54439 1.97127,19.11878 -0.49984,28.32705 0,0 -3.69713,5.28365 -4.9313,-1.67824 z"
+         id="path10557"
+         sodipodi:nodetypes="cscs"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path10559"
+         d="m 888.01574,250.55131 c -2.26634,-2.08505 -5.38766,-3.4728 -6.28749,-6.67234 3.2265,0.73551 5.28064,0.22118 10.25449,6.27789 l -3.967,0.39445 z"
+         style="fill:url(#linearGradient10827);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient10829);fill-opacity:1.0;fill-rule:evenodd;stroke:none"
+         d="m 832.44545,245.72369 c 2.63931,-1.58673 5.97594,-2.31849 7.50075,-5.27173 -3.30849,0.0717 -2.35794,-3.51286 -8.44809,1.41998 l 0.94734,3.85175 z"
+         id="path10561"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/skulls.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/skulls.svg
@@ -1,0 +1,13033 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="skulls.svg">
+  <title
+     id="title9557">Skulls Chess Piece Set</title>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7816" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop7818" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4006" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop4008" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         style="stop-color:#a08060;stop-opacity:1"
+         offset="0"
+         id="stop5177" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5179" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5177-6" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop5179-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5289"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5493"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient5960"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,883.27393)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6302"
+       gradientUnits="userSpaceOnUse"
+       x1="48.36805"
+       y1="775.46729"
+       x2="147.362"
+       y2="775.46729"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6304"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,883.27393)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6306"
+       gradientUnits="userSpaceOnUse"
+       x1="51.055473"
+       y1="785.65112"
+       x2="141.33739"
+       y2="785.65112"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6308"
+       gradientUnits="userSpaceOnUse"
+       x1="103.12096"
+       y1="773.41211"
+       x2="127.91366"
+       y2="773.41211"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6310"
+       gradientUnits="userSpaceOnUse"
+       x1="67.429749"
+       y1="772.61719"
+       x2="92.288887"
+       y2="772.61719"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6312"
+       gradientUnits="userSpaceOnUse"
+       x1="91.214981"
+       y1="785.36285"
+       x2="102.7421"
+       y2="785.36285"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6314"
+       gradientUnits="userSpaceOnUse"
+       x1="70.992546"
+       y1="811.80328"
+       x2="123.56433"
+       y2="811.80328"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6384"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6386"
+       gradientUnits="userSpaceOnUse"
+       x1="56.282593"
+       y1="731.37836"
+       x2="98.93782"
+       y2="731.37836"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6388"
+       gradientUnits="userSpaceOnUse"
+       x1="96.1549"
+       y1="733.2984"
+       x2="145.4668"
+       y2="733.2984"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6390"
+       gradientUnits="userSpaceOnUse"
+       x1="69.856102"
+       y1="754.6167"
+       x2="94.009399"
+       y2="754.6167"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6392"
+       gradientUnits="userSpaceOnUse"
+       x1="103.56205"
+       y1="754.18781"
+       x2="125.9644"
+       y2="754.18781"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,2.74286,854.19075)"
+       x1="493.99997"
+       y1="289.00003"
+       x2="659.67157"
+       y2="419.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6396"
+       gradientUnits="userSpaceOnUse"
+       x1="99.199997"
+       y1="735.10504"
+       x2="153.06779"
+       y2="735.10504"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,852.36218)"
+       x1="399.94489"
+       y1="107.97698"
+       x2="440"
+       y2="376.95392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6400"
+       gradientUnits="userSpaceOnUse"
+       x1="25.127617"
+       y1="707.44263"
+       x2="169.14285"
+       y2="707.44263"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,852.36218)"
+       x1="476.83954"
+       y1="271.28894"
+       x2="527.15973"
+       y2="393.89273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6404"
+       gradientUnits="userSpaceOnUse"
+       x1="41.334755"
+       y1="731.93378"
+       x2="152.49365"
+       y2="731.93378"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6406"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,852.36218)"
+       x1="281.48184"
+       y1="229.23729"
+       x2="481.76227"
+       y2="369.23727" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6408"
+       gradientUnits="userSpaceOnUse"
+       x1="41.481567"
+       y1="704.95374"
+       x2="122.85721"
+       y2="704.95374"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6410"
+       gradientUnits="userSpaceOnUse"
+       x1="92.34285"
+       y1="674.87982"
+       x2="101.94285"
+       y2="674.87982"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6412"
+       gradientUnits="userSpaceOnUse"
+       x1="79.976357"
+       y1="694.42743"
+       x2="87.355614"
+       y2="694.42743"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6414"
+       gradientUnits="userSpaceOnUse"
+       x1="102.75062"
+       y1="696.36688"
+       x2="113.71516"
+       y2="696.36688"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6416"
+       gradientUnits="userSpaceOnUse"
+       x1="89.027313"
+       y1="679.69513"
+       x2="104.81105"
+       y2="679.69513"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,883.27393)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6420"
+       gradientUnits="userSpaceOnUse"
+       x1="248.36806"
+       y1="775.46729"
+       x2="347.362"
+       y2="775.46729"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6422"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,883.27393)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6424"
+       gradientUnits="userSpaceOnUse"
+       x1="251.05547"
+       y1="785.65112"
+       x2="341.3374"
+       y2="785.65112"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6426"
+       gradientUnits="userSpaceOnUse"
+       x1="303.12097"
+       y1="773.41211"
+       x2="327.91367"
+       y2="773.41211"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6428"
+       gradientUnits="userSpaceOnUse"
+       x1="267.42975"
+       y1="772.61719"
+       x2="292.28888"
+       y2="772.61719"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6430"
+       gradientUnits="userSpaceOnUse"
+       x1="291.21497"
+       y1="785.36285"
+       x2="302.7421"
+       y2="785.36285"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6432"
+       gradientUnits="userSpaceOnUse"
+       x1="270.99255"
+       y1="811.80328"
+       x2="323.56433"
+       y2="811.80328"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6502"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6504"
+       gradientUnits="userSpaceOnUse"
+       x1="250.33974"
+       y1="729.77832"
+       x2="297.56638"
+       y2="729.77832"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6506"
+       gradientUnits="userSpaceOnUse"
+       x1="295.43027"
+       y1="734.26849"
+       x2="345.4668"
+       y2="734.26849"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6508"
+       gradientUnits="userSpaceOnUse"
+       x1="269.85611"
+       y1="754.6167"
+       x2="294.0094"
+       y2="754.6167"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6510"
+       gradientUnits="userSpaceOnUse"
+       x1="303.56204"
+       y1="754.18781"
+       x2="325.96439"
+       y2="754.18781"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25350812,0.05002971,-0.05002971,0.25350812,219.49264,829.39036)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6514"
+       gradientUnits="userSpaceOnUse"
+       x1="291.42554"
+       y1="700.13403"
+       x2="330.87399"
+       y2="700.13403"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6516"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23253349,0.11268297,-0.11268297,0.23253349,259.65879,812.50236)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6518"
+       gradientUnits="userSpaceOnUse"
+       x1="316.33826"
+       y1="701.10437"
+       x2="353.2262"
+       y2="701.10437"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6520"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24894286,-0.0692576,0.0692576,0.24894286,159.48142,878.16449)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6522"
+       gradientUnits="userSpaceOnUse"
+       x1="246.30501"
+       y1="700.01233"
+       x2="284.39862"
+       y2="700.01233"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22190492,-0.13239063,0.13239063,0.22190492,141.89787,921.36403)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6526"
+       gradientUnits="userSpaceOnUse"
+       x1="228.77269"
+       y1="710.81042"
+       x2="267.9151"
+       y2="710.81042"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6528"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,-0.25839749,186.1008,973.13366)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6530"
+       gradientUnits="userSpaceOnUse"
+       x1="266.44263"
+       y1="719.90375"
+       x2="306.27542"
+       y2="719.90375"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.257896,0.01609282,0.01609282,-0.257896,200.37949,963.83226)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6534"
+       gradientUnits="userSpaceOnUse"
+       x1="282.76651"
+       y1="717.54517"
+       x2="322.43253"
+       y2="717.54517"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6536"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24741052,0.07454766,0.07454766,-0.24741052,208.13637,941.90115)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6538"
+       gradientUnits="userSpaceOnUse"
+       x1="295.19739"
+       y1="722.61737"
+       x2="333.04474"
+       y2="722.61737"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20518446,0.15706286,0.15706286,-0.20518446,220.83778,907.64184)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6542"
+       gradientUnits="userSpaceOnUse"
+       x1="305.77536"
+       y1="732.12555"
+       x2="347.23318"
+       y2="732.12555"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6544"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2533744,-0.05070034,-0.05070034,-0.2533744,183.87812,994.44524)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6546"
+       gradientUnits="userSpaceOnUse"
+       x1="255.67673"
+       y1="723.49133"
+       x2="295.1105"
+       y2="723.49133"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6548"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,0.25839749,188.42739,846.95457)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6550"
+       gradientUnits="userSpaceOnUse"
+       x1="268.76923"
+       y1="700.18445"
+       x2="308.60202"
+       y2="700.18445"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21515612,0.14309806,-0.14309806,0.21515612,287.8365,812.45825)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6554"
+       gradientUnits="userSpaceOnUse"
+       x1="330.13855"
+       y1="708.22577"
+       x2="369.46072"
+       y2="708.22577"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18003086,-0.18535932,0.18535932,0.18003086,137.82757,961.57263)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6558"
+       gradientUnits="userSpaceOnUse"
+       x1="218.64304"
+       y1="719.88123"
+       x2="262.31421"
+       y2="719.88123"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6560"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0360752,0.25586697,-0.25586697,-0.0360752,415.39118,846.18728)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6562"
+       gradientUnits="userSpaceOnUse"
+       x1="327.52252"
+       y1="740.62958"
+       x2="370.69406"
+       y2="740.62958"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01878479,0.25771406,0.25771406,-0.01878479,186.49259,840.75062)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6566"
+       gradientUnits="userSpaceOnUse"
+       x1="225.94441"
+       y1="738.22644"
+       x2="268.10242"
+       y2="738.22644"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17521554,0.18991817,0.18991817,-0.17521554,140.42014,904.77727)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6570"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25263337,-0.05427246,-0.05427246,-0.25263337,166.39915,1008.0567)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6572"
+       gradientUnits="userSpaceOnUse"
+       x1="237.47273"
+       y1="735.98956"
+       x2="276.82419"
+       y2="735.98956"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6574"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21288069,0.14646217,-0.14646217,-0.21288069,460.14377,926.98216)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6576"
+       gradientUnits="userSpaceOnUse"
+       x1="333.70978"
+       y1="745.37531"
+       x2="374.21063"
+       y2="745.37531"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6578"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11992869,0.22888092,-0.22888092,0.11992869,349.94537,811.8505)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6580"
+       gradientUnits="userSpaceOnUse"
+       x1="330.8132"
+       y1="718.16827"
+       x2="376.71774"
+       y2="718.16827"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6606"
+       gradientUnits="userSpaceOnUse"
+       x1="237.99997"
+       y1="321.00003"
+       x2="566"
+       y2="321.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6634"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16621349,0,0,0.19465989,628.27205,877.82661)"
+       x1="224.16286"
+       y1="330.27112"
+       x2="603.85291"
+       y2="818.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6636"
+       gradientUnits="userSpaceOnUse"
+       x1="638.94916"
+       y1="765.56342"
+       x2="760.61444"
+       y2="765.56342"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6638"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,612.99887,849.77619)"
+       x1="158.89351"
+       y1="777.17603"
+       x2="380.3736"
+       y2="865.88708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6640"
+       gradientUnits="userSpaceOnUse"
+       x1="646.81274"
+       y1="828.37061"
+       x2="692.35657"
+       y2="828.37061"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6642"
+       gradientUnits="userSpaceOnUse"
+       x1="653.68457"
+       y1="829.35376"
+       x2="672.69208"
+       y2="829.35376"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6644"
+       gradientUnits="userSpaceOnUse"
+       x1="667.30975"
+       y1="768.87933"
+       x2="717.39886"
+       y2="768.87933"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6646"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2349088,-0.0222509,0.02074117,0.21897029,589.12197,874.25466)"
+       x1="588.7981"
+       y1="217.56953"
+       x2="848.7243"
+       y2="456.71457" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6648"
+       gradientUnits="userSpaceOnUse"
+       x1="696.2522"
+       y1="764.69159"
+       x2="777.38123"
+       y2="764.69159"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6650"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6652"
+       gradientUnits="userSpaceOnUse"
+       x1="633.10931"
+       y1="812.69128"
+       x2="645.08679"
+       y2="812.69128"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6654"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6656"
+       gradientUnits="userSpaceOnUse"
+       x1="633.05316"
+       y1="819.85101"
+       x2="645.47211"
+       y2="819.85101"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6660"
+       gradientUnits="userSpaceOnUse"
+       x1="635.27271"
+       y1="825.64288"
+       x2="644.61847"
+       y2="825.64288"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6662"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6664"
+       gradientUnits="userSpaceOnUse"
+       x1="644.05774"
+       y1="820.00983"
+       x2="660.35205"
+       y2="820.00983"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6666"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6668"
+       gradientUnits="userSpaceOnUse"
+       x1="642.68994"
+       y1="823.18207"
+       x2="658.1192"
+       y2="823.18207"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6670"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6672"
+       gradientUnits="userSpaceOnUse"
+       x1="643.49298"
+       y1="828.16602"
+       x2="656.23871"
+       y2="828.16602"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6674"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6676"
+       gradientUnits="userSpaceOnUse"
+       x1="634.34662"
+       y1="806.43097"
+       x2="647.85767"
+       y2="806.43097"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6678"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6680"
+       gradientUnits="userSpaceOnUse"
+       x1="620.89111"
+       y1="801.65491"
+       x2="636.18115"
+       y2="801.65491"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6682"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6684"
+       gradientUnits="userSpaceOnUse"
+       x1="645.40851"
+       y1="814.61499"
+       x2="660.90442"
+       y2="814.61499"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6686"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6688"
+       gradientUnits="userSpaceOnUse"
+       x1="657.91669"
+       y1="826.08704"
+       x2="664.66443"
+       y2="826.08704"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6690"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6692"
+       gradientUnits="userSpaceOnUse"
+       x1="654.81549"
+       y1="830.73816"
+       x2="662.13086"
+       y2="830.73816"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6694"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,852.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6696"
+       gradientUnits="userSpaceOnUse"
+       x1="660.17297"
+       y1="832.20099"
+       x2="668.17023"
+       y2="832.20099"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,912.80156)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6766"
+       gradientUnits="userSpaceOnUse"
+       x1="1061.8412"
+       y1="785.44971"
+       x2="1140.6234"
+       y2="785.44971"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6768"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,912.80156)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6770"
+       gradientUnits="userSpaceOnUse"
+       x1="1063.9589"
+       y1="793.47449"
+       x2="1135.876"
+       y2="793.47449"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6772"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.374"
+       y1="783.8302"
+       x2="1124.9105"
+       y2="783.8302"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6774"
+       gradientUnits="userSpaceOnUse"
+       x1="1077.2495"
+       y1="783.2038"
+       x2="1096.8384"
+       y2="783.2038"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6776"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.9921"
+       y1="793.24731"
+       x2="1105.0754"
+       y2="793.24731"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6778"
+       gradientUnits="userSpaceOnUse"
+       x1="1079.6692"
+       y1="814.08228"
+       x2="1121.871"
+       y2="814.08228"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6780"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6782"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.0854"
+       y1="813.7832"
+       x2="1101.2366"
+       y2="813.7832"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6784"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6786"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.3922"
+       y1="813.98004"
+       x2="1106.1254"
+       y2="813.98004"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6788"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6790"
+       gradientUnits="userSpaceOnUse"
+       x1="1103.7596"
+       y1="813.69153"
+       x2="1110.549"
+       y2="813.69153"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6792"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6794"
+       gradientUnits="userSpaceOnUse"
+       x1="1108.9393"
+       y1="813.28442"
+       x2="1113.9164"
+       y2="813.28442"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6796"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6798"
+       gradientUnits="userSpaceOnUse"
+       x1="1112.0919"
+       y1="813.03467"
+       x2="1116.6942"
+       y2="813.03467"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6800"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6802"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.3092"
+       y1="813.70508"
+       x2="1093.9316"
+       y2="813.70508"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6806"
+       gradientUnits="userSpaceOnUse"
+       x1="1084.6591"
+       y1="813.33734"
+       x2="1089.658"
+       y2="813.33734"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient6848"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6850"
+       gradientUnits="userSpaceOnUse"
+       x1="1064.5331"
+       y1="749.55829"
+       x2="1101.8083"
+       y2="749.55829"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6852"
+       gradientUnits="userSpaceOnUse"
+       x1="1096.4777"
+       y1="750.44092"
+       x2="1137.5516"
+       y2="750.44092"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6854"
+       gradientUnits="userSpaceOnUse"
+       x1="1078.9677"
+       y1="769.01947"
+       x2="1098.3879"
+       y2="769.01947"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6856"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.5277"
+       y1="768.68152"
+       x2="1123.5684"
+       y2="768.68152"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6859"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6861"
+       gradientUnits="userSpaceOnUse"
+       x1="109.05775"
+       y1="817.92242"
+       x2="114.82501"
+       y2="817.92242"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6864"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6866"
+       gradientUnits="userSpaceOnUse"
+       x1="103.78092"
+       y1="819.22729"
+       x2="110.23132"
+       y2="819.22729"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6869"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6871"
+       gradientUnits="userSpaceOnUse"
+       x1="82.105972"
+       y1="818.7121"
+       x2="87.151558"
+       y2="818.7121"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6874"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       x1="86.113861"
+       y1="819.38287"
+       x2="92.915047"
+       y2="819.38287"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6879"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6881"
+       gradientUnits="userSpaceOnUse"
+       x1="98.746925"
+       y1="819.18134"
+       x2="104.58971"
+       y2="819.18134"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6884"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6886"
+       gradientUnits="userSpaceOnUse"
+       x1="94.497787"
+       y1="819.11469"
+       x2="99.918884"
+       y2="819.11469"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6889"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6891"
+       gradientUnits="userSpaceOnUse"
+       x1="90.826149"
+       y1="818.85352"
+       x2="96.198097"
+       y2="818.85352"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6894"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6896"
+       gradientUnits="userSpaceOnUse"
+       x1="78.462914"
+       y1="817.44745"
+       x2="83.676331"
+       y2="817.44745"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6899"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6901"
+       gradientUnits="userSpaceOnUse"
+       x1="73.569695"
+       y1="809.95294"
+       x2="79.137154"
+       y2="809.95294"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6904"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6906"
+       gradientUnits="userSpaceOnUse"
+       x1="86.052475"
+       y1="811.08667"
+       x2="92.376343"
+       y2="811.08667"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6909"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6911"
+       gradientUnits="userSpaceOnUse"
+       x1="77.078804"
+       y1="810.85791"
+       x2="82.930519"
+       y2="810.85791"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6914"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6916"
+       gradientUnits="userSpaceOnUse"
+       x1="81.71109"
+       y1="811.32458"
+       x2="88.35408"
+       y2="811.32458"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6919"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6921"
+       gradientUnits="userSpaceOnUse"
+       x1="111.89223"
+       y1="810.47382"
+       x2="117.24081"
+       y2="810.47382"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6924"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6926"
+       gradientUnits="userSpaceOnUse"
+       x1="107.89149"
+       y1="810.79077"
+       x2="113.71567"
+       y2="810.79077"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6929"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6931"
+       gradientUnits="userSpaceOnUse"
+       x1="101.31824"
+       y1="811.30737"
+       x2="109.44228"
+       y2="811.30737"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6934"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6936"
+       gradientUnits="userSpaceOnUse"
+       x1="96.099007"
+       y1="811.02704"
+       x2="104.15182"
+       y2="811.02704"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient6939"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient6941"
+       gradientUnits="userSpaceOnUse"
+       x1="90.310471"
+       y1="811.10046"
+       x2="97.624428"
+       y2="811.10046"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7184"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7186"
+       gradientUnits="userSpaceOnUse"
+       x1="309.05774"
+       y1="817.92242"
+       x2="314.82501"
+       y2="817.92242"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7189"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7191"
+       gradientUnits="userSpaceOnUse"
+       x1="303.78091"
+       y1="819.22729"
+       x2="310.23132"
+       y2="819.22729"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7194"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7196"
+       gradientUnits="userSpaceOnUse"
+       x1="282.10596"
+       y1="818.7121"
+       x2="287.15155"
+       y2="818.7121"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7199"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7201"
+       gradientUnits="userSpaceOnUse"
+       x1="286.11386"
+       y1="819.38287"
+       x2="292.91504"
+       y2="819.38287"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7204"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7206"
+       gradientUnits="userSpaceOnUse"
+       x1="298.74692"
+       y1="819.18134"
+       x2="304.58972"
+       y2="819.18134"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7209"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7211"
+       gradientUnits="userSpaceOnUse"
+       x1="294.4978"
+       y1="819.11469"
+       x2="299.91888"
+       y2="819.11469"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7214"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7216"
+       gradientUnits="userSpaceOnUse"
+       x1="290.82614"
+       y1="818.85352"
+       x2="296.19809"
+       y2="818.85352"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7219"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7221"
+       gradientUnits="userSpaceOnUse"
+       x1="278.46292"
+       y1="817.44745"
+       x2="283.67633"
+       y2="817.44745"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7224"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7226"
+       gradientUnits="userSpaceOnUse"
+       x1="273.5697"
+       y1="809.95294"
+       x2="279.13715"
+       y2="809.95294"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7229"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7231"
+       gradientUnits="userSpaceOnUse"
+       x1="286.05246"
+       y1="811.08667"
+       x2="292.37634"
+       y2="811.08667"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7234"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7236"
+       gradientUnits="userSpaceOnUse"
+       x1="277.0788"
+       y1="810.85791"
+       x2="282.93051"
+       y2="810.85791"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7239"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7241"
+       gradientUnits="userSpaceOnUse"
+       x1="281.71109"
+       y1="811.32458"
+       x2="288.35406"
+       y2="811.32458"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7244"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7246"
+       gradientUnits="userSpaceOnUse"
+       x1="311.89224"
+       y1="810.47382"
+       x2="317.24081"
+       y2="810.47382"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7249"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7251"
+       gradientUnits="userSpaceOnUse"
+       x1="307.89148"
+       y1="810.79077"
+       x2="313.71567"
+       y2="810.79077"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7254"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7256"
+       gradientUnits="userSpaceOnUse"
+       x1="301.31824"
+       y1="811.30737"
+       x2="309.44229"
+       y2="811.30737"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7259"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7261"
+       gradientUnits="userSpaceOnUse"
+       x1="296.099"
+       y1="811.02704"
+       x2="304.15182"
+       y2="811.02704"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7264"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7266"
+       gradientUnits="userSpaceOnUse"
+       x1="290.31046"
+       y1="811.10046"
+       x2="297.62442"
+       y2="811.10046"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7269"
+       gradientUnits="userSpaceOnUse"
+       x1="438.85294"
+       y1="726.84784"
+       x2="460.22263"
+       y2="726.84784"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7272"
+       gradientUnits="userSpaceOnUse"
+       x1="486.30545"
+       y1="688.69989"
+       x2="489.61386"
+       y2="688.69989"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7275"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,852.10142)"
+       x1="459"
+       y1="322"
+       x2="539"
+       y2="322" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7277"
+       gradientUnits="userSpaceOnUse"
+       x1="505.93417"
+       y1="726.83801"
+       x2="524.81915"
+       y2="726.83801"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7280"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,395.68834,852.42966)"
+       x1="379.49451"
+       y1="419.62323"
+       x2="420.95035"
+       y2="419.62323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7282"
+       gradientUnits="userSpaceOnUse"
+       x1="485.9314"
+       y1="749.33234"
+       x2="495.89645"
+       y2="749.33234"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7285"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21089623,0,0,0.20696937,408.15849,860.17889)"
+       x1="242.74734"
+       y1="227.95091"
+       x2="563.46429"
+       y2="472.00671" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7287"
+       gradientUnits="userSpaceOnUse"
+       x1="477.81613"
+       y1="736.05231"
+       x2="524.61011"
+       y2="736.05231"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7290"
+       gradientUnits="userSpaceOnUse"
+       x1="539.29779"
+       y1="721.87408"
+       x2="562.30157"
+       y2="721.87408"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7293"
+       gradientUnits="userSpaceOnUse"
+       x1="428.48889"
+       y1="735.7572"
+       x2="437.39731"
+       y2="735.7572"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7296"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,852.10142)"
+       x1="749.64923"
+       y1="506.85049"
+       x2="297.93896"
+       y2="301.25592" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7298"
+       gradientUnits="userSpaceOnUse"
+       x1="475.8024"
+       y1="738.32703"
+       x2="528.16675"
+       y2="738.32703"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7301"
+       gradientUnits="userSpaceOnUse"
+       x1="480.60004"
+       y1="676.47284"
+       x2="513.27783"
+       y2="676.47284"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.44184,864.15702)"
+       x1="217.99556"
+       y1="116.56352"
+       x2="650.22534"
+       y2="599.48517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7307"
+       gradientUnits="userSpaceOnUse"
+       x1="422.84702"
+       y1="723.84576"
+       x2="570.11725"
+       y2="723.84576"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7310"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,852.10142)"
+       x1="313.02646"
+       y1="310.0217"
+       x2="436.50671"
+       y2="310.0217" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7312"
+       gradientUnits="userSpaceOnUse"
+       x1="471.41071"
+       y1="724.0578"
+       x2="500.57901"
+       y2="724.0578"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7315"
+       gradientUnits="userSpaceOnUse"
+       x1="473.91318"
+       y1="834.32428"
+       x2="544.76227"
+       y2="834.32428"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7318"
+       gradientUnits="userSpaceOnUse"
+       x1="447.76126"
+       y1="831.96173"
+       x2="474.34143"
+       y2="831.96173"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7321"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,450.40462,912.39475)"
+       x1="416.0477"
+       y1="150.12955"
+       x2="825.8576"
+       y2="861.172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7323"
+       gradientUnits="userSpaceOnUse"
+       x1="479.66254"
+       y1="786.77814"
+       x2="528.02679"
+       y2="786.77814"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7326"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,444.57813,906.8665)"
+       x1="128.10062"
+       y1="181.86472"
+       x2="740.29462"
+       y2="596.77478" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7328"
+       gradientUnits="userSpaceOnUse"
+       x1="466.40829"
+       y1="785.33112"
+       x2="521.17554"
+       y2="785.33112"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20752777,0,0,0.20252572,402.21129,873.78322)"
+       x1="474.40475"
+       y1="587.78589"
+       x2="504.64395"
+       y2="893.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7333"
+       gradientUnits="userSpaceOnUse"
+       x1="442.63852"
+       y1="830.45563"
+       x2="551.50421"
+       y2="830.45563"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7337"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7339"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,820.50808,868.62524)"
+       x1="794.93005"
+       y1="722.53284"
+       x2="770.78296"
+       y2="895.88794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7344"
+       gradientUnits="userSpaceOnUse"
+       x1="915.12128"
+       y1="827.7655"
+       x2="995.56488"
+       y2="827.7655"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="419.67706"
+       y1="352.28876"
+       x2="483.55563"
+       y2="352.28876" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7349"
+       gradientUnits="userSpaceOnUse"
+       x1="889.82465"
+       y1="707.5625"
+       x2="918.64362"
+       y2="707.5625"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="511.89685"
+       y1="446.66107"
+       x2="611.99969"
+       y2="452.35666" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7354"
+       gradientUnits="userSpaceOnUse"
+       x1="935.57111"
+       y1="749.2525"
+       x2="970.36121"
+       y2="749.2525"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7357"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7359"
+       gradientUnits="userSpaceOnUse"
+       x1="943.98199"
+       y1="773.57001"
+       x2="978.1402"
+       y2="773.57001"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7364"
+       gradientUnits="userSpaceOnUse"
+       x1="942.90027"
+       y1="759.54755"
+       x2="963.38831"
+       y2="759.54755"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7367"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7369"
+       gradientUnits="userSpaceOnUse"
+       x1="928.04724"
+       y1="728.44061"
+       x2="955.7854"
+       y2="728.44061"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,751.24771)"
+       x1="456.65414"
+       y1="391.58966"
+       x2="566.70068"
+       y2="425.28772" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7374"
+       gradientUnits="userSpaceOnUse"
+       x1="908.91254"
+       y1="721.44269"
+       x2="943.30023"
+       y2="721.44269"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7377"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,751.24771)"
+       x1="280.6785"
+       y1="392.55249"
+       x2="406.05249"
+       y2="444.0405" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7379"
+       gradientUnits="userSpaceOnUse"
+       x1="818.10461"
+       y1="740.09766"
+       x2="892.47595"
+       y2="740.09766"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,751.24771)"
+       x1="433.81351"
+       y1="323.27167"
+       x2="357.96667"
+       y2="397.28345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7384"
+       gradientUnits="userSpaceOnUse"
+       x1="855.84723"
+       y1="722.4212"
+       x2="900.60809"
+       y2="722.4212"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7387"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,751.24771)"
+       x1="377.70755"
+       y1="413.54922"
+       x2="474.78088"
+       y2="505.35657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7389"
+       gradientUnits="userSpaceOnUse"
+       x1="819.7616"
+       y1="754.84851"
+       x2="916.59564"
+       y2="754.84851"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4302688,0.10689897,-0.10689897,0.4302688,770.98002,722.98979)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7394"
+       gradientUnits="userSpaceOnUse"
+       x1="951.49579"
+       y1="801.44019"
+       x2="981.25293"
+       y2="801.44019"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7397"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,710.97769,777.30202)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7399"
+       gradientUnits="userSpaceOnUse"
+       x1="950.06189"
+       y1="785.60187"
+       x2="970.54993"
+       y2="785.60187"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41219086,0.16327132,-0.16327132,0.41219086,809.62069,725.64161)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7404"
+       gradientUnits="userSpaceOnUse"
+       x1="952.53705"
+       y1="828.3324"
+       x2="979.31989"
+       y2="828.3324"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7407"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43887269,0.06284457,-0.06284457,0.43887269,743.78848,770.5198)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7409"
+       gradientUnits="userSpaceOnUse"
+       x1="951.61542"
+       y1="812.61157"
+       x2="969.87512"
+       y2="812.61157"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,825.76857,869.14344)"
+       x1="354.36316"
+       y1="724.97058"
+       x2="456.54602"
+       y2="864.27307" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7414"
+       gradientUnits="userSpaceOnUse"
+       x1="882.36829"
+       y1="828.97711"
+       x2="919.28955"
+       y2="828.97711"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7417"
+       gradientUnits="userSpaceOnUse"
+       x1="844.43134"
+       y1="762.97943"
+       x2="880.50171"
+       y2="762.97943"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7421"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7423"
+       gradientUnits="userSpaceOnUse"
+       x1="1109.8584"
+       y1="818.90417"
+       x2="1114.7906"
+       y2="818.90417"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7426"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7428"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.7002"
+       y1="819.93237"
+       x2="1111.1707"
+       y2="819.93237"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7431"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7433"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.6204"
+       y1="819.52643"
+       x2="1092.984"
+       y2="819.52643"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7436"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7438"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7786"
+       y1="820.05499"
+       x2="1097.5256"
+       y2="820.05499"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7441"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7443"
+       gradientUnits="userSpaceOnUse"
+       x1="1101.7334"
+       y1="819.89618"
+       x2="1106.7252"
+       y2="819.89618"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7446"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7448"
+       gradientUnits="userSpaceOnUse"
+       x1="1098.3851"
+       y1="819.84363"
+       x2="1103.0446"
+       y2="819.84363"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7451"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7453"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.4919"
+       y1="819.63782"
+       x2="1100.1125"
+       y2="819.63782"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7456"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7458"
+       gradientUnits="userSpaceOnUse"
+       x1="1085.7498"
+       y1="818.52991"
+       x2="1090.2455"
+       y2="818.52991"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7461"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7463"
+       gradientUnits="userSpaceOnUse"
+       x1="1081.8938"
+       y1="812.62421"
+       x2="1086.6687"
+       y2="812.62421"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7466"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient7468"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7303"
+       y1="813.51758"
+       x2="1097.1011"
+       y2="813.51758"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient7471"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient8454"
+       x1="220.3288"
+       y1="949.39807"
+       x2="264.30008"
+       y2="949.39807"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8525"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8527"
+       gradientUnits="userSpaceOnUse"
+       x1="660.17297"
+       y1="832.20099"
+       x2="668.17023"
+       y2="832.20099" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8530"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8532"
+       gradientUnits="userSpaceOnUse"
+       x1="654.81549"
+       y1="830.73816"
+       x2="662.13086"
+       y2="830.73816" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8537"
+       gradientUnits="userSpaceOnUse"
+       x1="657.91669"
+       y1="826.08704"
+       x2="664.66443"
+       y2="826.08704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8542"
+       gradientUnits="userSpaceOnUse"
+       x1="645.40851"
+       y1="814.61499"
+       x2="660.90442"
+       y2="814.61499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8545"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8547"
+       gradientUnits="userSpaceOnUse"
+       x1="620.89111"
+       y1="801.65491"
+       x2="636.18115"
+       y2="801.65491" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8550"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8552"
+       gradientUnits="userSpaceOnUse"
+       x1="634.34662"
+       y1="806.43097"
+       x2="647.85767"
+       y2="806.43097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8555"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8557"
+       gradientUnits="userSpaceOnUse"
+       x1="643.49298"
+       y1="828.16602"
+       x2="656.23871"
+       y2="828.16602" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8560"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8562"
+       gradientUnits="userSpaceOnUse"
+       x1="642.68994"
+       y1="823.18207"
+       x2="658.1192"
+       y2="823.18207" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8567"
+       gradientUnits="userSpaceOnUse"
+       x1="644.05774"
+       y1="820.00983"
+       x2="660.35205"
+       y2="820.00983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8570"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8572"
+       gradientUnits="userSpaceOnUse"
+       x1="635.27271"
+       y1="825.64288"
+       x2="644.61847"
+       y2="825.64288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8575"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8577"
+       gradientUnits="userSpaceOnUse"
+       x1="633.05316"
+       y1="819.85101"
+       x2="645.47211"
+       y2="819.85101" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8580"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,652.36218)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8582"
+       gradientUnits="userSpaceOnUse"
+       x1="633.10931"
+       y1="812.69128"
+       x2="645.08679"
+       y2="812.69128" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2349088,-0.0222509,0.02074117,0.21897029,589.12197,674.25466)"
+       x1="588.7981"
+       y1="217.56953"
+       x2="848.7243"
+       y2="456.71457" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8587"
+       gradientUnits="userSpaceOnUse"
+       x1="696.2522"
+       y1="764.69159"
+       x2="777.38123"
+       y2="764.69159" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8590"
+       gradientUnits="userSpaceOnUse"
+       x1="667.30975"
+       y1="768.87933"
+       x2="717.39886"
+       y2="768.87933" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8593"
+       gradientUnits="userSpaceOnUse"
+       x1="653.68457"
+       y1="829.35376"
+       x2="672.69208"
+       y2="829.35376" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,612.99887,649.77619)"
+       x1="158.89351"
+       y1="777.17603"
+       x2="380.3736"
+       y2="865.88708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8598"
+       gradientUnits="userSpaceOnUse"
+       x1="646.81274"
+       y1="828.37061"
+       x2="692.35657"
+       y2="828.37061" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16621349,0,0,0.19465989,628.27205,677.82661)"
+       x1="224.16286"
+       y1="330.27112"
+       x2="603.85291"
+       y2="818.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8603"
+       gradientUnits="userSpaceOnUse"
+       x1="638.94916"
+       y1="765.56342"
+       x2="760.61444"
+       y2="765.56342" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8607"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8609"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8612"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,820.50808,668.62524)"
+       x1="794.93005"
+       y1="722.53284"
+       x2="770.78296"
+       y2="895.88794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8614"
+       gradientUnits="userSpaceOnUse"
+       x1="915.12128"
+       y1="827.7655"
+       x2="995.56488"
+       y2="827.7655" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8617"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="419.67706"
+       y1="352.28876"
+       x2="483.55563"
+       y2="352.28876" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8619"
+       gradientUnits="userSpaceOnUse"
+       x1="889.82465"
+       y1="707.5625"
+       x2="918.64362"
+       y2="707.5625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8622"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="511.89685"
+       y1="446.66107"
+       x2="611.99969"
+       y2="452.35666" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8624"
+       gradientUnits="userSpaceOnUse"
+       x1="935.57111"
+       y1="749.2525"
+       x2="970.36121"
+       y2="749.2525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8627"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8629"
+       gradientUnits="userSpaceOnUse"
+       x1="943.98199"
+       y1="773.57001"
+       x2="978.1402"
+       y2="773.57001" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8632"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8634"
+       gradientUnits="userSpaceOnUse"
+       x1="942.90027"
+       y1="759.54755"
+       x2="963.38831"
+       y2="759.54755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8637"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8639"
+       gradientUnits="userSpaceOnUse"
+       x1="928.04724"
+       y1="728.44061"
+       x2="955.7854"
+       y2="728.44061" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8642"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,551.24771)"
+       x1="456.65414"
+       y1="391.58966"
+       x2="566.70068"
+       y2="425.28772" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8644"
+       gradientUnits="userSpaceOnUse"
+       x1="908.91254"
+       y1="721.44269"
+       x2="943.30023"
+       y2="721.44269" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8647"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,551.24771)"
+       x1="280.6785"
+       y1="392.55249"
+       x2="406.05249"
+       y2="444.0405" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8649"
+       gradientUnits="userSpaceOnUse"
+       x1="818.10461"
+       y1="740.09766"
+       x2="892.47595"
+       y2="740.09766" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8652"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,551.24771)"
+       x1="433.81351"
+       y1="323.27167"
+       x2="357.96667"
+       y2="397.28345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8654"
+       gradientUnits="userSpaceOnUse"
+       x1="855.84723"
+       y1="722.4212"
+       x2="900.60809"
+       y2="722.4212" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,551.24771)"
+       x1="377.70755"
+       y1="413.54922"
+       x2="474.78088"
+       y2="505.35657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8659"
+       gradientUnits="userSpaceOnUse"
+       x1="819.7616"
+       y1="754.84851"
+       x2="916.59564"
+       y2="754.84851" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8662"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4302688,0.10689897,-0.10689897,0.4302688,770.98002,522.98979)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8664"
+       gradientUnits="userSpaceOnUse"
+       x1="951.49579"
+       y1="801.44019"
+       x2="981.25293"
+       y2="801.44019" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8667"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,710.97769,577.30202)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8669"
+       gradientUnits="userSpaceOnUse"
+       x1="950.06189"
+       y1="785.60187"
+       x2="970.54993"
+       y2="785.60187" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8672"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41219086,0.16327132,-0.16327132,0.41219086,809.62069,525.64161)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8674"
+       gradientUnits="userSpaceOnUse"
+       x1="952.53705"
+       y1="828.3324"
+       x2="979.31989"
+       y2="828.3324" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43887269,0.06284457,-0.06284457,0.43887269,743.78848,570.5198)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8679"
+       gradientUnits="userSpaceOnUse"
+       x1="951.61542"
+       y1="812.61157"
+       x2="969.87512"
+       y2="812.61157" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8682"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,825.76857,669.14344)"
+       x1="354.36316"
+       y1="724.97058"
+       x2="456.54602"
+       y2="864.27307" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8684"
+       gradientUnits="userSpaceOnUse"
+       x1="882.36829"
+       y1="828.97711"
+       x2="919.28955"
+       y2="828.97711" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8687"
+       gradientUnits="userSpaceOnUse"
+       x1="844.43134"
+       y1="762.97943"
+       x2="880.50171"
+       y2="762.97943" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8691"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.5277"
+       y1="768.68152"
+       x2="1123.5684"
+       y2="768.68152" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8694"
+       gradientUnits="userSpaceOnUse"
+       x1="1078.9677"
+       y1="769.01947"
+       x2="1098.3879"
+       y2="769.01947" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8697"
+       gradientUnits="userSpaceOnUse"
+       x1="1096.4777"
+       y1="750.44092"
+       x2="1137.5516"
+       y2="750.44092" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8700"
+       gradientUnits="userSpaceOnUse"
+       x1="1064.5331"
+       y1="749.55829"
+       x2="1101.8083"
+       y2="749.55829" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8703"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8705"
+       gradientUnits="userSpaceOnUse"
+       x1="1109.8584"
+       y1="818.90417"
+       x2="1114.7906"
+       y2="818.90417" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8708"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8710"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.7002"
+       y1="819.93237"
+       x2="1111.1707"
+       y2="819.93237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8713"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8715"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.6204"
+       y1="819.52643"
+       x2="1092.984"
+       y2="819.52643" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8718"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8720"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7786"
+       y1="820.05499"
+       x2="1097.5256"
+       y2="820.05499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8723"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8725"
+       gradientUnits="userSpaceOnUse"
+       x1="1101.7334"
+       y1="819.89618"
+       x2="1106.7252"
+       y2="819.89618" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8728"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8730"
+       gradientUnits="userSpaceOnUse"
+       x1="1098.3851"
+       y1="819.84363"
+       x2="1103.0446"
+       y2="819.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8733"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8735"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.4919"
+       y1="819.63782"
+       x2="1100.1125"
+       y2="819.63782" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8738"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8740"
+       gradientUnits="userSpaceOnUse"
+       x1="1085.7498"
+       y1="818.52991"
+       x2="1090.2455"
+       y2="818.52991" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8743"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8745"
+       gradientUnits="userSpaceOnUse"
+       x1="1081.8938"
+       y1="812.62421"
+       x2="1086.6687"
+       y2="812.62421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8748"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8750"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7303"
+       y1="813.51758"
+       x2="1097.1011"
+       y2="813.51758" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8753"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8755"
+       gradientUnits="userSpaceOnUse"
+       x1="1084.6591"
+       y1="813.33734"
+       x2="1089.658"
+       y2="813.33734" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8758"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8760"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.3092"
+       y1="813.70508"
+       x2="1093.9316"
+       y2="813.70508" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8763"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8765"
+       gradientUnits="userSpaceOnUse"
+       x1="1112.0919"
+       y1="813.03467"
+       x2="1116.6942"
+       y2="813.03467" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8768"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8770"
+       gradientUnits="userSpaceOnUse"
+       x1="1108.9393"
+       y1="813.28442"
+       x2="1113.9164"
+       y2="813.28442" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8773"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8775"
+       gradientUnits="userSpaceOnUse"
+       x1="1103.7596"
+       y1="813.69153"
+       x2="1110.549"
+       y2="813.69153" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8778"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8780"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.3922"
+       y1="813.98004"
+       x2="1106.1254"
+       y2="813.98004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8783"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8785"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.0854"
+       y1="813.7832"
+       x2="1101.2366"
+       y2="813.7832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8788"
+       gradientUnits="userSpaceOnUse"
+       x1="1079.6692"
+       y1="814.08228"
+       x2="1121.871"
+       y2="814.08228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8791"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.9921"
+       y1="793.24731"
+       x2="1105.0754"
+       y2="793.24731" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8794"
+       gradientUnits="userSpaceOnUse"
+       x1="1077.2495"
+       y1="783.2038"
+       x2="1096.8384"
+       y2="783.2038" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8797"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.374"
+       y1="783.8302"
+       x2="1124.9105"
+       y2="783.8302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8800"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,712.80156)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8802"
+       gradientUnits="userSpaceOnUse"
+       x1="1063.9589"
+       y1="793.47449"
+       x2="1135.876"
+       y2="793.47449" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient8805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,712.80156)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient8807"
+       gradientUnits="userSpaceOnUse"
+       x1="1061.8412"
+       y1="785.44971"
+       x2="1140.6234"
+       y2="785.44971" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9017"
+       gradientUnits="userSpaceOnUse"
+       x1="237.99997"
+       y1="321.00003"
+       x2="566"
+       y2="321.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9046"
+       gradientUnits="userSpaceOnUse"
+       x1="438.85294"
+       y1="726.84784"
+       x2="460.22263"
+       y2="726.84784" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9049"
+       gradientUnits="userSpaceOnUse"
+       x1="486.30545"
+       y1="688.69989"
+       x2="489.61386"
+       y2="688.69989" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9052"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,652.10142)"
+       x1="459"
+       y1="322"
+       x2="539"
+       y2="322" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9054"
+       gradientUnits="userSpaceOnUse"
+       x1="505.93417"
+       y1="726.83801"
+       x2="524.81915"
+       y2="726.83801" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,395.68834,652.42966)"
+       x1="379.49451"
+       y1="419.62323"
+       x2="420.95035"
+       y2="419.62323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9059"
+       gradientUnits="userSpaceOnUse"
+       x1="485.9314"
+       y1="749.33234"
+       x2="495.89645"
+       y2="749.33234" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21089623,0,0,0.20696937,408.15849,660.17889)"
+       x1="242.74734"
+       y1="227.95091"
+       x2="563.46429"
+       y2="472.00671" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9064"
+       gradientUnits="userSpaceOnUse"
+       x1="477.81613"
+       y1="736.05231"
+       x2="524.61011"
+       y2="736.05231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9067"
+       gradientUnits="userSpaceOnUse"
+       x1="539.29779"
+       y1="721.87408"
+       x2="562.30157"
+       y2="721.87408" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9070"
+       gradientUnits="userSpaceOnUse"
+       x1="428.48889"
+       y1="735.7572"
+       x2="437.39731"
+       y2="735.7572" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9073"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,652.10142)"
+       x1="749.64923"
+       y1="506.85049"
+       x2="297.93896"
+       y2="301.25592" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9075"
+       gradientUnits="userSpaceOnUse"
+       x1="475.8024"
+       y1="738.32703"
+       x2="528.16675"
+       y2="738.32703" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9078"
+       gradientUnits="userSpaceOnUse"
+       x1="480.60004"
+       y1="676.47284"
+       x2="513.27783"
+       y2="676.47284" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9082"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.44184,664.15702)"
+       x1="217.99556"
+       y1="116.56352"
+       x2="650.22534"
+       y2="599.48517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9084"
+       gradientUnits="userSpaceOnUse"
+       x1="422.84702"
+       y1="723.84576"
+       x2="570.11725"
+       y2="723.84576" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9087"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,652.10142)"
+       x1="313.02646"
+       y1="310.0217"
+       x2="436.50671"
+       y2="310.0217" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9089"
+       gradientUnits="userSpaceOnUse"
+       x1="471.41071"
+       y1="724.0578"
+       x2="500.57901"
+       y2="724.0578" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9092"
+       gradientUnits="userSpaceOnUse"
+       x1="473.91318"
+       y1="834.32428"
+       x2="544.76227"
+       y2="834.32428" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9095"
+       gradientUnits="userSpaceOnUse"
+       x1="447.76126"
+       y1="831.96173"
+       x2="474.34143"
+       y2="831.96173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,450.40462,712.39475)"
+       x1="416.0477"
+       y1="150.12955"
+       x2="825.8576"
+       y2="861.172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9100"
+       gradientUnits="userSpaceOnUse"
+       x1="479.66254"
+       y1="786.77814"
+       x2="528.02679"
+       y2="786.77814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9103"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,444.57813,706.8665)"
+       x1="128.10062"
+       y1="181.86472"
+       x2="740.29462"
+       y2="596.77478" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9105"
+       gradientUnits="userSpaceOnUse"
+       x1="466.40829"
+       y1="785.33112"
+       x2="521.17554"
+       y2="785.33112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9108"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20752777,0,0,0.20252572,402.21129,673.78322)"
+       x1="474.40475"
+       y1="587.78589"
+       x2="504.64395"
+       y2="893.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9110"
+       gradientUnits="userSpaceOnUse"
+       x1="442.63852"
+       y1="830.45563"
+       x2="551.50421"
+       y2="830.45563" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9278"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11992869,0.22888092,-0.22888092,0.11992869,349.94537,611.8505)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9280"
+       gradientUnits="userSpaceOnUse"
+       x1="330.8132"
+       y1="718.16827"
+       x2="376.71774"
+       y2="718.16827" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9283"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21288069,0.14646217,-0.14646217,-0.21288069,460.14377,726.98216)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9285"
+       gradientUnits="userSpaceOnUse"
+       x1="333.70978"
+       y1="745.37531"
+       x2="374.21063"
+       y2="745.37531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25263337,-0.05427246,-0.05427246,-0.25263337,166.39915,808.05674)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9290"
+       gradientUnits="userSpaceOnUse"
+       x1="237.47273"
+       y1="735.98956"
+       x2="276.82419"
+       y2="735.98956" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9293"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17521554,0.18991817,0.18991817,-0.17521554,140.42014,704.77727)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9295"
+       gradientUnits="userSpaceOnUse"
+       x1="220.3288"
+       y1="749.39807"
+       x2="264.30008"
+       y2="749.39807" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9298"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01878479,0.25771406,0.25771406,-0.01878479,186.49259,640.75062)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9300"
+       gradientUnits="userSpaceOnUse"
+       x1="225.94441"
+       y1="738.22644"
+       x2="268.10242"
+       y2="738.22644" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9303"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0360752,0.25586697,-0.25586697,-0.0360752,415.39118,646.18728)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9305"
+       gradientUnits="userSpaceOnUse"
+       x1="327.52252"
+       y1="740.62958"
+       x2="370.69406"
+       y2="740.62958" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9308"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18003086,-0.18535932,0.18535932,0.18003086,137.82757,761.57263)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9310"
+       gradientUnits="userSpaceOnUse"
+       x1="218.64304"
+       y1="719.88123"
+       x2="262.31421"
+       y2="719.88123" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9313"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21515612,0.14309806,-0.14309806,0.21515612,287.8365,612.45825)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9315"
+       gradientUnits="userSpaceOnUse"
+       x1="330.13855"
+       y1="708.22577"
+       x2="369.46072"
+       y2="708.22577" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9318"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,0.25839749,188.42739,646.95457)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9320"
+       gradientUnits="userSpaceOnUse"
+       x1="268.76923"
+       y1="700.18445"
+       x2="308.60202"
+       y2="700.18445" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9323"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2533744,-0.05070034,-0.05070034,-0.2533744,183.87812,794.44524)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9325"
+       gradientUnits="userSpaceOnUse"
+       x1="255.67673"
+       y1="723.49133"
+       x2="295.1105"
+       y2="723.49133" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9328"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20518446,0.15706286,0.15706286,-0.20518446,220.83778,707.64184)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9330"
+       gradientUnits="userSpaceOnUse"
+       x1="305.77536"
+       y1="732.12555"
+       x2="347.23318"
+       y2="732.12555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9333"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24741052,0.07454766,0.07454766,-0.24741052,208.13637,741.90115)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9335"
+       gradientUnits="userSpaceOnUse"
+       x1="295.19739"
+       y1="722.61737"
+       x2="333.04474"
+       y2="722.61737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.257896,0.01609282,0.01609282,-0.257896,200.37949,763.83226)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9340"
+       gradientUnits="userSpaceOnUse"
+       x1="282.76651"
+       y1="717.54517"
+       x2="322.43253"
+       y2="717.54517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9343"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,-0.25839749,186.1008,773.13366)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9345"
+       gradientUnits="userSpaceOnUse"
+       x1="266.44263"
+       y1="719.90375"
+       x2="306.27542"
+       y2="719.90375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22190492,-0.13239063,0.13239063,0.22190492,141.89787,721.36403)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9350"
+       gradientUnits="userSpaceOnUse"
+       x1="228.77269"
+       y1="710.81042"
+       x2="267.9151"
+       y2="710.81042" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9353"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24894286,-0.0692576,0.0692576,0.24894286,159.48142,678.16449)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9355"
+       gradientUnits="userSpaceOnUse"
+       x1="246.30501"
+       y1="700.01233"
+       x2="284.39862"
+       y2="700.01233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23253349,0.11268297,-0.11268297,0.23253349,259.65879,612.50236)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9360"
+       gradientUnits="userSpaceOnUse"
+       x1="316.33826"
+       y1="701.10437"
+       x2="353.2262"
+       y2="701.10437" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9363"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25350812,0.05002971,-0.05002971,0.25350812,219.49264,629.39036)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9365"
+       gradientUnits="userSpaceOnUse"
+       x1="291.42554"
+       y1="700.13403"
+       x2="330.87399"
+       y2="700.13403" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9368"
+       gradientUnits="userSpaceOnUse"
+       x1="303.56204"
+       y1="754.18781"
+       x2="325.96439"
+       y2="754.18781" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9371"
+       gradientUnits="userSpaceOnUse"
+       x1="269.85611"
+       y1="754.6167"
+       x2="294.0094"
+       y2="754.6167" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9374"
+       gradientUnits="userSpaceOnUse"
+       x1="295.43027"
+       y1="734.26849"
+       x2="345.4668"
+       y2="734.26849" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9377"
+       gradientUnits="userSpaceOnUse"
+       x1="250.33974"
+       y1="729.77832"
+       x2="297.56638"
+       y2="729.77832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9380"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9382"
+       gradientUnits="userSpaceOnUse"
+       x1="309.05774"
+       y1="817.92242"
+       x2="314.82501"
+       y2="817.92242" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9385"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9387"
+       gradientUnits="userSpaceOnUse"
+       x1="303.78091"
+       y1="819.22729"
+       x2="310.23132"
+       y2="819.22729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9390"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9392"
+       gradientUnits="userSpaceOnUse"
+       x1="282.10596"
+       y1="818.7121"
+       x2="287.15155"
+       y2="818.7121" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9395"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9397"
+       gradientUnits="userSpaceOnUse"
+       x1="286.11386"
+       y1="819.38287"
+       x2="292.91504"
+       y2="819.38287" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9400"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9402"
+       gradientUnits="userSpaceOnUse"
+       x1="298.74692"
+       y1="819.18134"
+       x2="304.58972"
+       y2="819.18134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9405"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9407"
+       gradientUnits="userSpaceOnUse"
+       x1="294.4978"
+       y1="819.11469"
+       x2="299.91888"
+       y2="819.11469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9410"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9412"
+       gradientUnits="userSpaceOnUse"
+       x1="290.82614"
+       y1="818.85352"
+       x2="296.19809"
+       y2="818.85352" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9415"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9417"
+       gradientUnits="userSpaceOnUse"
+       x1="278.46292"
+       y1="817.44745"
+       x2="283.67633"
+       y2="817.44745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9420"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9422"
+       gradientUnits="userSpaceOnUse"
+       x1="273.5697"
+       y1="809.95294"
+       x2="279.13715"
+       y2="809.95294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9425"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9427"
+       gradientUnits="userSpaceOnUse"
+       x1="286.05246"
+       y1="811.08667"
+       x2="292.37634"
+       y2="811.08667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9430"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9432"
+       gradientUnits="userSpaceOnUse"
+       x1="277.0788"
+       y1="810.85791"
+       x2="282.93051"
+       y2="810.85791" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9435"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9437"
+       gradientUnits="userSpaceOnUse"
+       x1="281.71109"
+       y1="811.32458"
+       x2="288.35406"
+       y2="811.32458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9440"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9442"
+       gradientUnits="userSpaceOnUse"
+       x1="311.89224"
+       y1="810.47382"
+       x2="317.24081"
+       y2="810.47382" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9445"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9447"
+       gradientUnits="userSpaceOnUse"
+       x1="307.89148"
+       y1="810.79077"
+       x2="313.71567"
+       y2="810.79077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9450"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9452"
+       gradientUnits="userSpaceOnUse"
+       x1="301.31824"
+       y1="811.30737"
+       x2="309.44229"
+       y2="811.30737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9455"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9457"
+       gradientUnits="userSpaceOnUse"
+       x1="296.099"
+       y1="811.02704"
+       x2="304.15182"
+       y2="811.02704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9460"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9462"
+       gradientUnits="userSpaceOnUse"
+       x1="290.31046"
+       y1="811.10046"
+       x2="297.62442"
+       y2="811.10046" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9465"
+       gradientUnits="userSpaceOnUse"
+       x1="270.99255"
+       y1="811.80328"
+       x2="323.56433"
+       y2="811.80328" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9468"
+       gradientUnits="userSpaceOnUse"
+       x1="291.21497"
+       y1="785.36285"
+       x2="302.7421"
+       y2="785.36285" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9471"
+       gradientUnits="userSpaceOnUse"
+       x1="267.42975"
+       y1="772.61719"
+       x2="292.28888"
+       y2="772.61719" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9474"
+       gradientUnits="userSpaceOnUse"
+       x1="303.12097"
+       y1="773.41211"
+       x2="327.91367"
+       y2="773.41211" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9477"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,683.27393)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9479"
+       gradientUnits="userSpaceOnUse"
+       x1="251.05547"
+       y1="785.65112"
+       x2="341.3374"
+       y2="785.65112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,683.27393)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9484"
+       gradientUnits="userSpaceOnUse"
+       x1="248.36806"
+       y1="775.46729"
+       x2="347.362"
+       y2="775.46729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9720"
+       gradientUnits="userSpaceOnUse"
+       x1="89.027313"
+       y1="679.69513"
+       x2="104.81105"
+       y2="679.69513" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9723"
+       gradientUnits="userSpaceOnUse"
+       x1="102.75062"
+       y1="696.36688"
+       x2="113.71516"
+       y2="696.36688" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9726"
+       gradientUnits="userSpaceOnUse"
+       x1="79.976357"
+       y1="694.42743"
+       x2="87.355614"
+       y2="694.42743" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9729"
+       gradientUnits="userSpaceOnUse"
+       x1="92.34285"
+       y1="674.87982"
+       x2="101.94285"
+       y2="674.87982" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,652.36218)"
+       x1="281.48184"
+       y1="229.23729"
+       x2="481.76227"
+       y2="369.23727" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9734"
+       gradientUnits="userSpaceOnUse"
+       x1="41.481567"
+       y1="704.95374"
+       x2="122.85721"
+       y2="704.95374" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,652.36218)"
+       x1="476.83954"
+       y1="271.28894"
+       x2="527.15973"
+       y2="393.89273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9739"
+       gradientUnits="userSpaceOnUse"
+       x1="41.334755"
+       y1="731.93378"
+       x2="152.49365"
+       y2="731.93378" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,652.36218)"
+       x1="399.94489"
+       y1="107.97698"
+       x2="440"
+       y2="376.95392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9744"
+       gradientUnits="userSpaceOnUse"
+       x1="25.127617"
+       y1="707.44263"
+       x2="169.14285"
+       y2="707.44263" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,2.74286,654.19075)"
+       x1="493.99997"
+       y1="289.00003"
+       x2="659.67157"
+       y2="419.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9749"
+       gradientUnits="userSpaceOnUse"
+       x1="99.199997"
+       y1="735.10504"
+       x2="153.06779"
+       y2="735.10504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9752"
+       gradientUnits="userSpaceOnUse"
+       x1="103.56205"
+       y1="754.18781"
+       x2="125.9644"
+       y2="754.18781" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9755"
+       gradientUnits="userSpaceOnUse"
+       x1="69.856102"
+       y1="754.6167"
+       x2="94.009399"
+       y2="754.6167" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9758"
+       gradientUnits="userSpaceOnUse"
+       x1="96.1549"
+       y1="733.2984"
+       x2="145.4668"
+       y2="733.2984" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9761"
+       gradientUnits="userSpaceOnUse"
+       x1="56.282593"
+       y1="731.37836"
+       x2="98.93782"
+       y2="731.37836" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9764"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9766"
+       gradientUnits="userSpaceOnUse"
+       x1="109.05775"
+       y1="817.92242"
+       x2="114.82501"
+       y2="817.92242" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9769"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9771"
+       gradientUnits="userSpaceOnUse"
+       x1="103.78092"
+       y1="819.22729"
+       x2="110.23132"
+       y2="819.22729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9774"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9776"
+       gradientUnits="userSpaceOnUse"
+       x1="82.105972"
+       y1="818.7121"
+       x2="87.151558"
+       y2="818.7121" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9779"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9781"
+       gradientUnits="userSpaceOnUse"
+       x1="86.113861"
+       y1="819.38287"
+       x2="92.915047"
+       y2="819.38287" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9784"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9786"
+       gradientUnits="userSpaceOnUse"
+       x1="98.746925"
+       y1="819.18134"
+       x2="104.58971"
+       y2="819.18134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9789"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9791"
+       gradientUnits="userSpaceOnUse"
+       x1="94.497787"
+       y1="819.11469"
+       x2="99.918884"
+       y2="819.11469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9794"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9796"
+       gradientUnits="userSpaceOnUse"
+       x1="90.826149"
+       y1="818.85352"
+       x2="96.198097"
+       y2="818.85352" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9799"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9801"
+       gradientUnits="userSpaceOnUse"
+       x1="78.462914"
+       y1="817.44745"
+       x2="83.676331"
+       y2="817.44745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9804"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9806"
+       gradientUnits="userSpaceOnUse"
+       x1="73.569695"
+       y1="809.95294"
+       x2="79.137154"
+       y2="809.95294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9809"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9811"
+       gradientUnits="userSpaceOnUse"
+       x1="86.052475"
+       y1="811.08667"
+       x2="92.376343"
+       y2="811.08667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9814"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9816"
+       gradientUnits="userSpaceOnUse"
+       x1="77.078804"
+       y1="810.85791"
+       x2="82.930519"
+       y2="810.85791" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9819"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9821"
+       gradientUnits="userSpaceOnUse"
+       x1="81.71109"
+       y1="811.32458"
+       x2="88.35408"
+       y2="811.32458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9824"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9826"
+       gradientUnits="userSpaceOnUse"
+       x1="111.89223"
+       y1="810.47382"
+       x2="117.24081"
+       y2="810.47382" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9829"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9831"
+       gradientUnits="userSpaceOnUse"
+       x1="107.89149"
+       y1="810.79077"
+       x2="113.71567"
+       y2="810.79077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9834"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9836"
+       gradientUnits="userSpaceOnUse"
+       x1="101.31824"
+       y1="811.30737"
+       x2="109.44228"
+       y2="811.30737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9839"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9841"
+       gradientUnits="userSpaceOnUse"
+       x1="96.099007"
+       y1="811.02704"
+       x2="104.15182"
+       y2="811.02704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9844"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9846"
+       gradientUnits="userSpaceOnUse"
+       x1="90.310471"
+       y1="811.10046"
+       x2="97.624428"
+       y2="811.10046" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9849"
+       gradientUnits="userSpaceOnUse"
+       x1="70.992546"
+       y1="811.80328"
+       x2="123.56433"
+       y2="811.80328" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9852"
+       gradientUnits="userSpaceOnUse"
+       x1="91.214981"
+       y1="785.36285"
+       x2="102.7421"
+       y2="785.36285" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9855"
+       gradientUnits="userSpaceOnUse"
+       x1="67.429749"
+       y1="772.61719"
+       x2="92.288887"
+       y2="772.61719" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9858"
+       gradientUnits="userSpaceOnUse"
+       x1="103.12096"
+       y1="773.41211"
+       x2="127.91366"
+       y2="773.41211" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9861"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,683.27393)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9863"
+       gradientUnits="userSpaceOnUse"
+       x1="51.055473"
+       y1="785.65112"
+       x2="141.33739"
+       y2="785.65112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient9866"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,683.27393)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient9868"
+       gradientUnits="userSpaceOnUse"
+       x1="48.36805"
+       y1="775.46729"
+       x2="147.362"
+       y2="775.46729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15204"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15206"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15209"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,820.50808,216.26324)"
+       x1="794.93005"
+       y1="722.53284"
+       x2="770.78296"
+       y2="895.88794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="915.12128"
+       y1="827.7655"
+       x2="995.56488"
+       y2="827.7655" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15214"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="419.67706"
+       y1="352.28876"
+       x2="483.55563"
+       y2="352.28876" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15216"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="889.82465"
+       y1="707.5625"
+       x2="918.64362"
+       y2="707.5625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15219"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="511.89685"
+       y1="446.66107"
+       x2="611.99969"
+       y2="452.35666" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15221"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="935.57111"
+       y1="749.2525"
+       x2="970.36121"
+       y2="749.2525" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15224"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15226"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="943.98199"
+       y1="773.57001"
+       x2="978.1402"
+       y2="773.57001" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15229"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15231"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="942.90027"
+       y1="759.54755"
+       x2="963.38831"
+       y2="759.54755" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15234"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15236"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="928.04724"
+       y1="728.44061"
+       x2="955.7854"
+       y2="728.44061" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15239"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,98.88571)"
+       x1="456.65414"
+       y1="391.58966"
+       x2="566.70068"
+       y2="425.28772" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="908.91254"
+       y1="721.44269"
+       x2="943.30023"
+       y2="721.44269" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15244"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,98.88571)"
+       x1="280.6785"
+       y1="392.55249"
+       x2="406.05249"
+       y2="444.0405" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15246"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="818.10461"
+       y1="740.09766"
+       x2="892.47595"
+       y2="740.09766" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15249"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,98.88571)"
+       x1="433.81351"
+       y1="323.27167"
+       x2="357.96667"
+       y2="397.28345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15251"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="855.84723"
+       y1="722.4212"
+       x2="900.60809"
+       y2="722.4212" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15254"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,98.88571)"
+       x1="377.70755"
+       y1="413.54922"
+       x2="474.78088"
+       y2="505.35657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15256"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="819.7616"
+       y1="754.84851"
+       x2="916.59564"
+       y2="754.84851" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4302688,0.10689897,-0.10689897,0.4302688,770.98002,70.62779)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15261"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="951.49579"
+       y1="801.44019"
+       x2="981.25293"
+       y2="801.44019" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15264"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,710.97769,124.94002)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15266"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="950.06189"
+       y1="785.60187"
+       x2="970.54993"
+       y2="785.60187" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15269"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41219086,0.16327132,-0.16327132,0.41219086,809.62069,73.27961)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="952.53705"
+       y1="828.3324"
+       x2="979.31989"
+       y2="828.3324" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15274"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43887269,0.06284457,-0.06284457,0.43887269,743.78848,118.1578)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15276"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="951.61542"
+       y1="812.61157"
+       x2="969.87512"
+       y2="812.61157" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,825.76857,216.78144)"
+       x1="354.36316"
+       y1="724.97058"
+       x2="456.54602"
+       y2="864.27307" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="882.36829"
+       y1="828.97711"
+       x2="919.28955"
+       y2="828.97711" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15284"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="844.43134"
+       y1="762.97943"
+       x2="880.50171"
+       y2="762.97943" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15288"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1105.5277"
+       y1="768.68152"
+       x2="1123.5684"
+       y2="768.68152" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15291"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1078.9677"
+       y1="769.01947"
+       x2="1098.3879"
+       y2="769.01947" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1096.4777"
+       y1="750.44092"
+       x2="1137.5516"
+       y2="750.44092" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15297"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1064.5331"
+       y1="749.55829"
+       x2="1101.8083"
+       y2="749.55829" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15300"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15302"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1109.8584"
+       y1="818.90417"
+       x2="1114.7906"
+       y2="818.90417" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15305"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15307"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1105.7002"
+       y1="819.93237"
+       x2="1111.1707"
+       y2="819.93237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15310"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15312"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1088.6204"
+       y1="819.52643"
+       x2="1092.984"
+       y2="819.52643" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15315"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15317"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1091.7786"
+       y1="820.05499"
+       x2="1097.5256"
+       y2="820.05499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15320"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15322"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1101.7334"
+       y1="819.89618"
+       x2="1106.7252"
+       y2="819.89618" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15325"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15327"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1098.3851"
+       y1="819.84363"
+       x2="1103.0446"
+       y2="819.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15330"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15332"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1095.4919"
+       y1="819.63782"
+       x2="1100.1125"
+       y2="819.63782" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15335"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1085.7498"
+       y1="818.52991"
+       x2="1090.2455"
+       y2="818.52991" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1081.8938"
+       y1="812.62421"
+       x2="1086.6687"
+       y2="812.62421" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15345"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1091.7303"
+       y1="813.51758"
+       x2="1097.1011"
+       y2="813.51758" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1084.6591"
+       y1="813.33734"
+       x2="1089.658"
+       y2="813.33734" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15355"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15357"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1088.3092"
+       y1="813.70508"
+       x2="1093.9316"
+       y2="813.70508" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1112.0919"
+       y1="813.03467"
+       x2="1116.6942"
+       y2="813.03467" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15365"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15367"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1108.9393"
+       y1="813.28442"
+       x2="1113.9164"
+       y2="813.28442" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15372"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1103.7596"
+       y1="813.69153"
+       x2="1110.549"
+       y2="813.69153" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15377"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.3922"
+       y1="813.98004"
+       x2="1106.1254"
+       y2="813.98004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15380"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15382"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1095.0854"
+       y1="813.7832"
+       x2="1101.2366"
+       y2="813.7832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15385"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1079.6692"
+       y1="814.08228"
+       x2="1121.871"
+       y2="814.08228" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15388"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1095.9921"
+       y1="793.24731"
+       x2="1105.0754"
+       y2="793.24731" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1077.2495"
+       y1="783.2038"
+       x2="1096.8384"
+       y2="783.2038" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1105.374"
+       y1="783.8302"
+       x2="1124.9105"
+       y2="783.8302" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15397"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,260.43956)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15399"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1063.9589"
+       y1="793.47449"
+       x2="1135.876"
+       y2="793.47449" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,260.43956)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15404"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="1061.8412"
+       y1="785.44971"
+       x2="1140.6234"
+       y2="785.44971" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15408"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15410"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="660.17297"
+       y1="832.20099"
+       x2="668.17023"
+       y2="832.20099" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15413"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15415"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="654.81549"
+       y1="830.73816"
+       x2="662.13086"
+       y2="830.73816" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15418"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15420"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="657.91669"
+       y1="826.08704"
+       x2="664.66443"
+       y2="826.08704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15423"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15425"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="645.40851"
+       y1="814.61499"
+       x2="660.90442"
+       y2="814.61499" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15428"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15430"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="620.89111"
+       y1="801.65491"
+       x2="636.18115"
+       y2="801.65491" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="634.34662"
+       y1="806.43097"
+       x2="647.85767"
+       y2="806.43097" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15438"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15440"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="643.49298"
+       y1="828.16602"
+       x2="656.23871"
+       y2="828.16602" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15443"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15445"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="642.68994"
+       y1="823.18207"
+       x2="658.1192"
+       y2="823.18207" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15448"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="644.05774"
+       y1="820.00983"
+       x2="660.35205"
+       y2="820.00983" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15453"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15455"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="635.27271"
+       y1="825.64288"
+       x2="644.61847"
+       y2="825.64288" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15458"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15460"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="633.05316"
+       y1="819.85101"
+       x2="645.47211"
+       y2="819.85101" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15463"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,200.00018)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="633.10931"
+       y1="812.69128"
+       x2="645.08679"
+       y2="812.69128" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2349088,-0.0222509,0.02074117,0.21897029,589.12197,221.89266)"
+       x1="588.7981"
+       y1="217.56953"
+       x2="848.7243"
+       y2="456.71457" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15470"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="696.2522"
+       y1="764.69159"
+       x2="777.38123"
+       y2="764.69159" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="667.30975"
+       y1="768.87933"
+       x2="717.39886"
+       y2="768.87933" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="653.68457"
+       y1="829.35376"
+       x2="672.69208"
+       y2="829.35376" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15479"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,612.99887,197.41419)"
+       x1="158.89351"
+       y1="777.17603"
+       x2="380.3736"
+       y2="865.88708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15481"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="646.81274"
+       y1="828.37061"
+       x2="692.35657"
+       y2="828.37061" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15484"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16621349,0,0,0.19465989,628.27205,225.46461)"
+       x1="224.16286"
+       y1="330.27112"
+       x2="603.85291"
+       y2="818.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15486"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="638.94916"
+       y1="765.56342"
+       x2="760.61444"
+       y2="765.56342" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15490"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="438.85294"
+       y1="726.84784"
+       x2="460.22263"
+       y2="726.84784" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15493"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="486.30545"
+       y1="688.69989"
+       x2="489.61386"
+       y2="688.69989" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,199.73942)"
+       x1="459"
+       y1="322"
+       x2="539"
+       y2="322" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15498"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="505.93417"
+       y1="726.83801"
+       x2="524.81915"
+       y2="726.83801" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15501"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,395.68834,200.06766)"
+       x1="379.49451"
+       y1="419.62323"
+       x2="420.95035"
+       y2="419.62323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15503"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="485.9314"
+       y1="749.33234"
+       x2="495.89645"
+       y2="749.33234" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21089623,0,0,0.20696937,408.15849,207.81689)"
+       x1="242.74734"
+       y1="227.95091"
+       x2="563.46429"
+       y2="472.00671" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="477.81613"
+       y1="736.05231"
+       x2="524.61011"
+       y2="736.05231" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15511"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="539.29779"
+       y1="721.87408"
+       x2="562.30157"
+       y2="721.87408" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15514"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="428.48889"
+       y1="735.7572"
+       x2="437.39731"
+       y2="735.7572" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15517"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,199.73942)"
+       x1="749.64923"
+       y1="506.85049"
+       x2="297.93896"
+       y2="301.25592" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15519"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="475.8024"
+       y1="738.32703"
+       x2="528.16675"
+       y2="738.32703" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="480.60004"
+       y1="676.47284"
+       x2="513.27783"
+       y2="676.47284" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15526"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.44184,211.79502)"
+       x1="217.99556"
+       y1="116.56352"
+       x2="650.22534"
+       y2="599.48517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15528"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="422.84702"
+       y1="723.84576"
+       x2="570.11725"
+       y2="723.84576" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15531"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,199.73942)"
+       x1="313.02646"
+       y1="310.0217"
+       x2="436.50671"
+       y2="310.0217" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="471.41071"
+       y1="724.0578"
+       x2="500.57901"
+       y2="724.0578" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15536"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="473.91318"
+       y1="834.32428"
+       x2="544.76227"
+       y2="834.32428" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15539"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="447.76126"
+       y1="831.96173"
+       x2="474.34143"
+       y2="831.96173" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15542"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,450.40462,260.03275)"
+       x1="416.0477"
+       y1="150.12955"
+       x2="825.8576"
+       y2="861.172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15544"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="479.66254"
+       y1="786.77814"
+       x2="528.02679"
+       y2="786.77814" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15547"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,444.57813,254.5045)"
+       x1="128.10062"
+       y1="181.86472"
+       x2="740.29462"
+       y2="596.77478" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="466.40829"
+       y1="785.33112"
+       x2="521.17554"
+       y2="785.33112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15552"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20752777,0,0,0.20252572,402.21129,221.42122)"
+       x1="474.40475"
+       y1="587.78589"
+       x2="504.64395"
+       y2="893.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15554"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="442.63852"
+       y1="830.45563"
+       x2="551.50421"
+       y2="830.45563" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15558"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11992869,0.22888092,-0.22888092,0.11992869,349.94537,159.4885)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15560"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="330.8132"
+       y1="718.16827"
+       x2="376.71774"
+       y2="718.16827" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15563"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21288069,0.14646217,-0.14646217,-0.21288069,460.14377,274.62016)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15565"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="333.70978"
+       y1="745.37531"
+       x2="374.21063"
+       y2="745.37531" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15568"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25263337,-0.05427246,-0.05427246,-0.25263337,166.39915,355.6947)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15570"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="237.47273"
+       y1="735.98956"
+       x2="276.82419"
+       y2="735.98956" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15573"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17521554,0.18991817,0.18991817,-0.17521554,140.42014,252.41527)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15575"
+       gradientUnits="userSpaceOnUse"
+       x1="220.3288"
+       y1="949.39807"
+       x2="264.30008"
+       y2="949.39807"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15578"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01878479,0.25771406,0.25771406,-0.01878479,186.49259,188.38862)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15580"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="225.94441"
+       y1="738.22644"
+       x2="268.10242"
+       y2="738.22644" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15583"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0360752,0.25586697,-0.25586697,-0.0360752,415.39118,193.82528)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15585"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="327.52252"
+       y1="740.62958"
+       x2="370.69406"
+       y2="740.62958" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15588"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18003086,-0.18535932,0.18535932,0.18003086,137.82757,309.21063)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15590"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="218.64304"
+       y1="719.88123"
+       x2="262.31421"
+       y2="719.88123" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21515612,0.14309806,-0.14309806,0.21515612,287.8365,160.09625)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15595"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="330.13855"
+       y1="708.22577"
+       x2="369.46072"
+       y2="708.22577" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15598"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,0.25839749,188.42739,194.59257)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="268.76923"
+       y1="700.18445"
+       x2="308.60202"
+       y2="700.18445" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15603"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2533744,-0.05070034,-0.05070034,-0.2533744,183.87812,342.08324)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15605"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="255.67673"
+       y1="723.49133"
+       x2="295.1105"
+       y2="723.49133" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20518446,0.15706286,0.15706286,-0.20518446,220.83778,255.27984)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15610"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="305.77536"
+       y1="732.12555"
+       x2="347.23318"
+       y2="732.12555" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15613"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24741052,0.07454766,0.07454766,-0.24741052,208.13637,289.53915)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15615"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="295.19739"
+       y1="722.61737"
+       x2="333.04474"
+       y2="722.61737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15618"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.257896,0.01609282,0.01609282,-0.257896,200.37949,311.47026)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15620"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="282.76651"
+       y1="717.54517"
+       x2="322.43253"
+       y2="717.54517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15623"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,-0.25839749,186.1008,320.77166)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="266.44263"
+       y1="719.90375"
+       x2="306.27542"
+       y2="719.90375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15628"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22190492,-0.13239063,0.13239063,0.22190492,141.89787,269.00203)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="228.77269"
+       y1="710.81042"
+       x2="267.9151"
+       y2="710.81042" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15633"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24894286,-0.0692576,0.0692576,0.24894286,159.48142,225.80249)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15635"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="246.30501"
+       y1="700.01233"
+       x2="284.39862"
+       y2="700.01233" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15638"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23253349,0.11268297,-0.11268297,0.23253349,259.65879,160.14036)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15640"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="316.33826"
+       y1="701.10437"
+       x2="353.2262"
+       y2="701.10437" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15643"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25350812,0.05002971,-0.05002971,0.25350812,219.49264,177.02836)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15645"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="291.42554"
+       y1="700.13403"
+       x2="330.87399"
+       y2="700.13403" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15648"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="303.56204"
+       y1="754.18781"
+       x2="325.96439"
+       y2="754.18781" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15651"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="269.85611"
+       y1="754.6167"
+       x2="294.0094"
+       y2="754.6167" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15654"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="295.43027"
+       y1="734.26849"
+       x2="345.4668"
+       y2="734.26849" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="250.33974"
+       y1="729.77832"
+       x2="297.56638"
+       y2="729.77832" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15660"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15662"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="309.05774"
+       y1="817.92242"
+       x2="314.82501"
+       y2="817.92242" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15665"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15667"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="303.78091"
+       y1="819.22729"
+       x2="310.23132"
+       y2="819.22729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15670"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15672"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="282.10596"
+       y1="818.7121"
+       x2="287.15155"
+       y2="818.7121" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15675"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="286.11386"
+       y1="819.38287"
+       x2="292.91504"
+       y2="819.38287" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15680"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15682"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="298.74692"
+       y1="819.18134"
+       x2="304.58972"
+       y2="819.18134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15687"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="294.4978"
+       y1="819.11469"
+       x2="299.91888"
+       y2="819.11469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15690"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15692"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="290.82614"
+       y1="818.85352"
+       x2="296.19809"
+       y2="818.85352" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15695"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15697"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="278.46292"
+       y1="817.44745"
+       x2="283.67633"
+       y2="817.44745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15700"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15702"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="273.5697"
+       y1="809.95294"
+       x2="279.13715"
+       y2="809.95294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15705"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15707"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="286.05246"
+       y1="811.08667"
+       x2="292.37634"
+       y2="811.08667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15710"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15712"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="277.0788"
+       y1="810.85791"
+       x2="282.93051"
+       y2="810.85791" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15715"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15717"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="281.71109"
+       y1="811.32458"
+       x2="288.35406"
+       y2="811.32458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15720"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15722"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="311.89224"
+       y1="810.47382"
+       x2="317.24081"
+       y2="810.47382" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15725"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="307.89148"
+       y1="810.79077"
+       x2="313.71567"
+       y2="810.79077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15732"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="301.31824"
+       y1="811.30737"
+       x2="309.44229"
+       y2="811.30737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15735"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="296.099"
+       y1="811.02704"
+       x2="304.15182"
+       y2="811.02704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15740"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15742"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="290.31046"
+       y1="811.10046"
+       x2="297.62442"
+       y2="811.10046" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15745"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="270.99255"
+       y1="811.80328"
+       x2="323.56433"
+       y2="811.80328" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="291.21497"
+       y1="785.36285"
+       x2="302.7421"
+       y2="785.36285" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="267.42975"
+       y1="772.61719"
+       x2="292.28888"
+       y2="772.61719" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="303.12097"
+       y1="773.41211"
+       x2="327.91367"
+       y2="773.41211" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,230.91193)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="251.05547"
+       y1="785.65112"
+       x2="341.3374"
+       y2="785.65112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15762"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,230.91193)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="248.36806"
+       y1="775.46729"
+       x2="347.362"
+       y2="775.46729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15768"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="89.027313"
+       y1="679.69513"
+       x2="104.81105"
+       y2="679.69513" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="102.75062"
+       y1="696.36688"
+       x2="113.71516"
+       y2="696.36688" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="79.976357"
+       y1="694.42743"
+       x2="87.355614"
+       y2="694.42743" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15777"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="92.34285"
+       y1="674.87982"
+       x2="101.94285"
+       y2="674.87982" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15780"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200.00018)"
+       x1="281.48184"
+       y1="229.23729"
+       x2="481.76227"
+       y2="369.23727" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15782"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="41.481567"
+       y1="704.95374"
+       x2="122.85721"
+       y2="704.95374" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15785"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200.00018)"
+       x1="476.83954"
+       y1="271.28894"
+       x2="527.15973"
+       y2="393.89273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15787"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="41.334755"
+       y1="731.93378"
+       x2="152.49365"
+       y2="731.93378" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15790"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200.00018)"
+       x1="399.94489"
+       y1="107.97698"
+       x2="440"
+       y2="376.95392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15792"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="25.127617"
+       y1="707.44263"
+       x2="169.14285"
+       y2="707.44263" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,2.74286,201.82875)"
+       x1="493.99997"
+       y1="289.00003"
+       x2="659.67157"
+       y2="419.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15797"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="99.199997"
+       y1="735.10504"
+       x2="153.06779"
+       y2="735.10504" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15800"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="103.56205"
+       y1="754.18781"
+       x2="125.9644"
+       y2="754.18781" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="69.856102"
+       y1="754.6167"
+       x2="94.009399"
+       y2="754.6167" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="96.1549"
+       y1="733.2984"
+       x2="145.4668"
+       y2="733.2984" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15809"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="56.282593"
+       y1="731.37836"
+       x2="98.93782"
+       y2="731.37836" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15812"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15814"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="109.05775"
+       y1="817.92242"
+       x2="114.82501"
+       y2="817.92242" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15817"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15819"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="103.78092"
+       y1="819.22729"
+       x2="110.23132"
+       y2="819.22729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15822"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15824"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="82.105972"
+       y1="818.7121"
+       x2="87.151558"
+       y2="818.7121" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15827"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="86.113861"
+       y1="819.38287"
+       x2="92.915047"
+       y2="819.38287" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15832"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15834"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="98.746925"
+       y1="819.18134"
+       x2="104.58971"
+       y2="819.18134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15837"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="94.497787"
+       y1="819.11469"
+       x2="99.918884"
+       y2="819.11469" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="90.826149"
+       y1="818.85352"
+       x2="96.198097"
+       y2="818.85352" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15847"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15849"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="78.462914"
+       y1="817.44745"
+       x2="83.676331"
+       y2="817.44745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15852"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15854"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="73.569695"
+       y1="809.95294"
+       x2="79.137154"
+       y2="809.95294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15859"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="86.052475"
+       y1="811.08667"
+       x2="92.376343"
+       y2="811.08667" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15862"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15864"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="77.078804"
+       y1="810.85791"
+       x2="82.930519"
+       y2="810.85791" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15867"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="81.71109"
+       y1="811.32458"
+       x2="88.35408"
+       y2="811.32458" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15872"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15874"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="111.89223"
+       y1="810.47382"
+       x2="117.24081"
+       y2="810.47382" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15879"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="107.89149"
+       y1="810.79077"
+       x2="113.71567"
+       y2="810.79077" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15882"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15884"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="101.31824"
+       y1="811.30737"
+       x2="109.44228"
+       y2="811.30737" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15887"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15889"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="96.099007"
+       y1="811.02704"
+       x2="104.15182"
+       y2="811.02704" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15892"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15894"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="90.310471"
+       y1="811.10046"
+       x2="97.624428"
+       y2="811.10046" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="70.992546"
+       y1="811.80328"
+       x2="123.56433"
+       y2="811.80328" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15900"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="91.214981"
+       y1="785.36285"
+       x2="102.7421"
+       y2="785.36285" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15903"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="67.429749"
+       y1="772.61719"
+       x2="92.288887"
+       y2="772.61719" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15906"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="103.12096"
+       y1="773.41211"
+       x2="127.91366"
+       y2="773.41211" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15909"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,230.91193)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="51.055473"
+       y1="785.65112"
+       x2="141.33739"
+       y2="785.65112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient15914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,230.91193)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient15916"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-452.362)"
+       x1="48.36805"
+       y1="775.46729"
+       x2="147.362"
+       y2="775.46729" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15920"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.5277"
+       y1="768.68152"
+       x2="1123.5684"
+       y2="768.68152"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15923"
+       gradientUnits="userSpaceOnUse"
+       x1="1078.9677"
+       y1="769.01947"
+       x2="1098.3879"
+       y2="769.01947"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15926"
+       gradientUnits="userSpaceOnUse"
+       x1="1096.4777"
+       y1="750.44092"
+       x2="1137.5516"
+       y2="750.44092"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15929"
+       gradientUnits="userSpaceOnUse"
+       x1="1064.5331"
+       y1="749.55829"
+       x2="1101.8083"
+       y2="749.55829"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15932"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15934"
+       gradientUnits="userSpaceOnUse"
+       x1="1109.8584"
+       y1="818.90417"
+       x2="1114.7906"
+       y2="818.90417"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15937"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15939"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.7002"
+       y1="819.93237"
+       x2="1111.1707"
+       y2="819.93237"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15942"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15944"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.6204"
+       y1="819.52643"
+       x2="1092.984"
+       y2="819.52643"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15947"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15949"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7786"
+       y1="820.05499"
+       x2="1097.5256"
+       y2="820.05499"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15952"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15954"
+       gradientUnits="userSpaceOnUse"
+       x1="1101.7334"
+       y1="819.89618"
+       x2="1106.7252"
+       y2="819.89618"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15957"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15959"
+       gradientUnits="userSpaceOnUse"
+       x1="1098.3851"
+       y1="819.84363"
+       x2="1103.0446"
+       y2="819.84363"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15962"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15964"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.4919"
+       y1="819.63782"
+       x2="1100.1125"
+       y2="819.63782"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15967"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15969"
+       gradientUnits="userSpaceOnUse"
+       x1="1085.7498"
+       y1="818.52991"
+       x2="1090.2455"
+       y2="818.52991"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15972"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15974"
+       gradientUnits="userSpaceOnUse"
+       x1="1081.8938"
+       y1="812.62421"
+       x2="1086.6687"
+       y2="812.62421"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15977"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15979"
+       gradientUnits="userSpaceOnUse"
+       x1="1091.7303"
+       y1="813.51758"
+       x2="1097.1011"
+       y2="813.51758"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15982"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15984"
+       gradientUnits="userSpaceOnUse"
+       x1="1084.6591"
+       y1="813.33734"
+       x2="1089.658"
+       y2="813.33734"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15987"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15989"
+       gradientUnits="userSpaceOnUse"
+       x1="1088.3092"
+       y1="813.70508"
+       x2="1093.9316"
+       y2="813.70508"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15992"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15994"
+       gradientUnits="userSpaceOnUse"
+       x1="1112.0919"
+       y1="813.03467"
+       x2="1116.6942"
+       y2="813.03467"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient15997"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient15999"
+       gradientUnits="userSpaceOnUse"
+       x1="1108.9393"
+       y1="813.28442"
+       x2="1113.9164"
+       y2="813.28442"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16002"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16004"
+       gradientUnits="userSpaceOnUse"
+       x1="1103.7596"
+       y1="813.69153"
+       x2="1110.549"
+       y2="813.69153"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16007"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16009"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.3922"
+       y1="813.98004"
+       x2="1106.1254"
+       y2="813.98004"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16012"
+       gradientUnits="userSpaceOnUse"
+       x1="1099.0664"
+       y1="814.13776"
+       x2="1099.5216"
+       y2="805.04639"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16014"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.0854"
+       y1="813.7832"
+       x2="1101.2366"
+       y2="813.7832"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16017"
+       gradientUnits="userSpaceOnUse"
+       x1="1079.6692"
+       y1="814.08228"
+       x2="1121.871"
+       y2="814.08228"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16020"
+       gradientUnits="userSpaceOnUse"
+       x1="1095.9921"
+       y1="793.24731"
+       x2="1105.0754"
+       y2="793.24731"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16023"
+       gradientUnits="userSpaceOnUse"
+       x1="1077.2495"
+       y1="783.2038"
+       x2="1096.8384"
+       y2="783.2038"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16026"
+       gradientUnits="userSpaceOnUse"
+       x1="1105.374"
+       y1="783.8302"
+       x2="1124.9105"
+       y2="783.8302"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,60.43956)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16031"
+       gradientUnits="userSpaceOnUse"
+       x1="1063.9589"
+       y1="793.47449"
+       x2="1135.876"
+       y2="793.47449"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16034"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17246857,0,0,0.17246857,1025.0368,60.43956)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16036"
+       gradientUnits="userSpaceOnUse"
+       x1="1061.8412"
+       y1="785.44971"
+       x2="1140.6234"
+       y2="785.44971"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16040"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16042"
+       gradientUnits="userSpaceOnUse"
+       x1="866.35437"
+       y1="720.33911"
+       x2="880.85162"
+       y2="720.33911"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16045"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,820.50808,16.26324)"
+       x1="794.93005"
+       y1="722.53284"
+       x2="770.78296"
+       y2="895.88794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16047"
+       gradientUnits="userSpaceOnUse"
+       x1="915.12128"
+       y1="827.7655"
+       x2="995.56488"
+       y2="827.7655"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16050"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="419.67706"
+       y1="352.28876"
+       x2="483.55563"
+       y2="352.28876" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16052"
+       gradientUnits="userSpaceOnUse"
+       x1="889.82465"
+       y1="707.5625"
+       x2="918.64362"
+       y2="707.5625"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="511.89685"
+       y1="446.66107"
+       x2="611.99969"
+       y2="452.35666" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16057"
+       gradientUnits="userSpaceOnUse"
+       x1="935.57111"
+       y1="749.2525"
+       x2="970.36121"
+       y2="749.2525"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16062"
+       gradientUnits="userSpaceOnUse"
+       x1="943.98199"
+       y1="773.57001"
+       x2="978.1402"
+       y2="773.57001"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16065"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16067"
+       gradientUnits="userSpaceOnUse"
+       x1="942.90027"
+       y1="759.54755"
+       x2="963.38831"
+       y2="759.54755"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16072"
+       gradientUnits="userSpaceOnUse"
+       x1="928.04724"
+       y1="728.44061"
+       x2="955.7854"
+       y2="728.44061"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,703.81609,-101.11429)"
+       x1="456.65414"
+       y1="391.58966"
+       x2="566.70068"
+       y2="425.28772" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16077"
+       gradientUnits="userSpaceOnUse"
+       x1="908.91254"
+       y1="721.44269"
+       x2="943.30023"
+       y2="721.44269"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16080"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,-101.11429)"
+       x1="280.6785"
+       y1="392.55249"
+       x2="406.05249"
+       y2="444.0405" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16082"
+       gradientUnits="userSpaceOnUse"
+       x1="818.10461"
+       y1="740.09766"
+       x2="892.47595"
+       y2="740.09766"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16085"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,-101.11429)"
+       x1="433.81351"
+       y1="323.27167"
+       x2="357.96667"
+       y2="397.28345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16087"
+       gradientUnits="userSpaceOnUse"
+       x1="855.84723"
+       y1="722.4212"
+       x2="900.60809"
+       y2="722.4212"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16090"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,706.10181,-101.11429)"
+       x1="377.70755"
+       y1="413.54922"
+       x2="474.78088"
+       y2="505.35657" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16092"
+       gradientUnits="userSpaceOnUse"
+       x1="819.7616"
+       y1="754.84851"
+       x2="916.59564"
+       y2="754.84851"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4302688,0.10689897,-0.10689897,0.4302688,770.98002,-129.37221)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16097"
+       gradientUnits="userSpaceOnUse"
+       x1="951.49579"
+       y1="801.44019"
+       x2="981.25293"
+       y2="801.44019"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16100"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44334949,0,0,0.44334949,710.97769,-75.05998)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16102"
+       gradientUnits="userSpaceOnUse"
+       x1="950.06189"
+       y1="785.60187"
+       x2="970.54993"
+       y2="785.60187"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41219086,0.16327132,-0.16327132,0.41219086,809.62069,-126.72039)"
+       x1="522.39294"
+       y1="485.50229"
+       x2="618.62885"
+       y2="469.00677" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16107"
+       gradientUnits="userSpaceOnUse"
+       x1="952.53705"
+       y1="828.3324"
+       x2="979.31989"
+       y2="828.3324"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16110"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43887269,0.06284457,-0.06284457,0.43887269,743.78848,-81.8422)"
+       x1="462.73083"
+       y1="428.60229"
+       x2="618.62885"
+       y2="428.60229" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16112"
+       gradientUnits="userSpaceOnUse"
+       x1="951.61542"
+       y1="812.61157"
+       x2="969.87512"
+       y2="812.61157"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2096576,0,0,0.2096576,825.76857,16.78144)"
+       x1="354.36316"
+       y1="724.97058"
+       x2="456.54602"
+       y2="864.27307" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16117"
+       gradientUnits="userSpaceOnUse"
+       x1="882.36829"
+       y1="828.97711"
+       x2="919.28955"
+       y2="828.97711"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16120"
+       gradientUnits="userSpaceOnUse"
+       x1="844.43134"
+       y1="762.97943"
+       x2="880.50171"
+       y2="762.97943"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16126"
+       gradientUnits="userSpaceOnUse"
+       x1="660.17297"
+       y1="832.20099"
+       x2="668.17023"
+       y2="832.20099"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16131"
+       gradientUnits="userSpaceOnUse"
+       x1="654.81549"
+       y1="830.73816"
+       x2="662.13086"
+       y2="830.73816"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16134"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16136"
+       gradientUnits="userSpaceOnUse"
+       x1="657.91669"
+       y1="826.08704"
+       x2="664.66443"
+       y2="826.08704"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16139"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16141"
+       gradientUnits="userSpaceOnUse"
+       x1="645.40851"
+       y1="814.61499"
+       x2="660.90442"
+       y2="814.61499"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16144"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16146"
+       gradientUnits="userSpaceOnUse"
+       x1="620.89111"
+       y1="801.65491"
+       x2="636.18115"
+       y2="801.65491"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16149"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16151"
+       gradientUnits="userSpaceOnUse"
+       x1="634.34662"
+       y1="806.43097"
+       x2="647.85767"
+       y2="806.43097"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16154"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16156"
+       gradientUnits="userSpaceOnUse"
+       x1="643.49298"
+       y1="828.16602"
+       x2="656.23871"
+       y2="828.16602"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16161"
+       gradientUnits="userSpaceOnUse"
+       x1="642.68994"
+       y1="823.18207"
+       x2="658.1192"
+       y2="823.18207"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16164"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16166"
+       gradientUnits="userSpaceOnUse"
+       x1="644.05774"
+       y1="820.00983"
+       x2="660.35205"
+       y2="820.00983"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16171"
+       gradientUnits="userSpaceOnUse"
+       x1="635.27271"
+       y1="825.64288"
+       x2="644.61847"
+       y2="825.64288"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16174"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16176"
+       gradientUnits="userSpaceOnUse"
+       x1="633.05316"
+       y1="819.85101"
+       x2="645.47211"
+       y2="819.85101"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16179"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,606.85714,1.8e-4)"
+       x1="164.82167"
+       y1="730.83307"
+       x2="324.81335"
+       y2="842.55597" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16181"
+       gradientUnits="userSpaceOnUse"
+       x1="633.10931"
+       y1="812.69128"
+       x2="645.08679"
+       y2="812.69128"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2349088,-0.0222509,0.02074117,0.21897029,589.12197,21.89266)"
+       x1="588.7981"
+       y1="217.56953"
+       x2="848.7243"
+       y2="456.71457" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16186"
+       gradientUnits="userSpaceOnUse"
+       x1="696.2522"
+       y1="764.69159"
+       x2="777.38123"
+       y2="764.69159"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16189"
+       gradientUnits="userSpaceOnUse"
+       x1="667.30975"
+       y1="768.87933"
+       x2="717.39886"
+       y2="768.87933"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16192"
+       gradientUnits="userSpaceOnUse"
+       x1="653.68457"
+       y1="829.35376"
+       x2="672.69208"
+       y2="829.35376"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16195"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,612.99887,-2.58581)"
+       x1="158.89351"
+       y1="777.17603"
+       x2="380.3736"
+       y2="865.88708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16197"
+       gradientUnits="userSpaceOnUse"
+       x1="646.81274"
+       y1="828.37061"
+       x2="692.35657"
+       y2="828.37061"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16200"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16621349,0,0,0.19465989,628.27205,25.46461)"
+       x1="224.16286"
+       y1="330.27112"
+       x2="603.85291"
+       y2="818.84363" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16202"
+       gradientUnits="userSpaceOnUse"
+       x1="638.94916"
+       y1="765.56342"
+       x2="760.61444"
+       y2="765.56342"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16206"
+       gradientUnits="userSpaceOnUse"
+       x1="438.85294"
+       y1="726.84784"
+       x2="460.22263"
+       y2="726.84784"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16209"
+       gradientUnits="userSpaceOnUse"
+       x1="486.30545"
+       y1="688.69989"
+       x2="489.61386"
+       y2="688.69989"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,-0.26058)"
+       x1="459"
+       y1="322"
+       x2="539"
+       y2="322" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16214"
+       gradientUnits="userSpaceOnUse"
+       x1="505.93417"
+       y1="726.83801"
+       x2="524.81915"
+       y2="726.83801"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,395.68834,0.06766)"
+       x1="379.49451"
+       y1="419.62323"
+       x2="420.95035"
+       y2="419.62323" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16219"
+       gradientUnits="userSpaceOnUse"
+       x1="485.9314"
+       y1="749.33234"
+       x2="495.89645"
+       y2="749.33234"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16222"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21089623,0,0,0.20696937,408.15849,7.81689)"
+       x1="242.74734"
+       y1="227.95091"
+       x2="563.46429"
+       y2="472.00671" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16224"
+       gradientUnits="userSpaceOnUse"
+       x1="477.81613"
+       y1="736.05231"
+       x2="524.61011"
+       y2="736.05231"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16227"
+       gradientUnits="userSpaceOnUse"
+       x1="539.29779"
+       y1="721.87408"
+       x2="562.30157"
+       y2="721.87408"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16230"
+       gradientUnits="userSpaceOnUse"
+       x1="428.48889"
+       y1="735.7572"
+       x2="437.39731"
+       y2="735.7572"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16233"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,-0.26058)"
+       x1="749.64923"
+       y1="506.85049"
+       x2="297.93896"
+       y2="301.25592" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16235"
+       gradientUnits="userSpaceOnUse"
+       x1="475.8024"
+       y1="738.32703"
+       x2="528.16675"
+       y2="738.32703"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16238"
+       gradientUnits="userSpaceOnUse"
+       x1="480.60004"
+       y1="676.47284"
+       x2="513.27783"
+       y2="676.47284"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16242"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.44184,11.79502)"
+       x1="217.99556"
+       y1="116.56352"
+       x2="650.22534"
+       y2="599.48517" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16244"
+       gradientUnits="userSpaceOnUse"
+       x1="422.84702"
+       y1="723.84576"
+       x2="570.11725"
+       y2="723.84576"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16247"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23650492,0,0,0.23210126,397.36069,-0.26058)"
+       x1="313.02646"
+       y1="310.0217"
+       x2="436.50671"
+       y2="310.0217" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16249"
+       gradientUnits="userSpaceOnUse"
+       x1="471.41071"
+       y1="724.0578"
+       x2="500.57901"
+       y2="724.0578"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16252"
+       gradientUnits="userSpaceOnUse"
+       x1="473.91318"
+       y1="834.32428"
+       x2="544.76227"
+       y2="834.32428"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16255"
+       gradientUnits="userSpaceOnUse"
+       x1="447.76126"
+       y1="831.96173"
+       x2="474.34143"
+       y2="831.96173"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16258"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,450.40462,60.03275)"
+       x1="416.0477"
+       y1="150.12955"
+       x2="825.8576"
+       y2="861.172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16260"
+       gradientUnits="userSpaceOnUse"
+       x1="479.66254"
+       y1="786.77814"
+       x2="528.02679"
+       y2="786.77814"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12666217,0,0,0.16138286,444.57813,54.5045)"
+       x1="128.10062"
+       y1="181.86472"
+       x2="740.29462"
+       y2="596.77478" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16265"
+       gradientUnits="userSpaceOnUse"
+       x1="466.40829"
+       y1="785.33112"
+       x2="521.17554"
+       y2="785.33112"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16268"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20752777,0,0,0.20252572,402.21129,21.42122)"
+       x1="474.40475"
+       y1="587.78589"
+       x2="504.64395"
+       y2="893.35999" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16270"
+       gradientUnits="userSpaceOnUse"
+       x1="442.63852"
+       y1="830.45563"
+       x2="551.50421"
+       y2="830.45563"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16274"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11992869,0.22888092,-0.22888092,0.11992869,349.94537,-40.5115)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16276"
+       gradientUnits="userSpaceOnUse"
+       x1="330.8132"
+       y1="718.16827"
+       x2="376.71774"
+       y2="718.16827"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.21288069,0.14646217,-0.14646217,-0.21288069,460.14377,74.62016)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16281"
+       gradientUnits="userSpaceOnUse"
+       x1="333.70978"
+       y1="745.37531"
+       x2="374.21063"
+       y2="745.37531"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16284"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25263337,-0.05427246,-0.05427246,-0.25263337,166.39915,155.69474)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16286"
+       gradientUnits="userSpaceOnUse"
+       x1="237.47273"
+       y1="735.98956"
+       x2="276.82419"
+       y2="735.98956"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16289"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17521554,0.18991817,0.18991817,-0.17521554,140.42014,52.41527)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16291"
+       gradientUnits="userSpaceOnUse"
+       x1="220.3288"
+       y1="749.39807"
+       x2="264.30008"
+       y2="749.39807"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16294"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01878479,0.25771406,0.25771406,-0.01878479,186.49259,-11.61138)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16296"
+       gradientUnits="userSpaceOnUse"
+       x1="225.94441"
+       y1="738.22644"
+       x2="268.10242"
+       y2="738.22644"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16299"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0360752,0.25586697,-0.25586697,-0.0360752,415.39118,-6.17472)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16301"
+       gradientUnits="userSpaceOnUse"
+       x1="327.52252"
+       y1="740.62958"
+       x2="370.69406"
+       y2="740.62958"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16304"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18003086,-0.18535932,0.18535932,0.18003086,137.82757,109.21063)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16306"
+       gradientUnits="userSpaceOnUse"
+       x1="218.64304"
+       y1="719.88123"
+       x2="262.31421"
+       y2="719.88123"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21515612,0.14309806,-0.14309806,0.21515612,287.8365,-39.90375)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16311"
+       gradientUnits="userSpaceOnUse"
+       x1="330.13855"
+       y1="708.22577"
+       x2="369.46072"
+       y2="708.22577"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16314"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,0.25839749,188.42739,-5.40743)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16316"
+       gradientUnits="userSpaceOnUse"
+       x1="268.76923"
+       y1="700.18445"
+       x2="308.60202"
+       y2="700.18445"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16319"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2533744,-0.05070034,-0.05070034,-0.2533744,183.87812,142.08324)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16321"
+       gradientUnits="userSpaceOnUse"
+       x1="255.67673"
+       y1="723.49133"
+       x2="295.1105"
+       y2="723.49133"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16324"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.20518446,0.15706286,0.15706286,-0.20518446,220.83778,55.27984)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16326"
+       gradientUnits="userSpaceOnUse"
+       x1="305.77536"
+       y1="732.12555"
+       x2="347.23318"
+       y2="732.12555"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16329"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24741052,0.07454766,0.07454766,-0.24741052,208.13637,89.53915)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16331"
+       gradientUnits="userSpaceOnUse"
+       x1="295.19739"
+       y1="722.61737"
+       x2="333.04474"
+       y2="722.61737"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16334"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.257896,0.01609282,0.01609282,-0.257896,200.37949,111.47026)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16336"
+       gradientUnits="userSpaceOnUse"
+       x1="282.76651"
+       y1="717.54517"
+       x2="322.43253"
+       y2="717.54517"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25839749,0,0,-0.25839749,186.1008,120.77166)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16341"
+       gradientUnits="userSpaceOnUse"
+       x1="266.44263"
+       y1="719.90375"
+       x2="306.27542"
+       y2="719.90375"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16344"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22190492,-0.13239063,0.13239063,0.22190492,141.89787,69.00203)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16346"
+       gradientUnits="userSpaceOnUse"
+       x1="228.77269"
+       y1="710.81042"
+       x2="267.9151"
+       y2="710.81042"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16349"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24894286,-0.0692576,0.0692576,0.24894286,159.48142,25.80249)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16351"
+       gradientUnits="userSpaceOnUse"
+       x1="246.30501"
+       y1="700.01233"
+       x2="284.39862"
+       y2="700.01233"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.23253349,0.11268297,-0.11268297,0.23253349,259.65879,-39.85964)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16356"
+       gradientUnits="userSpaceOnUse"
+       x1="316.33826"
+       y1="701.10437"
+       x2="353.2262"
+       y2="701.10437"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25350812,0.05002971,-0.05002971,0.25350812,219.49264,-22.97164)"
+       x1="405"
+       y1="176.00002"
+       x2="402"
+       y2="281" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16361"
+       gradientUnits="userSpaceOnUse"
+       x1="291.42554"
+       y1="700.13403"
+       x2="330.87399"
+       y2="700.13403"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16364"
+       gradientUnits="userSpaceOnUse"
+       x1="303.56204"
+       y1="754.18781"
+       x2="325.96439"
+       y2="754.18781"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16367"
+       gradientUnits="userSpaceOnUse"
+       x1="269.85611"
+       y1="754.6167"
+       x2="294.0094"
+       y2="754.6167"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16370"
+       gradientUnits="userSpaceOnUse"
+       x1="295.43027"
+       y1="734.26849"
+       x2="345.4668"
+       y2="734.26849"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16373"
+       gradientUnits="userSpaceOnUse"
+       x1="250.33974"
+       y1="729.77832"
+       x2="297.56638"
+       y2="729.77832"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16376"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16378"
+       gradientUnits="userSpaceOnUse"
+       x1="309.05774"
+       y1="817.92242"
+       x2="314.82501"
+       y2="817.92242"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16381"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16383"
+       gradientUnits="userSpaceOnUse"
+       x1="303.78091"
+       y1="819.22729"
+       x2="310.23132"
+       y2="819.22729"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16386"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16388"
+       gradientUnits="userSpaceOnUse"
+       x1="282.10596"
+       y1="818.7121"
+       x2="287.15155"
+       y2="818.7121"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16391"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16393"
+       gradientUnits="userSpaceOnUse"
+       x1="286.11386"
+       y1="819.38287"
+       x2="292.91504"
+       y2="819.38287"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16396"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16398"
+       gradientUnits="userSpaceOnUse"
+       x1="298.74692"
+       y1="819.18134"
+       x2="304.58972"
+       y2="819.18134"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16401"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16403"
+       gradientUnits="userSpaceOnUse"
+       x1="294.4978"
+       y1="819.11469"
+       x2="299.91888"
+       y2="819.11469"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16406"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16408"
+       gradientUnits="userSpaceOnUse"
+       x1="290.82614"
+       y1="818.85352"
+       x2="296.19809"
+       y2="818.85352"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16411"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16413"
+       gradientUnits="userSpaceOnUse"
+       x1="278.46292"
+       y1="817.44745"
+       x2="283.67633"
+       y2="817.44745"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16416"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16418"
+       gradientUnits="userSpaceOnUse"
+       x1="273.5697"
+       y1="809.95294"
+       x2="279.13715"
+       y2="809.95294"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16421"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16423"
+       gradientUnits="userSpaceOnUse"
+       x1="286.05246"
+       y1="811.08667"
+       x2="292.37634"
+       y2="811.08667"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16426"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16428"
+       gradientUnits="userSpaceOnUse"
+       x1="277.0788"
+       y1="810.85791"
+       x2="282.93051"
+       y2="810.85791"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16431"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16433"
+       gradientUnits="userSpaceOnUse"
+       x1="281.71109"
+       y1="811.32458"
+       x2="288.35406"
+       y2="811.32458"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16436"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16438"
+       gradientUnits="userSpaceOnUse"
+       x1="311.89224"
+       y1="810.47382"
+       x2="317.24081"
+       y2="810.47382"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16441"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16443"
+       gradientUnits="userSpaceOnUse"
+       x1="307.89148"
+       y1="810.79077"
+       x2="313.71567"
+       y2="810.79077"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16446"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16448"
+       gradientUnits="userSpaceOnUse"
+       x1="301.31824"
+       y1="811.30737"
+       x2="309.44229"
+       y2="811.30737"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16451"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16453"
+       gradientUnits="userSpaceOnUse"
+       x1="296.099"
+       y1="811.02704"
+       x2="304.15182"
+       y2="811.02704"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16456"
+       gradientUnits="userSpaceOnUse"
+       x1="297.81335"
+       y1="815.44781"
+       x2="298.04791"
+       y2="800.29547"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16458"
+       gradientUnits="userSpaceOnUse"
+       x1="290.31046"
+       y1="811.10046"
+       x2="297.62442"
+       y2="811.10046"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16461"
+       gradientUnits="userSpaceOnUse"
+       x1="270.99255"
+       y1="811.80328"
+       x2="323.56433"
+       y2="811.80328"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16464"
+       gradientUnits="userSpaceOnUse"
+       x1="291.21497"
+       y1="785.36285"
+       x2="302.7421"
+       y2="785.36285"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16467"
+       gradientUnits="userSpaceOnUse"
+       x1="267.42975"
+       y1="772.61719"
+       x2="292.28888"
+       y2="772.61719"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16470"
+       gradientUnits="userSpaceOnUse"
+       x1="303.12097"
+       y1="773.41211"
+       x2="327.91367"
+       y2="773.41211"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,30.91193)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16475"
+       gradientUnits="userSpaceOnUse"
+       x1="251.05547"
+       y1="785.65112"
+       x2="341.3374"
+       y2="785.65112"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16478"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,201.16977,30.91193)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16480"
+       gradientUnits="userSpaceOnUse"
+       x1="248.36806"
+       y1="775.46729"
+       x2="347.362"
+       y2="775.46729"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16484"
+       gradientUnits="userSpaceOnUse"
+       x1="89.027313"
+       y1="679.69513"
+       x2="104.81105"
+       y2="679.69513"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16487"
+       gradientUnits="userSpaceOnUse"
+       x1="102.75062"
+       y1="696.36688"
+       x2="113.71516"
+       y2="696.36688"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16490"
+       gradientUnits="userSpaceOnUse"
+       x1="79.976357"
+       y1="694.42743"
+       x2="87.355614"
+       y2="694.42743"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16493"
+       gradientUnits="userSpaceOnUse"
+       x1="92.34285"
+       y1="674.87982"
+       x2="101.94285"
+       y2="674.87982"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,1.8e-4)"
+       x1="281.48184"
+       y1="229.23729"
+       x2="481.76227"
+       y2="369.23727" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16498"
+       gradientUnits="userSpaceOnUse"
+       x1="41.481567"
+       y1="704.95374"
+       x2="122.85721"
+       y2="704.95374"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16501"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,1.8e-4)"
+       x1="476.83954"
+       y1="271.28894"
+       x2="527.15973"
+       y2="393.89273" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16503"
+       gradientUnits="userSpaceOnUse"
+       x1="41.334755"
+       y1="731.93378"
+       x2="152.49365"
+       y2="731.93378"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,1.8e-4)"
+       x1="399.94489"
+       y1="107.97698"
+       x2="440"
+       y2="376.95392" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16508"
+       gradientUnits="userSpaceOnUse"
+       x1="25.127617"
+       y1="707.44263"
+       x2="169.14285"
+       y2="707.44263"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16511"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,2.74286,1.82875)"
+       x1="493.99997"
+       y1="289.00003"
+       x2="659.67157"
+       y2="419.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16513"
+       gradientUnits="userSpaceOnUse"
+       x1="99.199997"
+       y1="735.10504"
+       x2="153.06779"
+       y2="735.10504"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16516"
+       gradientUnits="userSpaceOnUse"
+       x1="103.56205"
+       y1="754.18781"
+       x2="125.9644"
+       y2="754.18781"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16519"
+       gradientUnits="userSpaceOnUse"
+       x1="69.856102"
+       y1="754.6167"
+       x2="94.009399"
+       y2="754.6167"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16522"
+       gradientUnits="userSpaceOnUse"
+       x1="96.1549"
+       y1="733.2984"
+       x2="145.4668"
+       y2="733.2984"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16525"
+       gradientUnits="userSpaceOnUse"
+       x1="56.282593"
+       y1="731.37836"
+       x2="98.93782"
+       y2="731.37836"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16528"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16530"
+       gradientUnits="userSpaceOnUse"
+       x1="109.05775"
+       y1="817.92242"
+       x2="114.82501"
+       y2="817.92242"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16533"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16535"
+       gradientUnits="userSpaceOnUse"
+       x1="103.78092"
+       y1="819.22729"
+       x2="110.23132"
+       y2="819.22729"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16538"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16540"
+       gradientUnits="userSpaceOnUse"
+       x1="82.105972"
+       y1="818.7121"
+       x2="87.151558"
+       y2="818.7121"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16543"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16545"
+       gradientUnits="userSpaceOnUse"
+       x1="86.113861"
+       y1="819.38287"
+       x2="92.915047"
+       y2="819.38287"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16548"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16550"
+       gradientUnits="userSpaceOnUse"
+       x1="98.746925"
+       y1="819.18134"
+       x2="104.58971"
+       y2="819.18134"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16553"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16555"
+       gradientUnits="userSpaceOnUse"
+       x1="94.497787"
+       y1="819.11469"
+       x2="99.918884"
+       y2="819.11469"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16558"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16560"
+       gradientUnits="userSpaceOnUse"
+       x1="90.826149"
+       y1="818.85352"
+       x2="96.198097"
+       y2="818.85352"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16563"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16565"
+       gradientUnits="userSpaceOnUse"
+       x1="78.462914"
+       y1="817.44745"
+       x2="83.676331"
+       y2="817.44745"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16568"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16570"
+       gradientUnits="userSpaceOnUse"
+       x1="73.569695"
+       y1="809.95294"
+       x2="79.137154"
+       y2="809.95294"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16573"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16575"
+       gradientUnits="userSpaceOnUse"
+       x1="86.052475"
+       y1="811.08667"
+       x2="92.376343"
+       y2="811.08667"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16578"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16580"
+       gradientUnits="userSpaceOnUse"
+       x1="77.078804"
+       y1="810.85791"
+       x2="82.930519"
+       y2="810.85791"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16583"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16585"
+       gradientUnits="userSpaceOnUse"
+       x1="81.71109"
+       y1="811.32458"
+       x2="88.35408"
+       y2="811.32458"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16588"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16590"
+       gradientUnits="userSpaceOnUse"
+       x1="111.89223"
+       y1="810.47382"
+       x2="117.24081"
+       y2="810.47382"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16593"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16595"
+       gradientUnits="userSpaceOnUse"
+       x1="107.89149"
+       y1="810.79077"
+       x2="113.71567"
+       y2="810.79077"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16598"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16600"
+       gradientUnits="userSpaceOnUse"
+       x1="101.31824"
+       y1="811.30737"
+       x2="109.44228"
+       y2="811.30737"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16603"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16605"
+       gradientUnits="userSpaceOnUse"
+       x1="96.099007"
+       y1="811.02704"
+       x2="104.15182"
+       y2="811.02704"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16608"
+       gradientUnits="userSpaceOnUse"
+       x1="97.813354"
+       y1="817.46808"
+       x2="97.542831"
+       y2="802.82086"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16610"
+       gradientUnits="userSpaceOnUse"
+       x1="90.310471"
+       y1="811.10046"
+       x2="97.624428"
+       y2="811.10046"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16613"
+       gradientUnits="userSpaceOnUse"
+       x1="70.992546"
+       y1="811.80328"
+       x2="123.56433"
+       y2="811.80328"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16616"
+       gradientUnits="userSpaceOnUse"
+       x1="91.214981"
+       y1="785.36285"
+       x2="102.7421"
+       y2="785.36285"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16619"
+       gradientUnits="userSpaceOnUse"
+       x1="67.429749"
+       y1="772.61719"
+       x2="92.288887"
+       y2="772.61719"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16622"
+       gradientUnits="userSpaceOnUse"
+       x1="103.12096"
+       y1="773.41211"
+       x2="127.91366"
+       y2="773.41211"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,30.91193)"
+       x1="403.64108"
+       y1="286.73438"
+       x2="535.96454"
+       y2="715.77893" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16627"
+       gradientUnits="userSpaceOnUse"
+       x1="51.055473"
+       y1="785.65112"
+       x2="141.33739"
+       y2="785.65112"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient16630"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21886972,0,0,0.21886972,1.16977,30.91193)"
+       x1="317.82336"
+       y1="251.51895"
+       x2="716.78424"
+       y2="1040.8939" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16632"
+       gradientUnits="userSpaceOnUse"
+       x1="48.36805"
+       y1="775.46729"
+       x2="147.362"
+       y2="775.46729"
+       gradientTransform="translate(0,-652.362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient16635"
+       gradientUnits="userSpaceOnUse"
+       x1="237.99997"
+       y1="321.00003"
+       x2="566"
+       y2="321.00003" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient16637"
+       gradientUnits="userSpaceOnUse"
+       x1="237.99997"
+       y1="321.00003"
+       x2="566"
+       y2="321.00003" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.49497475"
+     inkscape:cx="-127.48723"
+     inkscape:cy="399.43661"
+     inkscape:document-units="px"
+     inkscape:current-layer="WhitePieces"
+     showgrid="false"
+     inkscape:window-width="1210"
+     inkscape:window-height="707"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Skulls Chess Piece Set</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:description>Chess piece set &quot;Skulls&quot; by Maurizio Monge.</dc:description>
+        <dc:date>2017-10-29</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect7736"
+         width="200"
+         height="200"
+         x="0"
+         y="0.00018261719" />
+      <path
+         style="fill:url(#linearGradient16630);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16632);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 50.19662,99.85596 c 0.18876,-11.30046 5.24297,-21.92754 13.17401,-29.65209 6.14524,-5.98524 13.07699,-10.09315 21.2055,-12.54932 7.495,-2.26473 17.59164,-2.10506 25.05486,0.0479 9.08237,2.62007 15.93386,6.15329 23.15118,12.24668 10.94209,9.23812 14.8218,26.44243 11.71698,32.29253 -1.24826,6.21866 -8.75294,27.35239 -11.6798,36.6881 -2.4205,5.772 -2.17943,12.32283 -2.51637,18.48897 0.8674,7.05234 -2.27221,13.77884 -5.92049,19.57191 -3.80413,4.071 -9.0867,5.78314 -12.44105,10.14069 -4.60592,5.98344 -10.59165,0.38884 -15.12851,1.43369 -5.75654,-0.93503 -11.74979,5.22272 -15.5132,-1.7372 -3.68267,-6.81061 -12.67224,-9.91028 -17.19717,-16.33 -4.55286,-3.16194 -2.95138,-9.47312 -3.16424,-14.23404 0.55428,-8.50335 0.132,-17.31473 -3.63023,-25.11607 -0.36847,-1.07926 -5.7463,-21.82853 -7.11147,-31.29176 z"
+         id="path7738"
+         sodipodi:nodetypes="cssssccccscscccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16625);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16627);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 64.00411,102.89189 c -1.12461,5.96635 0.38673,13.49533 -6.07811,16.98663 -4.33837,4.03265 -7.56308,13.80424 -2.34899,19.58954 8.85795,4.2399 15.63519,2.04536 17.63548,13.63138 0.96791,10.36136 11.2999,10.99739 17.2246,10.40576 6.50283,0.10571 15.64746,0.37901 21.83379,-0.0612 8.54028,-0.3148 5.23618,-17.5817 14.51314,-17.90277 8.97389,-1.10044 13.16499,-9.13957 12.6883,-17.01342 -2.62296,-6.68098 -7.47113,-12.37734 -5.51473,-20.32079"
+         id="path7740"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16622);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 107.36923,112.7437 c -2.96112,3.60996 -3.49219,4.94952 -4.24827,9.67619 0.0713,3.09089 3.87677,6.99636 6.44872,8.34666 3.6975,2.09452 7.19251,2.06574 11.46638,1.10082 2.34723,-0.45843 5.42677,-2.08796 5.75796,-4.62327 0.59916,-2.98362 1.89982,-12.22389 0.47939,-13.69005 -1.94249,-1.68904 -9.00703,-3.2547 -11.39985,-3.82663 -1.41926,-0.72063 -7.31604,1.79531 -8.50433,3.01628 z"
+         id="path7742"
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16619);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 70.81373,111.30227 c -2.70528,2.79541 -3.78265,4.98959 -3.25326,10.5077 0.3788,3.25544 0.62293,6.81157 3.15646,9.00551 8.61243,1.44686 16.32309,-1.08434 17.71287,-3.75034 2.86391,-3.47171 3.73826,-5.8181 3.85909,-10.13967 -0.43757,-4.46852 -4.52383,-8.16652 -8.60802,-7.59324 -3.72944,0.45413 -7.01187,-1.07242 -12.86714,1.97004 z"
+         id="path7744"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16616);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 97.59896,122.93615 c -1.10611,0.36444 -1.99324,3.17624 -2.5068,4.23408 -1.93077,4.71654 -4.8292,12.02474 -3.57046,15.51603 1.48849,0.93164 4.38873,-1.57634 5.4883,-1.19088 1.32583,0.31229 2.93653,1.92939 5.03294,1.56651 1.63847,0.70618 0.13028,-12.5952 -1.77891,-15.54714 -0.85123,-2.21499 -1.27982,-5.035 -2.66507,-4.5786 z"
+         id="path7746"
+         sodipodi:nodetypes="ccccccs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16613);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 72.82112,149.99336 c 2.61052,6.74233 -0.37428,14.3917 5.47178,16.96321 6.21567,1.85846 12.04955,2.63783 18.50795,2.47839 8.16021,-1.55056 15.83563,1.72631 20.83939,-5.07652 1.87386,-4.19382 0.94765,-11.43589 4.09552,-14.93103"
+         id="path7748"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16608);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16610);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 94.18946,154.25018 c -0.37103,0.38752 -1.62403,1.27824 -2.1887,2.40757 -0.42188,0.84376 -0.474,3.2092 -0.6566,3.93965 -0.38928,1.55707 0.20574,2.07271 1.31321,2.62644 1.00639,0.50319 2.13876,0.13441 2.84531,-0.21887 0.98689,-0.49345 0.85035,-1.43156 1.09435,-2.40757 0.2545,-1.01799 0,-2.45376 0,-3.50191 0,-1.34262 -0.12443,-1.87539 -0.87548,-2.62644 -0.63179,-0.63179 -0.008,-0.5236 -1.53209,-0.21887 z"
+         id="path7750"
+         sodipodi:nodetypes="csssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16603);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16605);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 98.2335,153.92693 c -0.0127,-0.0127 -0.93889,2.4423 -1.09435,3.06417 -0.24366,0.97463 0.47321,2.04682 0.21887,3.06418 -0.35834,1.43336 -0.63324,1.98152 0.21887,2.40757 1.12642,0.56321 1.72445,0.59527 2.84531,0.87548 1.34163,0.33541 2.17449,-0.71064 2.62643,-1.31322 0.56585,-0.75446 -0.3074,-2.54284 -0.43774,-3.06418 -0.29725,-1.18899 -0.75428,-1.9463 -1.31322,-3.06417 -0.32017,-0.64035 -1.47346,-1.15983 -1.96983,-1.5321 -0.3143,-0.23573 -0.72956,-0.29182 -1.09434,-0.43773 z"
+         id="path7752"
+         sodipodi:nodetypes="cssssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16598);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16600);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 102.72539,155.4489 c -1.10895,-0.8317 0,2.77235 0,4.15853 0,1.04552 0.0403,2.34987 0.21887,3.06418 0.15901,0.63608 2.17398,0.54349 2.62643,0.65661 1.39587,0.34897 2.34377,-0.529 2.84531,-1.53209 0.46243,-0.92487 -0.65661,-2.25085 -0.65661,-3.28305 0,-1.70755 -0.69665,-2.67982 -1.31322,-3.50192 -0.87206,-1.16275 -3.02761,-0.11679 -3.72078,0.43774 z"
+         id="path7754"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16593);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16595);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 109.29148,154.79229 c -0.005,-0.007 -0.43774,2.9757 -0.43774,3.93966 0,1.26579 -0.20067,2.00623 0.21887,2.84531 0.24519,0.49039 2.31342,0.59424 2.62644,0.43774 1.26761,-0.63381 1.09435,-3.00112 1.09435,-4.3774 0,-0.90738 -1.2345,-2.36821 -1.75096,-2.62644 -0.65421,-0.3271 -0.76946,-0.21887 -1.75096,-0.21887 z"
+         id="path7756"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16588);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16590);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 113.45001,154.35455 c -1.30672,-0.65336 -0.21887,2.91645 -0.21887,4.3774 0,1.45842 -0.69263,1.84885 0.21887,3.06418 0.67542,0.90057 1.82262,-0.80188 2.40756,-1.09435 0.64316,-0.32158 0.43775,-2.37616 0.43775,-3.06418 0,-1.12884 -0.47296,-2.25911 -0.87548,-3.06417 -0.3476,-0.69519 -1.5332,-0.3062 -1.96983,-0.21888 z"
+         id="path7758"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16583);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16585);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.52901,155.01116 c 0.005,-0.0103 0.43775,2.74011 0.43775,3.72079 0,0.72714 0.2512,2.13152 0.43774,3.06418 0.27499,1.37499 -1.11378,1.09435 -2.1887,1.09435 -1.18288,0 -1.82613,-0.9757 -2.40757,-1.75096 -0.45456,-0.60609 0.0624,-3.09501 0.21887,-3.72078 0.26746,-1.06983 1.30479,-1.63732 1.96983,-1.96984 0.66704,-0.33352 0.33994,-0.19931 1.53208,-0.43774 z"
+         id="path7760"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16578);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16580);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 81.71388,156.10551 c 0.6803,-0.34014 0,2.4463 0,3.28305 0,1.28608 0.56615,1.49414 0,2.62644 -0.45368,0.90736 -2.66305,-0.34661 -2.84531,-0.43774 -0.88294,-0.44147 -0.87548,-1.82981 -0.87548,-2.84531 0,-1.07569 0.90523,-2.30767 1.09435,-3.06417 0.54382,-2.1753 2.03383,-0.30303 2.62644,0.43773 z"
+         id="path7762"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16573);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16575);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.96676,156.76212 c 0.67061,-1.07116 0.64562,-1.80293 2.1887,-2.18869 0.10363,-0.0259 1.9092,1.94621 1.96982,2.18869 0.25681,1.02723 -0.0674,2.57568 0.21888,3.72079 0.38298,1.53196 -0.19642,1.9095 -1.31323,2.1887 -1.55186,0.38796 -1.83358,0.32609 -2.18869,-1.09435 -0.21664,-0.86654 -0.49573,-2.20178 -0.65661,-2.84531 -0.15899,-0.63596 -0.21887,-1.2953 -0.21887,-1.96983 z"
+         id="path7764"
+         sodipodi:nodetypes="cssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16568);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16570);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 77.99309,155.23003 c 0.30374,0.78747 0.21887,3.26654 0.21887,4.81514 0,1.69667 -0.69128,1.53209 -2.18869,1.53209 -1.19592,0 -1.5321,-0.97515 -1.5321,-2.1887 0,-1.47343 -0.12386,-2.15984 0.65662,-3.72078 0.51911,-1.03823 0.94608,-1.38383 1.53208,-1.96983 0.47562,-0.47562 1.06342,0.90756 1.31322,1.53208 z"
+         id="path7766"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16563);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16565);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 79.74405,163.54709 c -0.82541,-0.82541 0,2.33461 0,3.50192 0,1.32833 0.42718,1.53208 1.75096,1.53208 0.37769,0 0.98778,-2.63788 1.09435,-3.06417 0.25888,-1.03553 0.19972,-2.2653 0,-3.06418 -0.55744,-2.22976 -2.60614,0.49643 -2.84531,1.09435 z"
+         id="path7768"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16558);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16560);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 95.28381,170.11318 c -0.18849,-0.75397 -0.31212,-2.99945 -0.65661,-4.37739 -0.32807,-1.31228 -0.58446,-1.67881 -1.53209,-2.62644 -1.17164,-1.17164 -1.25193,2.31998 -1.31322,2.62644 -0.23898,1.19494 0.62231,1.83261 0.87548,2.8453 0.31033,1.2413 1.04225,1.53209 2.62644,1.53209 z"
+         id="path7770"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16553);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16555);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 95.72155,170.11318 c 0.35433,1.41734 -0.21887,-2.91644 -0.21887,-4.37739 0,-1.40179 -0.38673,-1.5831 0.43774,-2.40757 0.8815,-0.8815 2.23415,1.18525 2.40757,1.53209 0.47658,0.95317 0.65661,1.35588 0.65661,2.84531 0,1.34922 -1.01677,1.49329 -1.96983,1.96982 -1.28512,0.64256 2.77827,-0.38056 -1.31322,0.43774 z"
+         id="path7772"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16548);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16550);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 99.88008,170.11318 c -0.18025,0.0901 -0.21887,-3.22934 -0.21887,-4.15852 0,-1.36796 0.54471,-1.42019 1.31322,-2.1887 1.00699,-1.007 2.16769,1.43113 2.40757,1.75096 0.58435,0.77914 0.13891,2.50852 0,3.06417 -0.10846,0.43383 -2.96976,1.31923 -3.50192,1.53209 z"
+         id="path7774"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16543);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16545);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 92.00076,169.67544 c -0.30236,1.20946 -0.56521,-2.50457 -1.31321,-3.50191 -1.04382,-1.39176 -0.43268,-1.85786 -1.96984,-2.62644 -0.87996,-0.43998 -1.24192,1.82724 -1.53208,2.40757 -0.58801,1.17601 0.62612,2.17345 1.09435,2.40757 0.86719,0.43359 1.08378,1.19849 2.1887,1.75095 0.50992,0.25497 0.74733,0.29627 1.31321,0.43774"
+         id="path7776"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16538);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16540);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.09128,168.79997 c 0.32848,0.16424 0,-3.26061 0,-4.15853 0,-1.70318 -0.15149,-1.31322 -1.96983,-1.31322 -1.25671,0 -1.09435,2.12692 -1.09435,3.28305 0,1.52734 0.0734,1.8971 1.09435,2.40757 0.92781,0.4639 0.80708,0.65318 1.96983,-0.21887 z"
+         id="path7778"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16533);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16535);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 104.69521,169.45657 c 1.19078,0.5954 0.0612,-2.74888 0.65661,-3.93965 0.49117,-0.98234 1.89526,-1.31322 2.84531,-1.31322 1.38584,0 1.09435,1.17705 1.09435,2.40757 0,0.79458 -1.20425,1.64198 -1.75096,2.1887 -0.56969,0.56968 -1.95018,0.6566 -2.84531,0.6566 z"
+         id="path7780"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16528);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16530);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 110.16696,168.14336 c -0.51598,0.51597 0.0934,-2.12472 0.65661,-4.3774 0.29551,-1.18206 1.61383,-0.85504 2.40757,-0.65661 1.23099,0.30775 0.46128,2.36048 0.21887,2.84531 -0.62313,1.24626 -1.88768,2.1887 -3.28305,2.1887 z"
+         id="path7782"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16525);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 97.397,61.5285 c -0.41271,1.13494 0.61905,1.267 0.61905,3.09529 0,0.83394 -3.2379,4.66722 -2.78576,5.57152 0.65157,1.30312 2.42313,2.42312 2.78576,2.78576 0.24679,0.24678 -5.68363,-0.76927 -6.5001,1.85717 -0.69911,2.24892 -3.12929,-2.00116 -5.3682,-1.44143 -1.53312,0.38328 -4.45315,5.73305 -5.77483,6.39389 -1.91714,0.95857 -3.79036,-2.37548 -4.3334,-0.20332 -0.3806,1.5224 -0.26903,2.62374 -0.61906,4.02388 -0.63508,2.54031 1.01496,-0.94659 -3.09529,-0.26155 -1.87375,0.31229 -2.1667,-0.78128 -2.1667,3.40482 0,0.099 -3.83343,1.95248 -4.3334,2.78575 -0.96946,1.61577 -1.31483,2.12483 -1.85717,4.29421 -0.70823,2.8329 -5.312,1.21069 -6.77102,2.66971"
+         id="path7784"
+         sodipodi:nodetypes="csssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16522);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 97.34927,75.4976 c 1.34129,-1.34129 2.68258,-2.68258 4.02387,-4.02387 1.34129,-1.34129 -2.68258,2.68258 -4.02387,4.02387 -1.44447,1.44447 3.10773,-2.69917 4.3334,-4.33341 1.73318,-2.3109 5.1412,0.687 5.88105,2.16671 0.89719,1.79438 2.27028,3.28075 3.09528,2.78576 1.22911,-0.73747 3.20956,-1.23812 4.64293,-1.23812 2.97865,0 4.34001,2.48943 5.57152,4.95246 0.88611,1.77221 3.18551,-1.23811 5.57152,-1.23811 2.44536,0 3.64188,1.21844 3.09528,3.40481 -0.23661,0.94646 3.03279,2.1042 3.71435,2.78576 1.73735,1.73734 -0.66973,3.31477 2.1667,4.02387 2.60749,0.65187 7.51341,2.3427 9.1312,2.74715"
+         id="path7786"
+         sodipodi:nodetypes="cssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16519);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 70.77039,102.4824 c 2.27011,0.11564 7.30726,-1.31322 10.94349,-1.31322 3.80977,0 6.46028,-0.27177 9.63028,1.31322 0.59136,0.29569 1.18298,0.5915 1.75095,0.87549"
+         id="path7788"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16516);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 104.47634,103.35789 c 1.57353,-1.29251 4.94821,-3.06418 7.44158,-3.06418 2.77109,0 5.08038,0 7.87931,0 1.75096,0 3.50192,0 5.25288,0"
+         id="path7790"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16511);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16513);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 141.25714,70.17161 c 0,0 -14.85714,4.91429 -25.6,10.05715 -10.74286,5.14285 -14.62857,15.08571 -14.62857,15.08571 12.77284,-6.44504 28.65445,-13.0989 49.82857,-12.34286 1.16636,-5.72212 0.11361,-10.70453 -9.6,-12.8 z"
+         id="path7792"
+         sodipodi:nodetypes="csccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16506);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16508);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 49.82857,77.94304 C 39.03516,62.83682 26.45757,51.35222 26.97143,27.20019 72.19449,49.37318 126.02166,44.01851 167.31428,25.82876 160.32859,44.932 149.07071,61.07629 136.68571,66.51447 105.21845,90.35012 77.84411,85.98126 49.82857,77.94304 z"
+         id="path7794"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16501);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16503);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 45.71428,88.45732 c -2.13023,3.43372 -4.76675,9.4391 0.65557,11.25104 6.00458,3.3132 17.32519,1.06031 23.69207,-0.27808 7.10996,-2.18712 30.61778,-9.87094 35.01592,-14.55582 8.88488,-4.40761 37.13445,-15.127 43.53908,-15.83551 4.74157,-2.87773 0.52261,-12.85472 -5.25044,-11.12532 -4.16004,-0.88372 -44.50834,17.70475 -50.0708,19.58161 -4.54494,1.14974 -22.79607,8.44594 -28.1816,8.23027 -4.79316,-0.0449 -17.61781,2.73481 -19.3998,2.73181 z"
+         id="path7796"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient16496);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16498);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 100.85992,69.65507 c 2.51194,-4.31477 0.0843,-7.0522 5.12831,-9.64131 5.20221,-2.67032 8.65359,-4.19549 12.05721,-8.66506 2.74546,-3.60529 4.26857,-18.58877 1.56864,-22.12888 -2.77318,-3.63615 -9.87167,-1.06962 -12.47421,-5.40289 -1.41127,-2.34978 -3.1762,-5.72889 -5.67953,-6.59966 -2.32404,-0.80841 -4.89048,-1.03094 -7.2756,-0.76318 -4.38189,0.49191 -4.15541,6.6857 -8.02745,8.1995 -4.29459,1.679 -8.82687,-0.0871 -11.86892,3.62774 -3.52586,4.30561 -2.76778,17.68254 1.55194,21.9923 2.97958,2.9727 7.26759,5.43716 8.95368,9.4429 1.44812,3.44039 2.30358,2.15073 -0.67479,5.98783 -7.30576,9.41217 -27.1264,11.22318 -33.42839,9.64225 -5.36156,-1.34502 -10.20436,9.9566 -5.43367,12.19643 10.52619,4.94204 48.08108,-4.96793 55.60278,-17.88797 z"
+         id="path7798"
+         sodipodi:nodetypes="cssssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16493);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 94.17142,22.51784 5.94286,0"
+         id="path7800"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient16490);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 80.89064,29.78196 c 0.23178,12.99699 1.8812,20.16418 5.55069,24.5669"
+         id="path7802"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path7804"
+         d="m 112.80087,32.26951 c -2.15852,12.81859 -4.85357,19.66154 -9.13596,23.47078"
+         style="fill:none;stroke:url(#linearGradient16487);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path7806"
+         d="m 89.9416,26.54947 c 5.86532,2.64269 9.73021,1.28453 13.95516,0.6465"
+         style="fill:none;stroke:url(#linearGradient16484);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="0.00018261719"
+         x="200"
+         height="200"
+         width="200"
+         id="rect4651-1"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssccccscscccc"
+         id="path1328-6"
+         d="m 250.19662,99.85596 c 0.18876,-11.30046 5.24297,-21.92754 13.17401,-29.65209 6.14524,-5.98524 13.07699,-10.09315 21.2055,-12.54932 7.495,-2.26473 17.59164,-2.10506 25.05486,0.0479 9.08237,2.62007 15.93386,6.15329 23.15118,12.24668 10.94209,9.23812 14.8218,26.44243 11.71698,32.29253 -1.24826,6.21866 -8.75294,27.35239 -11.6798,36.6881 -2.4205,5.772 -2.17943,12.32283 -2.51637,18.48897 0.8674,7.05234 -2.27221,13.77884 -5.92049,19.57191 -3.80413,4.071 -9.0867,5.78314 -12.44105,10.14069 -4.60592,5.98344 -10.59165,0.38884 -15.12851,1.43369 -5.75654,-0.93503 -11.74979,5.22272 -15.5132,-1.7372 -3.68267,-6.81061 -12.67224,-9.91028 -17.19717,-16.33 -4.55286,-3.16194 -2.95138,-9.47312 -3.16424,-14.23404 0.55428,-8.50335 0.132,-17.31473 -3.63023,-25.11607 -0.36847,-1.07926 -5.7463,-21.82853 -7.11147,-31.29176 z"
+         style="fill:url(#linearGradient16478);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16480);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path2239-7"
+         d="m 264.00411,102.89189 c -1.12461,5.96635 0.38673,13.49533 -6.07811,16.98663 -4.33837,4.03265 -7.56308,13.80424 -2.34899,19.58954 8.85795,4.2399 15.63519,2.04536 17.63548,13.63138 0.96791,10.36136 11.2999,10.99739 17.2246,10.40576 6.50283,0.10571 15.64746,0.37901 21.83379,-0.0612 8.54028,-0.3148 5.23618,-17.5817 14.51314,-17.90277 8.97389,-1.10044 13.16499,-9.13957 12.6883,-17.01342 -2.62296,-6.68098 -7.47113,-12.37734 -5.51473,-20.32079"
+         style="fill:url(#linearGradient16473);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16475);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccc"
+         id="path2206-9"
+         d="m 307.36923,112.7437 c -2.96112,3.60996 -3.49219,4.94952 -4.24827,9.67619 0.0713,3.09089 3.87677,6.99636 6.44872,8.34666 3.6975,2.09452 7.19251,2.06574 11.46638,1.10082 2.34723,-0.45843 5.42677,-2.08796 5.75796,-4.62327 0.59916,-2.98362 1.89982,-12.22389 0.47939,-13.69005 -1.94249,-1.68904 -9.00703,-3.2547 -11.39985,-3.82663 -1.41926,-0.72063 -7.31604,1.79531 -8.50433,3.01628 z"
+         style="fill:url(#linearGradient16470);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         id="path2204-7"
+         d="m 270.81373,111.30227 c -2.70528,2.79541 -3.78265,4.98959 -3.25326,10.5077 0.3788,3.25544 0.62293,6.81157 3.15646,9.00551 8.61243,1.44686 16.32309,-1.08434 17.71287,-3.75034 2.86391,-3.47171 3.73826,-5.8181 3.85909,-10.13967 -0.43757,-4.46852 -4.52383,-8.16652 -8.60802,-7.59324 -3.72944,0.45413 -7.01187,-1.07242 -12.86714,1.97004 z"
+         style="fill:url(#linearGradient16467);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccs"
+         id="path2228-6"
+         d="m 297.59896,122.93615 c -1.10611,0.36444 -1.99324,3.17624 -2.5068,4.23408 -1.93077,4.71654 -4.8292,12.02474 -3.57046,15.51603 1.48849,0.93164 4.38873,-1.57634 5.4883,-1.19088 1.32583,0.31229 2.93653,1.92939 5.03294,1.56651 1.63847,0.70618 0.13028,-12.5952 -1.77891,-15.54714 -0.85123,-2.21499 -1.27982,-5.035 -2.66507,-4.5786 z"
+         style="fill:url(#linearGradient16464);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2244-6"
+         d="m 272.82112,149.99336 c 2.61052,6.74233 -0.37428,14.3917 5.47178,16.96321 6.21567,1.85846 12.04955,2.63783 18.50795,2.47839 8.16021,-1.55056 15.83563,1.72631 20.83939,-5.07652 1.87386,-4.19382 0.94765,-11.43589 4.09552,-14.93103"
+         style="fill:none;stroke:url(#linearGradient16461);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssc"
+         id="path2275-7"
+         d="m 294.18946,154.25018 c -0.37103,0.38752 -1.62403,1.27824 -2.1887,2.40757 -0.42188,0.84376 -0.474,3.2092 -0.6566,3.93965 -0.38928,1.55707 0.20574,2.07271 1.31321,2.62644 1.00639,0.50319 2.13876,0.13441 2.84531,-0.21887 0.98689,-0.49345 0.85035,-1.43156 1.09435,-2.40757 0.2545,-1.01799 0,-2.45376 0,-3.50191 0,-1.34262 -0.12443,-1.87539 -0.87548,-2.62644 -0.63179,-0.63179 -0.008,-0.5236 -1.53209,-0.21887 z"
+         style="fill:url(#linearGradient16456);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16458);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc"
+         id="path2277-4"
+         d="m 298.2335,153.92693 c -0.0127,-0.0127 -0.93889,2.4423 -1.09435,3.06417 -0.24366,0.97463 0.47321,2.04682 0.21887,3.06418 -0.35834,1.43336 -0.63324,1.98152 0.21887,2.40757 1.12642,0.56321 1.72445,0.59527 2.84531,0.87548 1.34163,0.33541 2.17449,-0.71064 2.62643,-1.31322 0.56585,-0.75446 -0.3074,-2.54284 -0.43774,-3.06418 -0.29725,-1.18899 -0.75428,-1.9463 -1.31322,-3.06417 -0.32017,-0.64035 -1.47346,-1.15983 -1.96983,-1.5321 -0.3143,-0.23573 -0.72956,-0.29182 -1.09434,-0.43773 z"
+         style="fill:url(#linearGradient16451);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16453);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2279-1"
+         d="m 302.72539,155.4489 c -1.10895,-0.8317 0,2.77235 0,4.15853 0,1.04552 0.0403,2.34987 0.21887,3.06418 0.15901,0.63608 2.17398,0.54349 2.62643,0.65661 1.39587,0.34897 2.34377,-0.529 2.84531,-1.53209 0.46243,-0.92487 -0.65661,-2.25085 -0.65661,-3.28305 0,-1.70755 -0.69665,-2.67982 -1.31322,-3.50192 -0.87206,-1.16275 -3.02761,-0.11679 -3.72078,0.43774 z"
+         style="fill:url(#linearGradient16446);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16448);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path2281-0"
+         d="m 309.29148,154.79229 c -0.005,-0.007 -0.43774,2.9757 -0.43774,3.93966 0,1.26579 -0.20067,2.00623 0.21887,2.84531 0.24519,0.49039 2.31342,0.59424 2.62644,0.43774 1.26761,-0.63381 1.09435,-3.00112 1.09435,-4.3774 0,-0.90738 -1.2345,-2.36821 -1.75096,-2.62644 -0.65421,-0.3271 -0.76946,-0.21887 -1.75096,-0.21887 z"
+         style="fill:url(#linearGradient16441);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16443);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2283-0"
+         d="m 313.45001,154.35455 c -1.30672,-0.65336 -0.21887,2.91645 -0.21887,4.3774 0,1.45842 -0.69263,1.84885 0.21887,3.06418 0.67542,0.90057 1.82262,-0.80188 2.40756,-1.09435 0.64316,-0.32158 0.43775,-2.37616 0.43775,-3.06418 0,-1.12884 -0.47296,-2.25911 -0.87548,-3.06417 -0.3476,-0.69519 -1.5332,-0.3062 -1.96983,-0.21888 z"
+         style="fill:url(#linearGradient16436);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16438);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2287-5"
+         d="m 286.52901,155.01116 c 0.005,-0.0103 0.43775,2.74011 0.43775,3.72079 0,0.72714 0.2512,2.13152 0.43774,3.06418 0.27499,1.37499 -1.11378,1.09435 -2.1887,1.09435 -1.18288,0 -1.82613,-0.9757 -2.40757,-1.75096 -0.45456,-0.60609 0.0624,-3.09501 0.21887,-3.72078 0.26746,-1.06983 1.30479,-1.63732 1.96983,-1.96984 0.66704,-0.33352 0.33994,-0.19931 1.53208,-0.43774 z"
+         style="fill:url(#linearGradient16431);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16433);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path2289-3"
+         d="m 281.71388,156.10551 c 0.6803,-0.34014 0,2.4463 0,3.28305 0,1.28608 0.56615,1.49414 0,2.62644 -0.45368,0.90736 -2.66305,-0.34661 -2.84531,-0.43774 -0.88294,-0.44147 -0.87548,-1.82981 -0.87548,-2.84531 0,-1.07569 0.90523,-2.30767 1.09435,-3.06417 0.54382,-2.1753 2.03383,-0.30303 2.62644,0.43773 z"
+         style="fill:url(#linearGradient16426);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16428);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2291-0"
+         d="m 286.96676,156.76212 c 0.67061,-1.07116 0.64562,-1.80293 2.1887,-2.18869 0.10363,-0.0259 1.9092,1.94621 1.96982,2.18869 0.25681,1.02723 -0.0674,2.57568 0.21888,3.72079 0.38298,1.53196 -0.19642,1.9095 -1.31323,2.1887 -1.55186,0.38796 -1.83358,0.32609 -2.18869,-1.09435 -0.21664,-0.86654 -0.49573,-2.20178 -0.65661,-2.84531 -0.15899,-0.63596 -0.21887,-1.2953 -0.21887,-1.96983 z"
+         style="fill:url(#linearGradient16421);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16423);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2295-8"
+         d="m 277.99309,155.23003 c 0.30374,0.78747 0.21887,3.26654 0.21887,4.81514 0,1.69667 -0.69128,1.53209 -2.18869,1.53209 -1.19592,0 -1.5321,-0.97515 -1.5321,-2.1887 0,-1.47343 -0.12386,-2.15984 0.65662,-3.72078 0.51911,-1.03823 0.94608,-1.38383 1.53208,-1.96983 0.47562,-0.47562 1.06342,0.90756 1.31322,1.53208 z"
+         style="fill:url(#linearGradient16416);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16418);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2299-4"
+         d="m 279.74405,163.54709 c -0.82541,-0.82541 0,2.33461 0,3.50192 0,1.32833 0.42718,1.53208 1.75096,1.53208 0.37769,0 0.98778,-2.63788 1.09435,-3.06417 0.25888,-1.03553 0.19972,-2.2653 0,-3.06418 -0.55744,-2.22976 -2.60614,0.49643 -2.84531,1.09435 z"
+         style="fill:url(#linearGradient16411);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16413);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2301-9"
+         d="m 295.28381,170.11318 c -0.18849,-0.75397 -0.31212,-2.99945 -0.65661,-4.37739 -0.32807,-1.31228 -0.58446,-1.67881 -1.53209,-2.62644 -1.17164,-1.17164 -1.25193,2.31998 -1.31322,2.62644 -0.23898,1.19494 0.62231,1.83261 0.87548,2.8453 0.31033,1.2413 1.04225,1.53209 2.62644,1.53209 z"
+         style="fill:url(#linearGradient16406);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16408);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-4"
+         d="m 295.72155,170.11318 c 0.35433,1.41734 -0.21887,-2.91644 -0.21887,-4.37739 0,-1.40179 -0.38673,-1.5831 0.43774,-2.40757 0.8815,-0.8815 2.23415,1.18525 2.40757,1.53209 0.47658,0.95317 0.65661,1.35588 0.65661,2.84531 0,1.34922 -1.01677,1.49329 -1.96983,1.96982 -1.28512,0.64256 2.77827,-0.38056 -1.31322,0.43774 z"
+         style="fill:url(#linearGradient16401);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16403);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2305-9"
+         d="m 299.88008,170.11318 c -0.18025,0.0901 -0.21887,-3.22934 -0.21887,-4.15852 0,-1.36796 0.54471,-1.42019 1.31322,-2.1887 1.00699,-1.007 2.16769,1.43113 2.40757,1.75096 0.58435,0.77914 0.13891,2.50852 0,3.06417 -0.10846,0.43383 -2.96976,1.31923 -3.50192,1.53209 z"
+         style="fill:url(#linearGradient16396);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16398);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2307-1"
+         d="m 292.00076,169.67544 c -0.30236,1.20946 -0.56521,-2.50457 -1.31321,-3.50191 -1.04382,-1.39176 -0.43268,-1.85786 -1.96984,-2.62644 -0.87996,-0.43998 -1.24192,1.82724 -1.53208,2.40757 -0.58801,1.17601 0.62612,2.17345 1.09435,2.40757 0.86719,0.43359 1.08378,1.19849 2.1887,1.75095 0.50992,0.25497 0.74733,0.29627 1.31321,0.43774"
+         style="fill:url(#linearGradient16391);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16393);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2309-2"
+         d="m 286.09128,168.79997 c 0.32848,0.16424 0,-3.26061 0,-4.15853 0,-1.70318 -0.15149,-1.31322 -1.96983,-1.31322 -1.25671,0 -1.09435,2.12692 -1.09435,3.28305 0,1.52734 0.0734,1.8971 1.09435,2.40757 0.92781,0.4639 0.80708,0.65318 1.96983,-0.21887 z"
+         style="fill:url(#linearGradient16386);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16388);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2311-0"
+         d="m 304.69521,169.45657 c 1.19078,0.5954 0.0612,-2.74888 0.65661,-3.93965 0.49117,-0.98234 1.89526,-1.31322 2.84531,-1.31322 1.38584,0 1.09435,1.17705 1.09435,2.40757 0,0.79458 -1.20425,1.64198 -1.75096,2.1887 -0.56969,0.56968 -1.95018,0.6566 -2.84531,0.6566 z"
+         style="fill:url(#linearGradient16381);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16383);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2313-1"
+         d="m 310.16696,168.14336 c -0.51598,0.51597 0.0934,-2.12472 0.65661,-4.3774 0.29551,-1.18206 1.61383,-0.85504 2.40757,-0.65661 1.23099,0.30775 0.46128,2.36048 0.21887,2.84531 -0.62313,1.24626 -1.88768,2.1887 -3.28305,2.1887 z"
+         style="fill:url(#linearGradient16376);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16378);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssssssss"
+         id="path2353-5"
+         d="m 296.02557,58.78565 c -0.41271,1.13494 0.61905,3.55271 0.61905,5.381 0,0.83393 -3.2379,4.66722 -2.78575,5.57152 0.65156,1.30312 2.42312,2.42312 2.78575,2.78575 0.24679,0.24679 -5.68363,-0.76926 -6.5001,1.85718 -0.69911,2.24892 -3.12929,-2.00116 -5.3682,-1.44143 -1.53312,0.38328 -4.45315,5.73304 -5.77483,6.39389 -1.91714,0.95857 -3.79036,-2.37548 -4.3334,-0.20332 -0.3806,1.52239 -0.26902,2.62373 -0.61906,4.02387 -0.63508,2.54032 1.01496,-0.94658 -3.09529,-0.26154 -1.87375,0.31229 -2.1667,-0.78128 -2.1667,3.40481 0,0.099 -3.83343,1.95248 -4.3334,2.78576 -0.96946,1.61577 -4.51483,3.49626 -5.05717,5.66563 -0.70823,2.83291 -6.68343,-0.16073 -8.14244,1.29828"
+         style="fill:none;stroke:url(#linearGradient16373);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssss"
+         id="path2357-3"
+         d="m 296.34457,73.3023 c 1.34129,-1.34129 10.4793,-1.45111 11.21915,0.0286 0.89719,1.79438 2.27028,3.28075 3.09528,2.78576 1.22911,-0.73747 3.20956,-1.23812 4.64293,-1.23812 2.97865,0 4.34001,2.48943 5.57152,4.95246 0.88611,1.77221 3.18551,-1.23811 5.57152,-1.23811 2.44536,0 3.64188,1.21844 3.09528,3.40481 -0.23661,0.94646 3.03279,2.1042 3.71435,2.78576 1.73735,1.73734 -0.66973,3.31477 2.1667,4.02387 2.60749,0.65187 7.51341,2.3427 9.1312,2.74715"
+         style="fill:none;stroke:url(#linearGradient16370);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2375-9"
+         d="m 270.77039,102.4824 c 2.27011,0.11564 7.30726,-1.31322 10.94349,-1.31322 3.80977,0 6.46028,-0.27177 9.63028,1.31322 0.59136,0.29569 1.18298,0.5915 1.75095,0.87549"
+         style="fill:none;stroke:url(#linearGradient16367);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2377-5"
+         d="m 304.47634,103.35789 c 1.57353,-1.29251 4.94821,-3.06418 7.44158,-3.06418 2.77109,0 5.08038,0 7.87931,0 1.75096,0 3.50192,0 5.25288,0"
+         style="fill:none;stroke:url(#linearGradient16364);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16359);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16361);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 293.25412,27.66838 11.55532,40.20735 24.23598,-34.72425 c -10.59996,14.80135 -25.20225,26.64899 -35.7913,-5.4831 z"
+         id="path3238"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3242"
+         d="m 318.16684,27.83066 0.98112,41.82336 32.24966,-27.44293 C 337.39059,53.84046 320.26114,61.5977 318.16684,27.83066 z"
+         style="fill:url(#linearGradient16354);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16356);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16349);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16351);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 248.13358,37.88382 28.39487,30.72274 6.04161,-41.91245 c -2.81581,17.98639 -10.53449,35.13325 -34.43648,11.18971 z"
+         id="path3254"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3258"
+         d="m 230.60126,57.30277 35.48526,22.15742 -5.21289,-42.02356 c 2.02185,18.09284 -0.90715,36.66739 -30.27237,19.86614 z"
+         style="fill:url(#linearGradient16344);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16346);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16339);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16341);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 268.27121,85.3712 19.12142,-37.20924 17.05423,38.75963 C 296.91324,70.34801 284.88115,55.89734 268.27121,85.3712 z"
+         id="path3266"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3268"
+         d="M 284.59509,81.25603 305.99675,45.30989 320.60396,85.0564 C 314.11715,68.04581 303.0084,52.87384 284.59509,81.25603 z"
+         style="fill:url(#linearGradient16334);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16336);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16329);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16331);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 297.02597,79.3501 29.04326,-30.11059 5.14694,42.03173 C 328.78435,73.22891 321.43288,55.92142 297.02597,79.3501 z"
+         id="path3270"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3272"
+         d="m 307.60394,77.11554 37.80066,-17.92391 -10.01723,41.14378 c 4.09179,-17.73968 3.32114,-36.52795 -27.78343,-23.21987 z"
+         style="fill:url(#linearGradient16324);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16326);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3274"
+         d="m 257.50529,91.24819 11.44885,-40.23777 24.3278,34.65995 C 282.64284,70.89714 268.00925,59.0882 257.50529,91.24819 z"
+         style="fill:url(#linearGradient16319);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16321);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3204"
+         d="m 270.5978,29.99304 19.12141,37.20924 17.05424,-38.75963 c -7.53362,16.57358 -19.56572,31.02426 -36.17565,1.55039 z"
+         style="fill:url(#linearGradient16314);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16316);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16309);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16311);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 336.65171,35.07786 -4.68459,41.57176 35.66504,-22.82895 c -15.45121,9.62804 -33.47245,14.99721 -30.98045,-18.74281 z"
+         id="path3246"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16304);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16306);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 220.47161,74.93054 40.01404,12.20784 -15.92188,-39.23835 c 6.6401,16.95134 8.62317,35.65055 -24.09216,27.03051 z"
+         id="path3262"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16299);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16301);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 368.86548,70.24866 -39.51439,13.73932 35.99906,22.29849 c -15.35948,-9.7737 -27.98882,-23.70543 3.51533,-36.03781 z"
+         id="path3290"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3294"
+         d="m 227.77298,67.76809 38.50086,16.36579 -37.41725,19.82685 c 15.98204,-8.71855 29.51977,-21.76933 -1.08361,-36.19264 z"
+         style="fill:url(#linearGradient16294);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16296);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16289);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16291);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 222.15737,88.80469 262.4715,77.62761 245.54803,116.4445 c 7.07287,-16.77538 9.5351,-35.41755 -23.39066,-27.63981 z"
+         id="path3298"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16284);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16286);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 239.3013,103.82526 10.87963,-40.3954 24.8147,34.31304 c -10.8466,-14.62155 -25.64545,-26.22272 -35.69433,6.08236 z"
+         id="path3276"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3302"
+         d="m 372.38205,92.03058 -36.84371,-19.81659 7.91921,41.59858 c -3.18749,-17.92426 -1.46564,-36.64933 28.9245,-21.78199 z"
+         style="fill:url(#linearGradient16279);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16281);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path3250"
+         d="m 356.72591,48.70282 -24.08415,34.20688 42.2474,-2.88312 c -18.17692,1.01913 -36.56127,-2.93165 -18.16325,-31.32376 z"
+         style="fill:url(#linearGradient16274);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16276);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0.00018261719"
+         x="400"
+         height="200"
+         width="200"
+         id="rect4651-15"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         id="path2213"
+         d="m 444.64308,163.20022 -0.13021,14.97909 26.53885,17.20601 78.57817,-1.41078 -0.0945,-12.8464 -25.39943,-20.32622 -79.49289,2.3983 z"
+         style="fill:url(#linearGradient16268);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16270);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscccccc"
+         id="path2275-74"
+         d="m 477.9202,90.04855 c -0.78273,0.33332 -1.22931,1.52657 -1.25644,3.74263 -0.28954,23.65111 -5.70227,66.29774 -8.38114,74.7366 l 11.29311,7.36196 39.72545,-5.82429 c 0,0 -14.12777,-45.10616 -29.28227,-67.54871 -2.46301,-0.29956 -4.81607,-0.9631 -6.99907,-1.93659 -2.48033,-2.99697 -4.26147,-6.58906 -5.09964,-10.5316 z"
+         style="fill:url(#linearGradient16263);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16265);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccc"
+         id="path1331"
+         d="m 512.67904,92.87729 c -4.48992,5.96152 -11.6282,9.82078 -19.65948,9.82078 -2.78914,0 -5.47434,-0.46372 -7.97465,-1.32008 3.29782,34.41721 -4.31656,72.78057 -3.43671,74.57703 l 44.54423,-0.86313 c 0,0 -12.68007,-47.50842 -8.44766,-75.01947 -2.64109,-1.84574 -3.02972,-6.07668 -5.02573,-7.19513 z"
+         style="fill:url(#linearGradient16258);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16260);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path2215"
+         d="m 449.63561,167.79358 22.83147,14.70114 -0.41505,8.91114"
+         style="fill:none;stroke:url(#linearGradient16255);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path2217"
+         d="m 475.78753,182.35934 67.10037,-0.79409"
+         style="fill:none;stroke:url(#linearGradient16252);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2271"
+         d="m 475.62633,73.17292 13.37874,-0.32825 0,-9.51898 9.03065,-2.29768 0.66894,21.33564 -25.41961,-0.32824 2.34128,-8.86249 z"
+         style="fill:url(#linearGradient16247);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16249);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccscccccccccsscsscsc"
+         id="path3341"
+         d="m 510.79439,18.7427 -33.53197,0.76884 2.75676,22.83296 C 469.7365,45.11457 457.135,56.59269 455.03095,69.0579 l -30.30959,-2.33552 1.38207,31.05079 10.41361,3.77165 21.69933,-4.91765 c 7.33035,18.30544 21.76366,22.25285 30.98955,25.41509 23.83138,8.16837 45.02394,-7.95447 50.38295,-25.76324 l 27.27198,0.44244 1.38208,-31.51499 -11.31528,-2.65466 -19.2456,2.0599 C 532.65968,54.27425 528.85276,48.42555 515.28799,42.98278 l 1.68509,-20.46843 -6.17869,-3.77165 z m -9.29021,41.56063 c 0.0524,-9.9e-4 0.10274,6.6e-4 0.1552,0 0.10576,-0.001 0.21174,0 0.31781,0 3.55932,0 6.94444,0.75544 9.99972,2.11792 3.52343,4.25735 5.63917,9.71967 5.63917,15.67409 0,13.5807 -11.01924,24.60273 -24.59652,24.60273 -3.55932,0 -6.94444,-0.75545 -9.99972,-2.11792 -3.52343,-4.25735 -5.63917,-9.71968 -5.63917,-15.67409 0,-13.42197 10.76517,-24.34921 24.12351,-24.60273 z"
+         style="opacity:0.98999999;fill:url(#linearGradient16242);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16244);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         transform="matrix(0.23650491,0,0,0.23210126,406.42903,9.93821)"
+         d="m 561.99997,321.00003 a 160,162 0 1 1 -320,0 160,162 0 1 1 320,0 z"
+         sodipodi:ry="162"
+         sodipodi:rx="160"
+         sodipodi:cy="321.00003"
+         sodipodi:cx="401.99997"
+         id="path2446"
+         style="opacity:0.98999999;fill:none;stroke:url(#linearGradient16635);stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="-325.38268"
+         inkscape:transform-center-x="-54.316399"
+         sodipodi:nodetypes="ccc"
+         id="path3329"
+         d="m 481.53721,22.77846 5.97109,2.6647 24.83235,-0.80931"
+         style="fill:none;stroke:url(#linearGradient16238);stroke-width:1.87434208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3345"
+         d="m 511.97691,62.42125 c 3.52343,4.25735 5.63917,9.71967 5.63917,15.67409 0,13.5807 -11.01924,24.60273 -24.59652,24.60273 -3.55932,0 -6.94444,-0.75545 -9.99972,-2.11792 4.51273,5.45271 11.33298,8.92864 18.95735,8.92864 13.57728,0 24.59651,-11.02202 24.59652,-24.60273 0,-10.02049 -5.99748,-18.65001 -14.5968,-22.48481 z m -33.71674,15.94971 c -0.0222,0.0806 -0.0452,0.15844 -0.0665,0.23935 0.0212,-0.0803 0.0445,-0.15939 0.0665,-0.23935 z m -0.86472,7.44174 c 0.002,0.0455 0.005,0.0924 0.007,0.13781 -0.002,-0.046 -0.006,-0.0917 -0.007,-0.13781 z m 0.007,0.20309 c 0.002,0.0453 0.005,0.0925 0.007,0.13781 -0.002,-0.046 -0.005,-0.0918 -0.007,-0.13781 z m 0.007,0.15957 c 0.002,0.0399 0.005,0.0762 0.007,0.11605 -0.002,-0.0391 -0.005,-0.0769 -0.007,-0.11605 z m 0.0517,0.73257 c 0.003,0.0408 0.004,0.0826 0.007,0.12331 -0.003,-0.0405 -0.004,-0.0828 -0.007,-0.12331 z m 0.0443,0.51498 c 0.008,0.0789 0.0208,0.15343 0.0296,0.2321 -0.009,-0.078 -0.0216,-0.15392 -0.0296,-0.2321 z m 0.0813,0.72531 c 0.005,0.0393 0.0168,0.0768 0.0222,0.11605 -0.005,-0.0401 -0.0169,-0.0759 -0.0222,-0.11605 z m 1.52989,5.84605 c 0.009,0.0229 0.013,0.0497 0.0222,0.0725 -0.01,-0.0244 -0.0125,-0.0481 -0.0222,-0.0725 z m 3.03761,5.47614 c 0.0219,0.0297 0.0445,0.0574 0.0665,0.087 -0.0218,-0.0294 -0.0448,-0.0575 -0.0665,-0.087 z"
+         style="opacity:0.98999999;fill:url(#linearGradient16233);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16235);stroke-width:3.18607593;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="52.246822"
+         inkscape:transform-center-x="325.65783"
+         sodipodi:nodetypes="ccc"
+         id="path3357"
+         d="m 429.42607,70.96088 6.93437,3.09149 0.0997,21.77714"
+         style="fill:none;stroke:url(#linearGradient16230);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="-325.38267"
+         inkscape:transform-center-x="-54.316399"
+         sodipodi:nodetypes="cc"
+         id="path3365"
+         d="M 540.23498,70.66935 561.3644,68.3548"
+         style="fill:none;stroke:url(#linearGradient16227);stroke-width:1.87434077;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccsccccscccccsccccsc"
+         id="path1369"
+         d="m 500.93301,61.75824 c -2.52758,0.0324 -4.95354,0.50508 -7.20341,1.33883 l 0.47451,1.22241 0,13.24603 -13.49735,0 -0.2768,-0.27812 c -0.61261,2.02617 -0.94244,4.17549 -0.94244,6.40311 0,1.97502 0.25902,3.89021 0.74472,5.71106 l 13.97187,-0.24577 0,14.90178 -0.22408,0.31692 c 2.26265,0.80667 4.70124,1.24828 7.23638,1.24828 2.70146,0 4.57504,-0.7314 6.96183,-1.64208 l -0.26588,-0.751 0.21089,0 -0.42178,-14.0739 14.4332,0.46567 c 0.52438,-1.88661 0.80404,-3.87601 0.80404,-5.93096 0,-2.42955 -0.39011,-4.76802 -1.1138,-6.95287 l -14.12344,0 0.84358,-12.41815 0.71836,-1.00251 c -2.48998,-1.00402 -5.20337,-1.55873 -8.047,-1.55873 -0.0937,0 -0.18997,-10e-4 -0.2834,0 z"
+         style="fill:url(#linearGradient16222);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16224);stroke-width:3.34277487;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2269"
+         d="m 487.80573,89.91319 0.19593,10.83194 6.02044,3.28241 -0.66894,-13.78611 -5.54743,-0.32824 z"
+         style="fill:url(#linearGradient16217);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16219);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3162"
+         d="m 508.75453,72.3871 c 1.65554,0 8.51418,0 8.51418,0 l 5.67612,4.17782 -15.13632,0 0.94602,-4.17782 z"
+         style="fill:url(#linearGradient16212);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16214);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="52.246821"
+         inkscape:transform-center-x="325.65781"
+         sodipodi:nodetypes="cc"
+         id="path3172"
+         d="m 488.6767,44.20917 -1.43407,-15.7425"
+         style="fill:none;stroke:url(#linearGradient16209);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="52.246795"
+         inkscape:transform-center-x="325.6578"
+         sodipodi:nodetypes="cc"
+         id="path3174"
+         d="m 459.28547,74.47935 -19.49537,0.013"
+         style="fill:none;stroke:url(#linearGradient16206);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0.00018261719"
+         x="600"
+         height="200"
+         width="200"
+         id="rect4651-6"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccsss"
+         id="path4300"
+         d="m 674.71354,63.83693 c -12.77326,15.42725 -21.90477,47.67484 -6.32406,75.24164 12.89327,22.81193 -29.3334,28.96604 -27.55711,44.37952 24.74833,-0.0476 93.80866,-0.63052 117.91538,0.21213 1.46084,-14.42929 -39.65165,-13.95421 -26.77986,-48.31532 8.45325,-22.56586 10.96916,-69.25335 -4.9956,-85.00509 -10.46733,-10.32766 -29.67181,-13.79285 -52.25875,13.48712 z"
+         style="fill:url(#linearGradient16200);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16202);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cscc"
+         id="path2465"
+         d="m 649.34173,192.15705 c -3.1901,-5.28174 5.24386,-29.51883 10.66827,-32.98289 4.92746,-3.14671 29.89762,30.88328 30.51798,33.87409 l -41.18625,-0.8912 z"
+         style="fill:url(#linearGradient16195);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16197);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         id="path2479"
+         d="m 653.68459,187.81419 c 0.0447,0.89674 0.18384,-7.53345 1.21806,-10.12382 1.25671,-3.42067 2.51536,-9.08268 4.79737,-11.90756 0.81398,-0.96052 2.84456,1.92734 3.73709,2.5497 1.88741,1.24768 8.0548,16.08309 9.07687,18.52905 0.72821,1.42693 -0.94705,1.66937 -1.95332,1.47447 -1.83868,-0.0253 -16.22484,0.13927 -16.87607,-0.52184 z"
+         style="fill:url(#linearGradient16192);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csscsssccssscssc"
+         id="path4296"
+         d="m 681.68651,76.43314 c -2.65715,0.0546 -5.1027,0.84341 -7.08475,2.65773 -5.36237,4.90858 -12.53117,34.63622 -1.51007,53.71134 3.89323,6.73833 9.59001,19.95846 24.38175,23.79968 6.48032,-12.87412 7.34723,-10.48587 15.57248,-24.79338 10.30904,-17.93219 -0.0539,-34.5536 -6.80196,-42.47398 -4.20734,-4.93826 -15.44546,-12.96705 -24.36761,-12.90139 -0.064,4.7e-4 -0.12607,-10e-4 -0.18984,0 z m 19.60877,24.89016 c 0.01,0.008 10.53854,2.34291 1.46019,5.26519 -3.22035,1.03661 -7.86703,0.64697 -7.11889,-1.65986 1.02226,-3.15207 5.64862,-3.6128 5.6587,-3.60533 z M 681.543,101.18279 c 3.48107,2.08864 7.91279,3.90628 3.97441,4.89087 -4.25858,1.06464 -6.16141,1.39852 -8.63453,-1.00082 -2.75625,-2.674 -0.54283,-2.12818 4.66012,-3.89005 z"
+         style="fill:url(#linearGradient16189);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccscscc"
+         id="path5193"
+         d="m 704.17792,196.18869 -6.09713,-0.67227 67.54748,-143.25086 c 0,0 -6.32091,-8.69659 -18.7416,-13.84722 -8.33752,-3.45741 -25.29633,-6.14344 -25.29633,-6.14344 0.71297,-4.77403 24.66955,-5.30189 38.65346,-0.17075 12.47849,4.57877 16.0878,11.24596 15.17481,17.35936 l -71.24069,146.72518 z"
+         style="fill:url(#linearGradient16184);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16186);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2240"
+         d="m 644.01991,159.40422 c -2.30196,-0.77195 -6.60341,-2.71482 -8.13701,-2.10138 -1.93844,0.77537 -1.93608,3.50774 -1.40066,4.04315 1.3131,1.31311 4.87434,2.12761 7.2744,2.12761 3.14052,0 1.67168,-4.1877 0.37722,-4.44659"
+         style="fill:url(#linearGradient16179);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16181);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssc"
+         id="path2242"
+         d="m 643.71141,167.01714 c 2.9152,0 -4.07412,-1.67846 -7.68163,-2.70918 -3.29082,-0.94023 -1.54159,2.87517 -0.53858,4.59347 0.62498,1.07067 7.01831,1.48719 8.22021,1.88782 0.76379,0.2546 -0.93955,-1.31676 -1.50885,-1.88606 -0.56929,-0.56929 1.0059,-1.25736 1.50885,-1.88605 z"
+         style="fill:url(#linearGradient16174);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16176);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2244-9"
+         d="m 643.55155,172.97258 c -0.93569,-0.93569 -3.14562,-1.95001 -4.52654,-2.64047 -1.95561,-0.97781 -2.91039,3.06966 -2.64047,4.14931 0.23396,0.93585 4.6193,1.72084 5.06536,1.83236 2.1619,0.54048 1.85108,-2.33894 2.10165,-3.3412 z"
+         style="fill:url(#linearGradient16169);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16171);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path2246"
+         d="m 647.86073,160.22735 c 0.18287,0.0457 2.80617,3.39373 4.0846,4.48076 1.54636,1.31486 3.01249,2.58433 4.03883,4.63701 1.8572,3.71439 6.53381,9.33053 -0.26672,2.53 -1.4319,-1.4319 -5.27392,-2.80384 -6.45527,-4.10356 -1.00325,-1.10378 -2.97513,-3.14725 -3.59999,-3.77211 -1.31653,-1.31653 -0.0739,-3.31761 2.19855,-3.7721 z"
+         style="fill:url(#linearGradient16164);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16166);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssc"
+         id="path2248"
+         d="m 646.39765,166.86089 c -1.63941,-1.6394 4.97518,2.08694 6.61459,3.72635 1.16793,1.16793 3.5151,4.04856 4.03884,4.57229 0.0783,0.0783 -3.61956,-0.0208 -3.92836,-0.1752 -2.33758,-1.16879 -7.03559,-3.16967 -8.61113,-4.35133 -0.35907,-0.2693 -0.77618,-2.56422 -0.7539,-2.58651"
+         style="fill:url(#linearGradient16159);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16161);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2250"
+         d="m 645.21663,177.29336 c -1.61257,-1.20943 0.0145,-4.49343 1.96999,-4.00454 5.0887,1.27217 10.09714,5.07709 7.06491,5.07709 -2.9249,0 -6.6752,0.1073 -9.0349,-1.07255 z"
+         style="fill:url(#linearGradient16154);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16156);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssc"
+         id="path2252"
+         d="m 646.79074,153.01469 c -0.81687,-0.046 -5.67489,-1.88203 -7.38782,-1.97857 -1.2484,-0.0704 -2.60499,0.92696 -3.60617,1.35895 -1.87098,0.8073 3.71547,3.63407 3.74533,3.64335 1.35594,0.42134 2.6965,1.4976 4.12749,0.88015 0.69749,-0.30095 2.6943,-3.27551 3.12117,-3.90388 z"
+         style="fill:url(#linearGradient16149);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16151);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssc"
+         id="path2254"
+         d="m 633.71147,150.62661 c 4.98869,-1.38659 -4.72572,-2.75043 -7.40987,-4.06311 -4.11025,-2.01012 -5.07459,-0.66565 -3.84751,1.8684 0.51381,1.06108 2.18283,1.93905 3.04611,2.49611 1.185,0.76466 3.41438,1.48091 4.82107,1.75516 2.26632,0.44184 2.82329,0.85127 3.3902,-2.05656 z"
+         style="fill:url(#linearGradient16144);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16146);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssc"
+         id="path2256"
+         d="m 648.97127,155.93154 c 3.7e-4,-1.8671 7.48043,8.57879 9.77178,10.2973 2.51727,1.88795 0.42175,4.43855 -3.53193,0.48487 -1.27978,-1.27978 -3.173,-2.77174 -4.85763,-3.7342 -1.35754,-0.77558 -3.00244,-3.60433 -3.79072,-5.18088 -0.59626,-1.19253 2.04244,-0.0368 2.4085,-1.86709 z"
+         style="fill:url(#linearGradient16139);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16141);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2258"
+         d="m 662.67158,171.53959 c -0.64727,-1.29454 1.44746,2.97312 0.80018,4.26766 -0.74792,1.49584 -4.03461,-0.9568 -4.33211,-1.55179 -0.66209,-1.32418 1.04667,-2.80928 0.2588,-2.98259 -1.45731,-0.32057 2.82858,0.17782 3.27313,0.26672 z"
+         style="fill:url(#linearGradient16134);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16136);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2260"
+         d="m 657.91905,176.28418 c 0.1195,-0.11949 5.14249,0.21168 2.24687,2.66729 -2.54392,2.15735 -4.28353,1.98523 -4.28353,-0.14575 0,-0.93107 0.8107,-1.90856 2.03666,-2.52154 z"
+         style="fill:url(#linearGradient16129);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16131);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssc"
+         id="path2262"
+         d="m 664.94322,177.29458 c 0,-1.55274 3.10929,3.33601 1.8671,4.26765 -1.01862,0.76397 -3.85624,1.12343 -5.2374,1.12343 -1.1862,0 1.19554,-2.30452 0.96181,-3.46746 -0.35162,-1.7495 2.35199,-1.86713 2.40849,-1.92362 z"
+         style="fill:url(#linearGradient16124);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16126);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0.00018261719"
+         x="800"
+         height="200"
+         width="200"
+         id="rect4651-0"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2701"
+         d="m 845.34562,118.52553 c 1.11825,1.92054 1.6663,2.99722 4.42397,3.68663 1.61062,0.40266 1.10599,-2.63788 1.10599,-4.42396 0,-2.79429 0.64245,-3.0862 2.58064,-4.0553 1.86484,-0.93242 2.92728,2.16793 3.31797,2.94931 0.9281,1.8562 3.4449,0.97906 4.42397,0 1.32498,-1.32499 1.10599,-2.95142 1.10599,-5.16129 0,-0.70941 -1.84332,-1.45433 -1.84332,-3.68664 0,-0.54862 4.31499,-0.36866 5.16129,-0.36866 0.31562,0 3.14836,3.88568 3.31797,4.0553 1.44244,1.44244 3.35128,0.67072 4.0553,-0.73733 0.9283,-1.8566 -1.35187,-3.07225 -2.58064,-3.68664 -1.209,-0.60449 -1.23748,-3.47523 -1.47466,-4.42396 -0.4215,-1.68601 3.67106,-0.15681 5.16129,0.73733 2.23792,1.34275 1.15195,2.93782 4.0553,2.21198 2.24591,-0.56148 1.32055,-2.96591 0.73733,-4.42396 -0.38726,-0.96816 -1.74566,-1.27933 -2.21198,-2.21198"
+         style="fill:none;stroke:url(#linearGradient16120);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc"
+         id="path1343"
+         d="m 917.1099,167.71241 c -6.5118,4.473 2.61918,12.1603 -3.60237,17.04909 -6.3053,5.74106 -2.26825,4.37318 -10.12279,5.97179 -5.43331,1.45388 -23.59717,2.08401 -18.19594,-1.76555 7.15768,-5.123 10.0254,-13.49983 15.90766,-19.61605 3.61005,-2.67129 18.8562,-15.53276 16.01344,-1.63928 z"
+         style="fill:url(#linearGradient16115);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16117);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4260"
+         d="m 953.57426,161.94619 c 0.14482,-1.82072 1.58721,-3.58489 0.77074,-5.42929 -0.7782,-1.39127 -1.38926,-3.34762 -0.22674,-4.70839 1.95942,-2.0993 4.94736,-2.49744 7.43713,-3.68061 1.39795,-0.50972 2.811,-0.98019 4.24503,-1.37827 1.65224,0.39703 2.20701,2.34932 2.00014,3.84966 -0.14215,3.57366 -0.66896,7.15414 -0.28305,10.72764 0.11812,2.31845 -0.16122,4.66174 0.33666,6.95125 0.20925,1.25624 0.43227,2.66522 -0.41171,3.75604 -0.92333,1.46823 -2.88184,2.14091 -4.48756,1.43103 -1.8442,-0.59224 -2.8009,-2.40074 -4.20808,-3.57418 -1.56636,-1.25735 -3.68875,-1.8695 -4.8861,-3.54622 -0.69463,-1.36792 -0.31849,-2.9412 -0.28646,-4.39866 z"
+         style="fill:url(#linearGradient16110);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16112);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccc"
+         id="path4262"
+         d="m 955.00897,164.0229 c 1.64588,-1.3012 -1.57206,-1.02901 1.40136,-1.5899 2.97342,-0.56088 6.23749,0.79427 7.93009,3.30778 0.82449,0.98653 1.66644,2.32603 3.03633,2.5002 2.58316,-0.11093 2.33757,-3.22883 3.49549,-4.70335 1.48922,-1.12702 2.70719,0.6014 2.20637,2.0248 -0.14998,1.9513 0.4963,3.76576 1.34611,5.4594 0.45921,1.88159 0.23638,3.95716 1.33595,5.65 1.92136,4.02295 1.80606,8.58646 1.65561,12.93376 -1.85587,0.3491 -1.25197,-2.67426 -1.91177,-3.81179 -0.40031,-2.33408 -0.0677,-4.79893 -0.76159,-7.06535 -1.36405,-1.68108 -3.29733,0.88928 -2.31842,2.31915 -0.15701,1.93172 -1.2804,3.92804 -2.57941,5.22914 0.0355,-1.29908 -0.48809,-3.14875 -2.19683,-2.83409 -2.27367,0.6026 0.14389,3.3746 -1.72862,4.19419 -1.67377,0.13979 -2.39906,-2.02106 -3.05529,-3.25862 -0.96773,-2.56094 -1.20987,-5.32827 -2.20445,-7.88474 -1.04811,-2.80297 -1.61211,-6.0597 -4.00177,-8.08782 -1.42953,-0.72419 -3.29504,-3.08155 -1.64916,-4.38276 z"
+         style="fill:url(#linearGradient16105);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16107);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient16100);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16102);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 953.20205,136.52978 c -0.11474,-1.82286 1.06302,-3.77367 -0.007,-5.48372 -0.96755,-1.26691 -1.84976,-3.11689 -0.89186,-4.62871 1.64206,-2.35584 4.54339,-3.1735 6.84031,-4.69765 1.31159,-0.70272 2.64367,-1.36875 4.0068,-1.96608 1.69183,0.15882 2.51773,2.01275 2.52563,3.52726 0.36585,3.55774 0.35189,7.17673 1.24044,10.65945 0.44557,2.27829 0.50121,4.63752 1.31859,6.83334 0.38522,1.21389 0.80571,2.57703 0.12487,3.77647 -0.70588,1.58429 -2.54927,2.52779 -4.2394,2.05269 -1.90953,-0.32484 -3.11292,-1.97948 -4.67223,-2.9416 -1.72877,-1.02262 -3.9165,-1.32774 -5.33944,-2.81781 -0.88151,-1.25564 -0.73218,-2.86636 -0.90706,-4.31364 z"
+         id="path4241" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4243"
+         d="m 953.80836,139.40875 c 0.83312,-0.54815 -0.60808,-1.80761 1.00447,-1.71545 3.29829,-1.1931 7.0967,0.21187 9.223,2.90325 1.13088,1.5657 3.9174,1.90156 4.47772,-0.3488 0.4249,-1.36666 0.48847,-4.84297 2.73345,-3.61085 1.30785,1.09416 0.36455,2.87824 1.16355,4.21569 0.75529,1.76012 1.99164,3.31781 2.25565,5.26827 0.30516,1.84053 1.60628,3.19423 2.38069,4.81942 1.60963,3.3808 2.01148,7.15749 2.37746,10.83772 -1.90114,0.0654 -1.78878,-2.32715 -2.30704,-3.60876 -0.85445,-1.90581 -0.73147,-4.10984 -1.48928,-6.06458 -0.60382,-2.48403 -3.58457,-0.14722 -2.58104,1.66377 0.89103,1.65481 -0.8122,5.02023 -1.57571,5.41929 0.2371,-1.93433 -3.19937,-3.44217 -3.36294,-0.97212 0.29575,1.20115 0.52494,3.91911 -1.50034,2.95684 -2.38456,-1.59584 -3.11838,-4.567 -4.17044,-7.07321 -1.00937,-2.59461 -2.31471,-5.06081 -3.62299,-7.51263 -0.89451,-1.57781 -2.23009,-2.91214 -3.89772,-3.64769 -1.05952,-0.73319 -2.29368,-2.34531 -1.10849,-3.53016 z"
+         style="fill:url(#linearGradient16095);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16097);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccc"
+         id="path1404"
+         d="m 897.27688,58.98919 c 3.4177,4.77828 27.94089,36.04178 12.34916,51.22112 -6.98535,7.21672 -15.88179,9.83871 -25.99981,9.11112 -9.0356,3.38229 -41.79586,23.08085 -52.00055,28.00473 -3.87756,0.54277 -10.46957,-1.49628 -10.01299,-4.45918 4.57708,-2.38349 8.84027,-2.23142 11.67666,-5.62515 6.02828,-1.40318 12.1608,-5.39016 14.724,-13.6596 5.70526,-1.40377 25.8808,-14.773 32.23282,-20.77046 3.04325,-3.54256 8.4774,-7.30113 10.61219,-11.5061 2.23198,-5.19015 1.0306,-19.12504 -0.88366,-25.4059 7.49108,9.22389 -0.88344,-14.20077 7.30218,-6.91058 z"
+         style="fill:url(#linearGradient16090);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16092);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccc"
+         id="path3182"
+         d="m 892.10863,33.36621 c 3.39497,-0.39792 7.7696,2.2625 6.41988,6.0886 -0.54246,3.31765 -3.01656,6.14022 -6.25356,7.05328 -3.57719,1.90155 -8.03741,1.09927 -11.50071,3.06337 -2.82773,3.62785 3.80316,13.18097 6.65285,12.89879 -0.64213,5.4988 -0.91929,23.3462 -1.37817,25.82933 -0.94585,3.89168 -11.97094,11.93327 -16.85216,15.41152 -2.64905,3.54229 -8.05098,4.51964 -10.59573,0.30141 -2.62384,-2.88943 0.89753,-25.56846 3.5515,-32.70699 1.46025,-4.05328 7.36062,-25.8253 12.29749,-30.79516 1.69199,-1.13286 13.55301,-6.85189 17.65861,-7.14415 z"
+         style="fill:url(#linearGradient16085);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16087);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccs"
+         id="path2295-80"
+         d="m 879.5372,36.59392 c -0.90931,-1.17854 -13.87962,8.80199 -17.22388,12.79517 -6.13736,7.65052 -14.10562,17.77013 -17.37377,23.85776 -3.52873,3.52843 -19.21286,22.42504 -24.66145,40.04002 1.76484,-1.06394 10.0905,-10.19232 12.66318,-11.43011 3.20232,-3.2743 -3.92234,13.6658 -6.94107,18.28818 -3.1389,1.8005 -3.48479,5.47955 -4.69674,8.88085 -0.99839,3.33746 -2.29579,6.81278 -0.40179,9.94766 3.61758,-1.46867 7.19287,-5.39812 11.80419,-6.12377 1.46888,-4.02072 2.58824,-12.01154 9.49046,-12.80172 6.81628,-1.02543 12.98094,-4.49749 18.01108,-9.13024 3.47641,-3.69162 19.1766,-14.05102 19.00863,-15.07389 -5.72928,1.37587 -11.95139,4.53102 -18.02495,3.81004 2.85362,-4.02431 17.85762,-19.63045 20.72661,-24.78603 1.57862,-4.78738 3.45896,-9.48633 5.66656,-14.03479 1.64788,-4.00011 5.83299,-7.20769 0.26725,-12.30742 -1.80003,-0.92086 -2.14987,3.50069 -3.84176,5.89271 -2.97877,4.73423 -12.52263,4.68031 -14.00038,-1.35599 -1.6553,-6.77673 10.13042,-15.68742 9.52783,-16.46843 z"
+         style="fill:url(#linearGradient16080);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16082);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4100"
+         d="m 914.44597,44.10255 c 1.44896,2.74012 4.24007,4.5793 7.20285,5.31399 2.50799,1.76531 -0.32688,5.25623 1.6578,7.29135 1.96279,2.02618 3.35229,4.59257 3.88939,7.35703 1.39227,3.07691 2.94105,6.15414 3.36391,9.54877 1.12761,3.4983 4.48713,5.47103 6.81942,8.10746 1.48979,1.65008 3.23923,3.27033 3.96315,5.41628 0.70078,2.28062 -1.59626,3.11472 -3.36414,2.80025 -1.30006,0.91035 0.27936,5.38029 -2.3584,3.87491 -2.26056,-1.84198 -2.90432,-4.90921 -2.57583,-7.67852 -0.18861,-3.36588 -2.20609,-6.22187 -3.36573,-9.29022 -2.13219,-3.44143 -5.31407,-6.34528 -9.1875,-7.66058 -2.45547,-0.93569 -4.88646,-2.37478 -6.05894,-4.83621 -1.72425,-2.52192 -3.25934,-5.297 -3.41067,-8.4218 -0.58356,-3.93121 -0.42474,-8.31975 2.13014,-11.57173 0.34396,-0.31907 0.85937,-0.37461 1.29455,-0.25098 z"
+         style="fill:url(#linearGradient16075);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16077);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4102"
+         d="m 929.87584,62.96128 c 1.88582,-1.37809 4.24811,-0.13242 6.33727,-0.56127 2.90689,-0.27827 6.18287,-0.44841 8.63327,1.43038 2.18978,2.34425 3.73351,5.28537 4.35934,8.43385 0.76416,2.30997 2.49881,4.08107 3.92564,5.98059 0.86253,1.48511 1.29674,3.64529 0.046,5.0338 -1.43568,1.0594 -3.12203,-0.35551 -3.86762,-1.59777 -1.13407,-1.4752 -2.115,-3.452 -3.7136,-4.34316 -1.61927,0.65209 0.50534,2.76361 -0.0751,4.08459 -0.0309,1.68517 0.48941,3.34167 1.29843,4.80679 0.50729,1.59278 -0.58679,4.07523 -2.52589,3.65041 -1.63025,-0.52388 -1.69391,-2.47448 -1.99732,-3.88067 -0.71637,-2.40961 -3.66528,-2.96942 -4.87202,-5.04124 -2.95297,-4.67848 -6.27702,-9.40963 -7.23346,-14.97438 -0.14446,-1.00288 -0.20934,-2.01475 -0.31497,-3.02192 z"
+         style="fill:url(#linearGradient16070);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16072);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4106"
+         d="m 946.04044,110.47545 c -0.11473,-1.82287 1.06302,-3.77367 -0.007,-5.48372 -0.96755,-1.26691 -1.84975,-3.11689 -0.89186,-4.62871 1.64206,-2.35584 4.5434,-3.1735 6.84031,-4.69765 1.31159,-0.70273 2.64368,-1.36875 4.0068,-1.96608 1.69183,0.15881 2.51773,2.01276 2.52563,3.52726 0.36585,3.55774 0.3519,7.17673 1.24044,10.65944 0.44557,2.2783 0.50121,4.63753 1.3186,6.83335 0.38521,1.21389 0.8057,2.57703 0.12487,3.77647 -0.70589,1.58429 -2.54927,2.52779 -4.23941,2.05269 -1.90953,-0.32485 -3.11291,-1.97948 -4.67222,-2.9416 -1.72877,-1.02262 -3.91651,-1.32774 -5.33945,-2.81781 -0.88151,-1.25564 -0.73218,-2.86636 -0.90706,-4.31364 z"
+         style="fill:url(#linearGradient16065);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16067);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4108"
+         d="m 946.05783,115.65363 c 0.67636,-0.73285 -1.026,-1.60765 0.5612,-1.90703 2.9133,-1.95317 6.93841,-1.50551 9.65091,0.59378 1.47502,1.24682 4.26033,0.90091 4.26151,-1.41816 0.0828,-1.4288 -0.69366,-4.81787 1.78217,-4.1634 1.53308,0.74653 1.04779,2.70543 2.14569,3.81076 1.1574,1.52607 2.73286,2.73971 3.45936,4.56896 0.73994,1.71265 2.32908,2.71269 3.4725,4.10321 2.37731,2.89294 3.67792,6.46131 4.92047,9.94472 -1.82928,0.52185 -2.29712,-1.8272 -3.10911,-2.94602 -1.28876,-1.64356 -1.70084,-3.81222 -2.90761,-5.52657 -1.18495,-2.26515 -3.51429,0.72143 -2.10372,2.23702 1.26374,1.39115 0.42222,5.06794 -0.22254,5.63933 -0.2363,-1.93443 -3.93495,-2.56919 -3.49812,-0.13258 0.57665,1.0944 1.45442,3.6769 -0.74313,3.23136 -2.69899,-0.9738 -4.12755,-3.68037 -5.75287,-5.85897 -1.60519,-2.27468 -3.46665,-4.35337 -5.3275,-6.41741 -1.24856,-1.31558 -2.86647,-2.28851 -4.66226,-2.60026 -1.20504,-0.45609 -2.79149,-1.72308 -1.92695,-3.15874 z"
+         style="fill:url(#linearGradient16060);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16062);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path4104"
+         d="m 962.44999,98.96429 c 2.10305,0.98621 2.20678,3.92503 4.38211,4.83765 1.31702,0.95523 2.33377,3.04425 1.23154,4.50475 -1.42093,1.55816 -3.63013,-0.43203 -3.74971,-2.08598 -0.278,-2.5918 -3.15494,-3.44784 -4.49777,-5.35785 -0.48993,-0.62284 -0.66136,-2.21889 -1.697,-1.91388 0.59459,1.46498 1.78152,3.64432 0.13687,4.8879 -2.23882,0.60058 -2.85338,-2.18039 -4.18014,-3.25278 -1.79672,-1.22637 -4.05629,1.24301 -2.01722,2.62817 1.17445,0.54775 1.46696,3.3305 -0.25622,2.42891 -1.67795,-1.05566 -2.44586,-3.16635 -4.37155,-3.91102 -2.15137,-1.0706 -4.84316,-1.44553 -6.2974,-3.56844 -1.32455,-1.61127 -2.66219,-3.24189 -3.6879,-5.06002 -0.43522,-2.16629 2.32931,-2.25723 3.73306,-1.64712 1.62627,0.35037 3.6449,1.03843 5.04582,-0.23429 1.45925,-1.7036 0.0626,-4.52818 1.99176,-5.9734 2.07511,-1.24859 3.36858,1.291 4.57528,2.46001 1.66488,0.95721 4.07776,0.65092 5.16948,2.51235 0.94318,1.75549 1.81254,3.56092 3.04657,5.14274 0.63988,1.09193 1.79025,2.23495 1.44242,3.6023 z"
+         style="fill:url(#linearGradient16055);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16057);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccc"
+         id="path4084"
+         d="m 902.9348,44.34747 c -1.95065,-1.58391 -5.03144,-2.1142 -7.12287,-0.49953 -3.62634,1.3407 -5.81751,7.27982 -2.58747,9.26979 1.50728,1.45343 5.67739,1.86915 7.2076,0.87776 3.57878,0.98093 5.35584,3.67556 7.12153,4.09007 1.95842,1.11529 2.50062,3.48171 3.54965,5.31705 0.79244,1.52533 1.65497,3.23101 3.22058,4.06995 1.8516,0.42007 3.29611,-1.43452 1.98662,-2.55398 -1.70313,-1.56987 -1.78446,-14.9342 -2.1849,-19.53547 -0.0769,-1.84467 -3.49723,-3.43052 -4.35722,-1.82399 -1.54142,1.61347 -2.31937,9.89663 -1.92855,7.49382 -0.6182,-2.012 -3.2554,-5.2408 -4.90497,-6.70547 z"
+         style="fill:url(#linearGradient16050);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16052);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscccc"
+         id="path1341"
+         d="m 965.88904,178.67165 c -14.74923,-8.1134 -24.88511,-12.98314 -38.77368,-20.67849 -8.06218,-3.59847 -9.28754,10.30952 -6.28,16.63723 3.19977,6.73218 -9.94552,9.43894 -0.25859,15.97561 9.16491,2.01065 31.29307,2.65341 47.19504,2.58387 9.57944,1.94465 40.50729,-10.09135 17.82897,-17.84788 -7.02175,-1.7005 -12.58113,5.59675 -19.71174,3.32966 z"
+         style="fill:url(#linearGradient16045);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16047);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssss"
+         id="path2699"
+         d="m 866.72811,67.28129 c -0.92834,2.08876 0.85795,3.80725 1.84332,4.79262 0.92808,0.92808 2.91051,1.46496 4.42396,1.84332 1.60762,0.40191 3.40592,-0.45714 5.07281,-0.45714 2.19032,0 2.66913,-3.23063 2.66913,-5.07281 0,-1.75147 -2.39826,-3.32186 -2.94931,-4.42397 -0.64935,-1.2987 -4.17779,-1.15474 -4.96959,-1.94654 -0.5564,-0.5564 -4.46335,1.60384 -6.09032,5.26452 z"
+         style="fill:url(#linearGradient16040);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16042);stroke-width:0.22857143px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0.00018261719"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect4651-3"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssccccscscccc"
+         id="path1328-7"
+         d="m 1063.6698,114.76727 c 0.1488,-8.90473 4.1315,-17.27881 10.3811,-23.36574 4.8424,-4.71635 10.3046,-7.95336 16.7098,-9.88881 5.906,-1.78461 13.8622,-1.65879 19.7432,0.0378 7.1569,2.0646 12.5558,4.84878 18.243,9.65035 8.6223,7.27958 11.6795,20.83653 9.2329,25.44638 -0.9836,4.90028 -6.8972,21.55358 -9.2036,28.91007 -1.9073,4.54833 -1.7174,9.71036 -1.9829,14.56925 0.6835,5.55722 -1.7905,10.85767 -4.6653,15.4226 -2.9976,3.20794 -7.1603,4.55708 -9.8035,7.99081 -3.6295,4.71495 -8.3462,0.30642 -11.9212,1.12975 -4.5361,-0.73681 -9.2588,4.11548 -12.2244,-1.36891 -2.9019,-5.36674 -9.9856,-7.80926 -13.5512,-12.86797 -3.5877,-2.49161 -2.3257,-7.46478 -2.4935,-11.21637 0.4368,-6.70062 0.104,-13.64394 -2.8606,-19.79138 -0.2903,-0.85043 -4.528,-17.2008 -5.6038,-24.65778 z"
+         style="fill:url(#linearGradient16034);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16036);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc"
+         id="path2239-5"
+         d="m 1074.5501,117.15958 c -0.8862,4.70145 0.3047,10.63426 -4.7896,13.38539 -3.4186,3.17773 -5.9596,10.87769 -1.851,15.43649 6.9801,3.34102 12.3205,1.61174 13.8967,10.74147 0.7627,8.16472 8.9043,8.66591 13.5729,8.1997 5.1242,0.0833 12.3302,0.29865 17.205,-0.0482 6.7297,-0.24807 4.1261,-13.85433 11.4363,-14.10733 7.0714,-0.86714 10.374,-7.20195 9.9983,-13.4065 -2.0669,-5.26459 -5.8872,-9.7533 -4.3456,-16.01272"
+         style="fill:url(#linearGradient16029);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16031);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccc"
+         id="path2206-3"
+         d="m 1108.7216,124.92275 c -2.3333,2.84465 -2.7518,3.90021 -3.3476,7.6248 0.056,2.43563 3.0549,5.51312 5.0816,6.57714 2.9136,1.65048 5.6676,1.6278 9.0354,0.86744 1.8496,-0.36124 4.2763,-1.6453 4.5373,-3.64312 0.4721,-2.35106 1.497,-9.63238 0.3777,-10.78769 -1.5307,-1.33098 -7.0975,-2.5647 -8.983,-3.01537 -1.1184,-0.56788 -5.765,1.41469 -6.7014,2.3768 z"
+         style="fill:url(#linearGradient16026);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc"
+         id="path2204-8"
+         d="m 1079.916,123.78693 c -2.1317,2.20277 -2.9807,3.93176 -2.5635,8.28002 0.2984,2.56527 0.4908,5.36749 2.4872,7.0963 6.7866,1.14012 12.8626,-0.85446 13.9577,-2.95524 2.2568,-2.73569 2.9457,-4.58466 3.041,-7.99002 -0.3448,-3.52119 -3.5648,-6.43521 -6.7831,-5.98346 -2.9388,0.35785 -5.5253,-0.84505 -10.1393,1.5524 z"
+         style="fill:url(#linearGradient16023);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccs"
+         id="path2228-8"
+         d="m 1101.0227,132.95437 c -0.8716,0.28718 -1.5707,2.50287 -1.9754,3.33644 -1.5214,3.71662 -3.8054,9.47545 -2.8135,12.22658 1.1729,0.73413 3.4583,-1.24216 4.3248,-0.93842 1.0447,0.24609 2.314,1.52036 3.9659,1.23442 1.2911,0.55645 0.1027,-9.92498 -1.4017,-12.25109 -0.6708,-1.74541 -1.0086,-3.96757 -2.1001,-3.60793 z"
+         style="fill:url(#linearGradient16020);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path2244-8"
+         d="m 1081.4978,154.27534 c 2.0571,5.31294 -0.2949,11.34061 4.3118,13.36695 4.8979,1.46447 9.495,2.07861 14.5842,1.95297 6.4302,-1.22183 12.4784,1.36032 16.4213,-4.00028 1.4766,-3.30472 0.7468,-9.01145 3.2273,-11.76559"
+         style="fill:none;stroke:url(#linearGradient16017);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssc"
+         id="path2275-5"
+         d="m 1098.336,157.88444 c -0.2924,0.30536 -1.2797,1.00724 -1.7247,1.89714 -0.3324,0.66488 -0.3735,2.52884 -0.5174,3.10443 -0.3067,1.22698 0.1621,1.63329 1.0348,2.06964 0.7931,0.39649 1.6854,0.1059 2.2421,-0.17248 0.7777,-0.38883 0.6701,-1.12806 0.8624,-1.89716 0.2005,-0.80216 0,-1.93355 0,-2.75949 0,-1.05798 -0.098,-1.4778 -0.6899,-2.06963 -0.4979,-0.49785 -0.01,-0.41259 -1.2073,-0.17245 z"
+         style="fill:url(#linearGradient16012);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16014);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssc"
+         id="path2277-6"
+         d="m 1101.268,157.88444 c -0.01,-0.01 -0.7399,1.92451 -0.8624,2.41454 -0.192,0.76802 0.3729,1.61289 0.1725,2.41456 -0.2824,1.12948 -0.499,1.56144 0.1725,1.89716 0.8876,0.4438 1.3588,0.46908 2.2421,0.68987 1.0572,0.2643 1.7135,-0.55997 2.0696,-1.0348 0.4459,-0.59453 -0.2422,-2.00375 -0.345,-2.41456 -0.2342,-0.93693 -0.5943,-1.53368 -1.0348,-2.41456 -0.2523,-0.5046 -1.161,-0.91393 -1.5522,-1.20729 -0.2477,-0.18576 -0.5749,-0.22995 -0.8623,-0.34492 z"
+         style="fill:url(#linearGradient16007);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16009);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2279-9"
+         d="m 1105.0623,158.57431 c -0.8739,-0.65539 0,2.18458 0,3.2769 0,0.82386 0.032,1.85169 0.1725,2.41456 0.1253,0.50123 1.713,0.42826 2.0696,0.5174 1.0999,0.27499 1.8468,-0.41686 2.2421,-1.20729 0.3644,-0.72878 -0.5174,-1.77366 -0.5174,-2.58701 0,-1.34555 -0.549,-2.1117 -1.0349,-2.75951 -0.6871,-0.91625 -2.3857,-0.092 -2.9319,0.34495 z"
+         style="fill:url(#linearGradient16002);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient16004);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path2281-4"
+         d="m 1110.2363,158.05689 c 0,-0.005 -0.3449,2.34484 -0.3449,3.10443 0,0.99745 -0.1581,1.58091 0.1725,2.24211 0.1932,0.38642 1.8229,0.46824 2.0696,0.34493 0.9989,-0.49944 0.8623,-2.36487 0.8623,-3.44938 0,-0.71501 -0.9727,-1.86614 -1.3797,-2.06962 -0.5155,-0.25775 -0.6063,-0.17247 -1.3798,-0.17247 z"
+         style="fill:url(#linearGradient15997);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15999);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2283-9"
+         d="m 1113.5133,157.71196 c -1.0297,-0.51486 -0.1725,2.29815 -0.1725,3.44936 0,1.14924 -0.5458,1.4569 0.1725,2.41456 0.5322,0.70964 1.4362,-0.63186 1.8971,-0.86234 0.5068,-0.25341 0.3449,-1.8724 0.3449,-2.41456 0,-0.88952 -0.3726,-1.78016 -0.6898,-2.41454 -0.2739,-0.54782 -1.2082,-0.2413 -1.5522,-0.17248 z"
+         style="fill:url(#linearGradient15992);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15994);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2287-8"
+         d="m 1092.2996,158.22936 c 0,-0.008 0.345,2.1592 0.345,2.93196 0,0.57299 0.1979,1.67964 0.3449,2.41456 0.2167,1.0835 -0.8777,0.86235 -1.7247,0.86235 -0.9321,0 -1.439,-0.76884 -1.8972,-1.37975 -0.3581,-0.47759 0.049,-2.43884 0.1725,-2.93196 0.2108,-0.84302 1.0282,-1.29019 1.5522,-1.55221 0.5256,-0.26282 0.2679,-0.15707 1.2073,-0.34495 z"
+         style="fill:url(#linearGradient15987);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15989);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssc"
+         id="path2289-9"
+         d="m 1088.5053,159.09171 c 0.5361,-0.26804 0,1.92768 0,2.58703 0,1.01342 0.4461,1.17738 0,2.06962 -0.3575,0.715 -2.0985,-0.27312 -2.2421,-0.34493 -0.6957,-0.34789 -0.6899,-1.4419 -0.6899,-2.24211 0,-0.84763 0.7133,-1.81842 0.8624,-2.41456 0.4285,-1.71412 1.6026,-0.23878 2.0696,0.34495 z"
+         style="fill:url(#linearGradient15982);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15984);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssc"
+         id="path2291-7"
+         d="m 1092.6446,159.6091 c 0.5284,-0.84407 0.5087,-1.42068 1.7246,-1.72466 0.082,-0.0204 1.5045,1.5336 1.5523,1.72466 0.2023,0.80946 -0.053,2.02963 0.1724,2.93199 0.3018,1.20716 -0.1547,1.50466 -1.0348,1.72468 -1.2229,0.30571 -1.4449,0.25694 -1.7247,-0.86234 -0.1707,-0.68284 -0.3906,-1.73501 -0.5174,-2.24211 -0.1253,-0.50112 -0.1724,-1.02069 -0.1724,-1.55222 z"
+         style="fill:url(#linearGradient15977);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15979);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2295-3"
+         d="m 1085.5733,158.40183 c 0.2394,0.62053 0.1725,2.57401 0.1725,3.79431 0,1.33697 -0.5447,1.20729 -1.7247,1.20729 -0.9424,0 -1.2073,-0.76843 -1.2073,-1.72469 0,-1.16107 -0.098,-1.70195 0.5174,-2.93198 0.4091,-0.81811 0.7455,-1.09043 1.2073,-1.55222 0.3748,-0.37477 0.838,0.71517 1.0348,1.20729 z"
+         style="fill:url(#linearGradient15972);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15974);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2299-1"
+         d="m 1086.9531,164.95565 c -0.6504,-0.65044 0,1.83965 0,2.75948 0,1.04673 0.3366,1.20729 1.3797,1.20729 0.2977,0 0.7784,-2.07866 0.8624,-2.41456 0.204,-0.816 0.1573,-1.78506 0,-2.41456 -0.4393,-1.75706 -2.0536,0.39117 -2.2421,0.86235 z"
+         style="fill:url(#linearGradient15967);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15969);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2301-4"
+         d="m 1099.1983,170.12969 c -0.1485,-0.59412 -0.2459,-2.36356 -0.5174,-3.44935 -0.2585,-1.03409 -0.4605,-1.32291 -1.2072,-2.06964 -0.9233,-0.92324 -0.9865,1.82814 -1.0348,2.06964 -0.1884,0.94159 0.4903,1.44409 0.6898,2.24208 0.2445,0.97813 0.8213,1.20727 2.0696,1.20727 z"
+         style="fill:url(#linearGradient15962);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15964);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2303-8"
+         d="m 1099.5433,170.12969 c 0.2792,1.11687 -0.1725,-2.29815 -0.1725,-3.44935 0,-1.10462 -0.3047,-1.24749 0.345,-1.89717 0.6946,-0.69462 1.7605,0.93397 1.8971,1.20727 0.3755,0.7511 0.5174,1.06845 0.5174,2.24211 0,1.06318 -0.8012,1.17671 -1.5522,1.55222 -1.0127,0.50632 2.1893,-0.29988 -1.0348,0.34492 z"
+         style="fill:url(#linearGradient15957);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15959);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2305-6"
+         d="m 1102.8202,170.12969 c -0.142,0.071 -0.1725,-2.54471 -0.1725,-3.2769 0,-1.07794 0.4293,-1.11911 1.0348,-1.72469 0.7935,-0.79351 1.7082,1.12774 1.8972,1.37976 0.4605,0.61396 0.1095,1.97669 0,2.41456 -0.085,0.34186 -2.3402,1.03953 -2.7595,1.20727 z"
+         style="fill:url(#linearGradient15952);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15954);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2307-3"
+         d="m 1096.6113,169.78477 c -0.2382,0.95305 -0.4454,-1.97361 -1.0348,-2.75951 -0.8225,-1.09669 -0.3409,-1.46399 -1.5522,-2.06961 -0.6934,-0.34672 -0.9786,1.43984 -1.2073,1.89714 -0.4633,0.9267 0.4934,1.71268 0.8623,1.89716 0.6834,0.34167 0.8541,0.94441 1.7247,1.37974 0.4019,0.20092 0.5889,0.23348 1.0349,0.34495"
+         style="fill:url(#linearGradient15947);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15949);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2309-9"
+         d="m 1091.9547,169.09489 c 0.2588,0.12942 0,-2.56935 0,-3.2769 0,-1.34211 -0.1194,-1.03482 -1.5523,-1.03482 -0.9902,0 -0.8623,1.676 -0.8623,2.58704 0,1.20353 0.058,1.49491 0.8623,1.89714 0.7312,0.36557 0.636,0.51471 1.5523,-0.17246 z"
+         style="fill:url(#linearGradient15942);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15944);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2311-2"
+         d="m 1106.6145,169.61229 c 0.9383,0.46916 0.048,-2.16611 0.5174,-3.10443 0.387,-0.77408 1.4935,-1.03482 2.2421,-1.03482 1.092,0 0.8623,0.92751 0.8623,1.89717 0,0.62613 -0.9489,1.29387 -1.3797,1.72468 -0.4489,0.44891 -1.5367,0.5174 -2.2421,0.5174 z"
+         style="fill:url(#linearGradient15937);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15939);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2313-3"
+         d="m 1110.9262,168.57748 c -0.4066,0.40659 0.074,-1.67426 0.5174,-3.44938 0.2329,-0.93145 1.2717,-0.67376 1.8972,-0.5174 0.97,0.24251 0.3635,1.86006 0.1725,2.24209 -0.4911,0.98204 -1.4875,1.72469 -2.5871,1.72469 z"
+         style="fill:url(#linearGradient15932);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15934);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssssssssss"
+         id="path2353-3"
+         d="m 1099.4875,83.41592 c -0.3252,0.89433 0.4878,0.99841 0.4878,2.43909 0,0.65713 -2.5514,3.67775 -2.1951,4.39034 0.5134,1.02685 1.9094,1.90941 2.1951,2.19514 0.1945,0.19449 -5.927,-0.60617 -6.5703,1.46347 -0.5509,1.77213 -2.4659,-1.57691 -4.2302,-1.13585 -1.208,0.30203 -3.509,4.51762 -4.5505,5.03835 -1.5107,0.75536 -2.9868,-1.87186 -3.4147,-0.1602 -0.2999,1.19963 -0.212,2.06748 -0.4878,3.1708 -0.5005,2.00176 0.7998,-0.74592 -2.4391,-0.20611 -1.4765,0.2461 -1.7074,-0.61564 -1.7074,2.68299 0,0.078 -3.0207,1.53854 -3.4146,2.19517 -0.764,1.27323 -1.0361,1.67435 -1.4635,3.3838 -0.5581,2.23234 -4.1858,0.95403 -5.3355,2.10374"
+         style="fill:none;stroke:url(#linearGradient15929);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssssssssssss"
+         id="path2357-4"
+         d="m 1098.527,93.79319 c 1.0569,-1.05695 2.1139,-2.11387 3.1708,-3.1708 1.0569,-1.05694 -2.1139,2.11385 -3.1708,3.1708 -1.1382,1.13822 2.4489,-2.12694 3.4147,-3.41471 1.3658,-1.82099 4.0513,0.54135 4.6343,1.70735 0.707,1.41396 1.789,2.58523 2.439,2.19517 0.9686,-0.58112 2.5292,-0.97563 3.6586,-0.97563 2.3472,0 3.42,1.96166 4.3904,3.90251 0.6982,1.39651 2.5101,-0.97562 4.3903,-0.97562 1.927,0 2.8698,0.96012 2.4391,2.68298 -0.1865,0.74581 2.3898,1.6581 2.9269,2.19517 1.369,1.36901 -0.5278,2.61202 1.7073,3.17079 2.0547,0.51368 5.9206,1.84604 7.1954,2.16475"
+         style="fill:none;stroke:url(#linearGradient15926);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2375-6"
+         d="m 1079.8819,116.8369 c 1.7888,0.0911 5.7581,-1.03481 8.6234,-1.03481 3.0021,0 5.0907,-0.21417 7.5886,1.03481 0.466,0.23299 0.9322,0.4661 1.3798,0.68988"
+         style="fill:none;stroke:url(#linearGradient15923);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssc"
+         id="path2377-7"
+         d="m 1106.442,117.52678 c 1.24,-1.0185 3.8992,-2.41456 5.864,-2.41456 2.1836,0 4.0033,0 6.2088,0 1.3798,0 2.7595,0 4.1393,0"
+         style="fill:none;stroke:url(#linearGradient15920);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect5962"
+         width="200"
+         height="200"
+         x="0"
+         y="200.00018" />
+      <path
+         style="fill:url(#linearGradient15914);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15916);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 50.19662,299.85596 c 0.18876,-11.30046 5.24297,-21.92754 13.17401,-29.65209 6.14524,-5.98524 13.07699,-10.09315 21.2055,-12.54932 7.495,-2.26473 17.59164,-2.10506 25.05486,0.0479 9.08237,2.62007 15.93386,6.15329 23.15118,12.24668 10.94209,9.23812 14.8218,26.44243 11.71698,32.29253 -1.24826,6.21866 -8.75294,27.35239 -11.6798,36.6881 -2.4205,5.772 -2.17943,12.32284 -2.51637,18.48894 0.8674,7.0524 -2.27221,13.7789 -5.92049,19.5719 -3.80413,4.071 -9.0867,5.7832 -12.44105,10.1407 -4.60592,5.9835 -10.59165,0.3889 -15.12851,1.4337 -5.75654,-0.935 -11.74979,5.2227 -15.5132,-1.7372 -3.68267,-6.8106 -12.67224,-9.9103 -17.19717,-16.33 -4.55286,-3.1619 -2.95138,-9.4731 -3.16424,-14.234 0.55428,-8.5034 0.132,-17.31475 -3.63023,-25.11609 -0.36847,-1.07926 -5.7463,-21.82853 -7.11147,-31.29176 z"
+         id="path5964"
+         sodipodi:nodetypes="cssssccccscscccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15909);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15911);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 64.00411,302.89189 c -1.12461,5.96635 0.38673,13.49533 -6.07811,16.98663 -4.33837,4.03265 -7.56308,13.80424 -2.34899,19.58954 8.85795,4.2399 15.63519,2.04536 17.63548,13.63134 0.96791,10.3614 11.2999,10.9974 17.2246,10.4058 6.50283,0.1057 15.64746,0.379 21.83379,-0.061 8.54028,-0.3148 5.23618,-17.5817 14.51314,-17.90277 8.97389,-1.10044 13.16499,-9.13957 12.6883,-17.01342 -2.62296,-6.68098 -7.47113,-12.37734 -5.51473,-20.32079"
+         id="path5966"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15906);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 107.36923,312.7437 c -2.96112,3.60996 -3.49219,4.94952 -4.24827,9.67619 0.0713,3.09089 3.87677,6.99636 6.44872,8.34666 3.6975,2.09452 7.19251,2.06574 11.46638,1.10082 2.34723,-0.45843 5.42677,-2.08796 5.75796,-4.62327 0.59916,-2.98362 1.89982,-12.22389 0.47939,-13.69005 -1.94249,-1.68904 -9.00703,-3.2547 -11.39985,-3.82663 -1.41926,-0.72063 -7.31604,1.79531 -8.50433,3.01628 z"
+         id="path5968"
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15903);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 70.81373,311.30227 c -2.70528,2.79541 -3.78265,4.98959 -3.25326,10.5077 0.3788,3.25544 0.62293,6.81157 3.15646,9.00551 8.61243,1.44686 16.32309,-1.08434 17.71287,-3.75034 2.86391,-3.47171 3.73826,-5.8181 3.85909,-10.13967 -0.43757,-4.46852 -4.52383,-8.16652 -8.60802,-7.59324 -3.72944,0.45413 -7.01187,-1.07242 -12.86714,1.97004 z"
+         id="path5970"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15900);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 97.59896,322.93615 c -1.10611,0.36444 -1.99324,3.17624 -2.5068,4.23408 -1.93077,4.71654 -4.8292,12.02474 -3.57046,15.51603 1.48849,0.93164 4.38873,-1.57634 5.4883,-1.19088 1.32583,0.31229 2.93653,1.92939 5.03294,1.56651 1.63847,0.70618 0.13028,-12.5952 -1.77891,-15.54714 -0.85123,-2.21499 -1.27982,-5.035 -2.66507,-4.5786 z"
+         id="path5972"
+         sodipodi:nodetypes="ccccccs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15897);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 72.82112,349.9934 c 2.61052,6.7423 -0.37428,14.3917 5.47178,16.9632 6.21567,1.8584 12.04955,2.6378 18.50795,2.4784 8.16021,-1.5506 15.83563,1.7263 20.83939,-5.0766 1.87386,-4.1938 0.94765,-11.4359 4.09552,-14.931"
+         id="path5974"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15892);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15894);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 94.18946,354.2502 c -0.37103,0.3875 -1.62403,1.2782 -2.1887,2.4075 -0.42188,0.8438 -0.474,3.2092 -0.6566,3.9397 -0.38928,1.5571 0.20574,2.0727 1.31321,2.6264 1.00639,0.5032 2.13876,0.1344 2.84531,-0.2188 0.98689,-0.4935 0.85035,-1.4316 1.09435,-2.4076 0.2545,-1.018 0,-2.4538 0,-3.5019 0,-1.3426 -0.12443,-1.8754 -0.87548,-2.6265 -0.63179,-0.6317 -0.008,-0.5235 -1.53209,-0.2188 z"
+         id="path5978"
+         sodipodi:nodetypes="csssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15887);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15889);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 98.2335,353.9269 c -0.0127,-0.013 -0.93889,2.4423 -1.09435,3.0642 -0.24366,0.9746 0.47321,2.0468 0.21887,3.0642 -0.35834,1.4333 -0.63324,1.9815 0.21887,2.4075 1.12642,0.5633 1.72445,0.5953 2.84531,0.8755 1.34163,0.3354 2.17449,-0.7106 2.62643,-1.3132 0.56585,-0.7545 -0.3074,-2.5428 -0.43774,-3.0642 -0.29725,-1.189 -0.75428,-1.9463 -1.31322,-3.0641 -0.32017,-0.6404 -1.47346,-1.1599 -1.96983,-1.5321 -0.3143,-0.2358 -0.72956,-0.2919 -1.09434,-0.4378 z"
+         id="path5980"
+         sodipodi:nodetypes="cssssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15882);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15884);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 102.72539,355.4489 c -1.10895,-0.8317 0,2.7723 0,4.1585 0,1.0455 0.0403,2.3499 0.21887,3.0642 0.15901,0.6361 2.17398,0.5435 2.62643,0.6566 1.39587,0.349 2.34377,-0.529 2.84531,-1.5321 0.46243,-0.9248 -0.65661,-2.2508 -0.65661,-3.283 0,-1.7076 -0.69665,-2.6798 -1.31322,-3.5019 -0.87206,-1.1628 -3.02761,-0.1168 -3.72078,0.4377 z"
+         id="path5982"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15877);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15879);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 109.29148,354.7923 c -0.005,-0.01 -0.43774,2.9757 -0.43774,3.9396 0,1.2658 -0.20067,2.0063 0.21887,2.8454 0.24519,0.4904 2.31342,0.5942 2.62644,0.4377 1.26761,-0.6338 1.09435,-3.0011 1.09435,-4.3774 0,-0.9074 -1.2345,-2.3682 -1.75096,-2.6264 -0.65421,-0.3271 -0.76946,-0.2189 -1.75096,-0.2189 z"
+         id="path5984"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15872);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15874);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 113.45001,354.3545 c -1.30672,-0.6533 -0.21887,2.9165 -0.21887,4.3774 0,1.4585 -0.69263,1.8489 0.21887,3.0642 0.67542,0.9006 1.82262,-0.8019 2.40756,-1.0943 0.64316,-0.3216 0.43775,-2.3762 0.43775,-3.0642 0,-1.1288 -0.47296,-2.2591 -0.87548,-3.0642 -0.3476,-0.6952 -1.5332,-0.3062 -1.96983,-0.2189 z"
+         id="path5986"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15867);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15869);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.52901,355.0112 c 0.005,-0.01 0.43775,2.7401 0.43775,3.7207 0,0.7272 0.2512,2.1316 0.43774,3.0642 0.27499,1.375 -1.11378,1.0944 -2.1887,1.0944 -1.18288,0 -1.82613,-0.9757 -2.40757,-1.751 -0.45456,-0.6061 0.0624,-3.095 0.21887,-3.7208 0.26746,-1.0698 1.30479,-1.6373 1.96983,-1.9698 0.66704,-0.3335 0.33994,-0.1993 1.53208,-0.4377 z"
+         id="path5988"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15862);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15864);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 81.71388,356.1055 c 0.6803,-0.3401 0,2.4463 0,3.2831 0,1.286 0.56615,1.4941 0,2.6264 -0.45368,0.9074 -2.66305,-0.3466 -2.84531,-0.4377 -0.88294,-0.4415 -0.87548,-1.8298 -0.87548,-2.8454 0,-1.0756 0.90523,-2.3076 1.09435,-3.0641 0.54382,-2.1753 2.03383,-0.3031 2.62644,0.4377 z"
+         id="path5990"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15857);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15859);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.96676,356.7621 c 0.67061,-1.0711 0.64562,-1.8029 2.1887,-2.1887 0.10363,-0.026 1.9092,1.9462 1.96982,2.1887 0.25681,1.0272 -0.0674,2.5757 0.21888,3.7208 0.38298,1.532 -0.19642,1.9095 -1.31323,2.1887 -1.55186,0.388 -1.83358,0.3261 -2.18869,-1.0943 -0.21664,-0.8666 -0.49573,-2.2018 -0.65661,-2.8454 -0.15899,-0.6359 -0.21887,-1.2953 -0.21887,-1.9698 z"
+         id="path5992"
+         sodipodi:nodetypes="cssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15852);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15854);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 77.99309,355.23 c 0.30374,0.7875 0.21887,3.2666 0.21887,4.8152 0,1.6966 -0.69128,1.5321 -2.18869,1.5321 -1.19592,0 -1.5321,-0.9752 -1.5321,-2.1887 0,-1.4735 -0.12386,-2.1599 0.65662,-3.7208 0.51911,-1.0382 0.94608,-1.3838 1.53208,-1.9698 0.47562,-0.4757 1.06342,0.9075 1.31322,1.532 z"
+         id="path5994"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15847);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15849);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 79.74405,363.5471 c -0.82541,-0.8254 0,2.3346 0,3.5019 0,1.3283 0.42718,1.5321 1.75096,1.5321 0.37769,0 0.98778,-2.6379 1.09435,-3.0642 0.25888,-1.0355 0.19972,-2.2653 0,-3.0642 -0.55744,-2.2297 -2.60614,0.4965 -2.84531,1.0944 z"
+         id="path5996"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15842);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15844);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 95.28381,370.1132 c -0.18849,-0.754 -0.31212,-2.9995 -0.65661,-4.3774 -0.32807,-1.3123 -0.58446,-1.6788 -1.53209,-2.6264 -1.17164,-1.1717 -1.25193,2.3199 -1.31322,2.6264 -0.23898,1.1949 0.62231,1.8326 0.87548,2.8453 0.31033,1.2413 1.04225,1.5321 2.62644,1.5321 z"
+         id="path5998"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15837);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15839);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 95.72155,370.1132 c 0.35433,1.4173 -0.21887,-2.9165 -0.21887,-4.3774 0,-1.4018 -0.38673,-1.5831 0.43774,-2.4076 0.8815,-0.8815 2.23415,1.1853 2.40757,1.5321 0.47658,0.9532 0.65661,1.3559 0.65661,2.8453 0,1.3492 -1.01677,1.4933 -1.96983,1.9698 -1.28512,0.6426 2.77827,-0.3805 -1.31322,0.4378 z"
+         id="path6000"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15832);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15834);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 99.88008,370.1132 c -0.18025,0.09 -0.21887,-3.2294 -0.21887,-4.1585 0,-1.368 0.54471,-1.4202 1.31322,-2.1887 1.00699,-1.007 2.16769,1.4311 2.40757,1.7509 0.58435,0.7792 0.13891,2.5085 0,3.0642 -0.10846,0.4338 -2.96976,1.3192 -3.50192,1.5321 z"
+         id="path6002"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15827);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15829);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 92.00076,369.6754 c -0.30236,1.2095 -0.56521,-2.5045 -1.31321,-3.5019 -1.04382,-1.3917 -0.43268,-1.8578 -1.96984,-2.6264 -0.87996,-0.44 -1.24192,1.8272 -1.53208,2.4076 -0.58801,1.176 0.62612,2.1734 1.09435,2.4075 0.86719,0.4336 1.08378,1.1985 2.1887,1.751 0.50992,0.2549 0.74733,0.2962 1.31321,0.4377"
+         id="path6004"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15822);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15824);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 86.09128,368.8 c 0.32848,0.1642 0,-3.2606 0,-4.1586 0,-1.7031 -0.15149,-1.3132 -1.96983,-1.3132 -1.25671,0 -1.09435,2.1269 -1.09435,3.2831 0,1.5273 0.0734,1.8971 1.09435,2.4075 0.92781,0.4639 0.80708,0.6532 1.96983,-0.2188 z"
+         id="path6006"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15817);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15819);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 104.69521,369.4566 c 1.19078,0.5954 0.0612,-2.7489 0.65661,-3.9397 0.49117,-0.9823 1.89526,-1.3132 2.84531,-1.3132 1.38584,0 1.09435,1.177 1.09435,2.4076 0,0.7945 -1.20425,1.6419 -1.75096,2.1887 -0.56969,0.5696 -1.95018,0.6566 -2.84531,0.6566 z"
+         id="path6008"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15812);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15814);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 110.16696,368.1434 c -0.51598,0.5159 0.0934,-2.1248 0.65661,-4.3774 0.29551,-1.1821 1.61383,-0.8551 2.40757,-0.6566 1.23099,0.3077 0.46128,2.3604 0.21887,2.8453 -0.62313,1.2462 -1.88768,2.1887 -3.28305,2.1887 z"
+         id="path6010"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15809);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 97.397,261.5285 c -0.41271,1.13494 0.61905,1.267 0.61905,3.09529 0,0.83394 -3.2379,4.66722 -2.78576,5.57152 0.65157,1.30312 2.42313,2.42312 2.78576,2.78576 0.24679,0.24678 -5.68363,-0.76927 -6.5001,1.85717 -0.69911,2.24892 -3.12929,-2.00116 -5.3682,-1.44143 -1.53312,0.38328 -4.45315,5.73305 -5.77483,6.39389 -1.91714,0.95857 -3.79036,-2.37548 -4.3334,-0.20332 -0.3806,1.5224 -0.26903,2.62374 -0.61906,4.02388 -0.63508,2.54031 1.01496,-0.94659 -3.09529,-0.26155 -1.87375,0.31229 -2.1667,-0.78128 -2.1667,3.40482 0,0.099 -3.83343,1.95248 -4.3334,2.78575 -0.96946,1.61577 -1.31483,2.12483 -1.85717,4.29421 -0.70823,2.8329 -5.312,1.21069 -6.77102,2.66971"
+         id="path6012"
+         sodipodi:nodetypes="csssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15806);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 97.34927,275.4976 c 1.34129,-1.34129 2.68258,-2.68258 4.02387,-4.02387 1.34129,-1.34129 -2.68258,2.68258 -4.02387,4.02387 -1.44447,1.44447 3.10773,-2.69917 4.3334,-4.33341 1.73318,-2.3109 5.1412,0.687 5.88105,2.16671 0.89719,1.79438 2.27028,3.28075 3.09528,2.78576 1.22911,-0.73747 3.20956,-1.23812 4.64293,-1.23812 2.97865,0 4.34001,2.48943 5.57152,4.95246 0.88611,1.77221 3.18551,-1.23811 5.57152,-1.23811 2.44536,0 3.64188,1.21844 3.09528,3.40481 -0.23661,0.94646 3.03279,2.1042 3.71435,2.78576 1.73735,1.73734 -0.66973,3.31477 2.1667,4.02387 2.60749,0.65187 7.51341,2.3427 9.1312,2.74715"
+         id="path6014"
+         sodipodi:nodetypes="cssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15803);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 70.77039,302.4824 c 2.27011,0.11564 7.30726,-1.31322 10.94349,-1.31322 3.80977,0 6.46028,-0.27177 9.63028,1.31322 0.59136,0.29569 1.18298,0.5915 1.75095,0.87549"
+         id="path6016"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15800);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 104.47634,303.35789 c 1.57353,-1.29251 4.94821,-3.06418 7.44158,-3.06418 2.77109,0 5.08038,0 7.87931,0 1.75096,0 3.50192,0 5.25288,0"
+         id="path6018"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15795);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15797);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 141.25714,270.17161 c 0,0 -14.85714,4.91429 -25.6,10.05715 -10.74286,5.14285 -14.62857,15.08571 -14.62857,15.08571 12.77284,-6.44504 28.65445,-13.0989 49.82857,-12.34286 1.16636,-5.72212 0.11361,-10.70453 -9.6,-12.8 z"
+         id="path6020"
+         sodipodi:nodetypes="csccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15790);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15792);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 49.82857,277.94304 c -10.79341,-15.10622 -23.371,-26.59082 -22.85714,-50.74285 45.22306,22.17299 99.05023,16.81832 140.34285,-1.37143 -6.98569,19.10324 -18.24357,35.24753 -30.62857,40.68571 -31.46726,23.83565 -58.8416,19.46679 -86.85714,11.42857 z"
+         id="path6022"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15785);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15787);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 45.71428,288.45732 c -2.13023,3.43372 -4.76675,9.4391 0.65557,11.25104 6.00458,3.3132 17.32519,1.06031 23.69207,-0.27808 7.10996,-2.18712 30.61778,-9.87094 35.01592,-14.55582 8.88488,-4.40761 37.13445,-15.127 43.53908,-15.83551 4.74157,-2.87773 0.52261,-12.85472 -5.25044,-11.12532 -4.16004,-0.88372 -44.50834,17.70475 -50.0708,19.58161 -4.54494,1.14974 -22.79607,8.44594 -28.1816,8.23027 -4.79316,-0.0449 -17.61781,2.73481 -19.3998,2.73181 z"
+         id="path6024"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15780);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15782);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 100.85992,269.65507 c 2.51194,-4.31477 0.0843,-7.0522 5.12831,-9.64131 5.20221,-2.67032 8.65359,-4.19549 12.05721,-8.66506 2.74546,-3.60529 4.26857,-18.58877 1.56864,-22.12888 -2.77318,-3.63615 -9.87167,-1.06962 -12.47421,-5.40289 -1.41127,-2.34978 -3.1762,-5.72889 -5.67953,-6.59966 -2.32404,-0.80841 -4.89048,-1.03094 -7.2756,-0.76318 -4.38189,0.49191 -4.15541,6.6857 -8.02745,8.1995 -4.29459,1.679 -8.82687,-0.0871 -11.86892,3.62774 -3.52586,4.30561 -2.76778,17.68254 1.55194,21.9923 2.97958,2.9727 7.26759,5.43716 8.95368,9.4429 1.44812,3.44039 2.30358,2.15073 -0.67479,5.98783 -7.30576,9.41217 -27.1264,11.22318 -33.42839,9.64225 -5.36156,-1.34502 -10.20436,9.9566 -5.43367,12.19643 10.52619,4.94204 48.08108,-4.96793 55.60278,-17.88797 z"
+         id="path6026"
+         sodipodi:nodetypes="cssssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15777);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 94.17142,222.51784 5.94286,0"
+         id="path6028"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15774);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 80.89064,229.78196 c 0.23178,12.99699 1.8812,20.16418 5.55069,24.5669"
+         id="path6030"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6032"
+         d="m 112.80087,232.26951 c -2.15852,12.81859 -4.85357,19.66154 -9.13596,23.47078"
+         style="fill:none;stroke:url(#linearGradient15771);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cc"
+         id="path6034"
+         d="m 89.9416,226.54947 c 5.86532,2.64269 9.73021,1.28453 13.95516,0.6465"
+         style="fill:none;stroke:url(#linearGradient15768);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6036"
+         width="200"
+         height="200"
+         x="200"
+         y="200.00018" />
+      <path
+         style="fill:url(#linearGradient15762);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15764);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 250.19662,299.85596 c 0.18876,-11.30046 5.24297,-21.92754 13.17401,-29.65209 6.14524,-5.98524 13.07699,-10.09315 21.2055,-12.54932 7.495,-2.26473 17.59164,-2.10506 25.05486,0.0479 9.08237,2.62007 15.93386,6.15329 23.15118,12.24668 10.94209,9.23812 14.8218,26.44243 11.71698,32.29253 -1.24826,6.21866 -8.75294,27.35239 -11.6798,36.6881 -2.4205,5.772 -2.17943,12.32284 -2.51637,18.48894 0.8674,7.0524 -2.27221,13.7789 -5.92049,19.5719 -3.80413,4.071 -9.0867,5.7832 -12.44105,10.1407 -4.60592,5.9835 -10.59165,0.3889 -15.12851,1.4337 -5.75654,-0.935 -11.74979,5.2227 -15.5132,-1.7372 -3.68267,-6.8106 -12.67224,-9.9103 -17.19717,-16.33 -4.55286,-3.1619 -2.95138,-9.4731 -3.16424,-14.234 0.55428,-8.5034 0.132,-17.31475 -3.63023,-25.11609 -0.36847,-1.07926 -5.7463,-21.82853 -7.11147,-31.29176 z"
+         id="path6038"
+         sodipodi:nodetypes="cssssccccscscccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15757);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15759);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 264.00411,302.89189 c -1.12461,5.96635 0.38673,13.49533 -6.07811,16.98663 -4.33837,4.03265 -7.56308,13.80424 -2.34899,19.58954 8.85795,4.2399 15.63519,2.04536 17.63548,13.63134 0.96791,10.3614 11.2999,10.9974 17.2246,10.4058 6.50283,0.1057 15.64746,0.379 21.83379,-0.061 8.54028,-0.3148 5.23618,-17.5817 14.51314,-17.90277 8.97389,-1.10044 13.16499,-9.13957 12.6883,-17.01342 -2.62296,-6.68098 -7.47113,-12.37734 -5.51473,-20.32079"
+         id="path6040"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15754);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 307.36923,312.7437 c -2.96112,3.60996 -3.49219,4.94952 -4.24827,9.67619 0.0713,3.09089 3.87677,6.99636 6.44872,8.34666 3.6975,2.09452 7.19251,2.06574 11.46638,1.10082 2.34723,-0.45843 5.42677,-2.08796 5.75796,-4.62327 0.59916,-2.98362 1.89982,-12.22389 0.47939,-13.69005 -1.94249,-1.68904 -9.00703,-3.2547 -11.39985,-3.82663 -1.41926,-0.72063 -7.31604,1.79531 -8.50433,3.01628 z"
+         id="path6042"
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15751);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 270.81373,311.30227 c -2.70528,2.79541 -3.78265,4.98959 -3.25326,10.5077 0.3788,3.25544 0.62293,6.81157 3.15646,9.00551 8.61243,1.44686 16.32309,-1.08434 17.71287,-3.75034 2.86391,-3.47171 3.73826,-5.8181 3.85909,-10.13967 -0.43757,-4.46852 -4.52383,-8.16652 -8.60802,-7.59324 -3.72944,0.45413 -7.01187,-1.07242 -12.86714,1.97004 z"
+         id="path6044"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15748);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 297.59896,322.93615 c -1.10611,0.36444 -1.99324,3.17624 -2.5068,4.23408 -1.93077,4.71654 -4.8292,12.02474 -3.57046,15.51603 1.48849,0.93164 4.38873,-1.57634 5.4883,-1.19088 1.32583,0.31229 2.93653,1.92939 5.03294,1.56651 1.63847,0.70618 0.13028,-12.5952 -1.77891,-15.54714 -0.85123,-2.21499 -1.27982,-5.035 -2.66507,-4.5786 z"
+         id="path6046"
+         sodipodi:nodetypes="ccccccs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15745);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 272.82112,349.9934 c 2.61052,6.7423 -0.37428,14.3917 5.47178,16.9632 6.21567,1.8584 12.04955,2.6378 18.50795,2.4784 8.16021,-1.5506 15.83563,1.7263 20.83939,-5.0766 1.87386,-4.1938 0.94765,-11.4359 4.09552,-14.931"
+         id="path6048"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15740);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15742);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 294.18946,354.2502 c -0.37103,0.3875 -1.62403,1.2782 -2.1887,2.4075 -0.42188,0.8438 -0.474,3.2092 -0.6566,3.9397 -0.38928,1.5571 0.20574,2.0727 1.31321,2.6264 1.00639,0.5032 2.13876,0.1344 2.84531,-0.2188 0.98689,-0.4935 0.85035,-1.4316 1.09435,-2.4076 0.2545,-1.018 0,-2.4538 0,-3.5019 0,-1.3426 -0.12443,-1.8754 -0.87548,-2.6265 -0.63179,-0.6317 -0.008,-0.5235 -1.53209,-0.2188 z"
+         id="path6052"
+         sodipodi:nodetypes="csssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15735);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15737);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 298.2335,353.9269 c -0.0127,-0.013 -0.93889,2.4423 -1.09435,3.0642 -0.24366,0.9746 0.47321,2.0468 0.21887,3.0642 -0.35834,1.4333 -0.63324,1.9815 0.21887,2.4075 1.12642,0.5633 1.72445,0.5953 2.84531,0.8755 1.34163,0.3354 2.17449,-0.7106 2.62643,-1.3132 0.56585,-0.7545 -0.3074,-2.5428 -0.43774,-3.0642 -0.29725,-1.189 -0.75428,-1.9463 -1.31322,-3.0641 -0.32017,-0.6404 -1.47346,-1.1599 -1.96983,-1.5321 -0.3143,-0.2358 -0.72956,-0.2919 -1.09434,-0.4378 z"
+         id="path6054"
+         sodipodi:nodetypes="cssssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15730);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15732);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 302.72539,355.4489 c -1.10895,-0.8317 0,2.7723 0,4.1585 0,1.0455 0.0403,2.3499 0.21887,3.0642 0.15901,0.6361 2.17398,0.5435 2.62643,0.6566 1.39587,0.349 2.34377,-0.529 2.84531,-1.5321 0.46243,-0.9248 -0.65661,-2.2508 -0.65661,-3.283 0,-1.7076 -0.69665,-2.6798 -1.31322,-3.5019 -0.87206,-1.1628 -3.02761,-0.1168 -3.72078,0.4377 z"
+         id="path6056"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15725);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15727);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 309.29148,354.7923 c -0.005,-0.01 -0.43774,2.9757 -0.43774,3.9396 0,1.2658 -0.20067,2.0063 0.21887,2.8454 0.24519,0.4904 2.31342,0.5942 2.62644,0.4377 1.26761,-0.6338 1.09435,-3.0011 1.09435,-4.3774 0,-0.9074 -1.2345,-2.3682 -1.75096,-2.6264 -0.65421,-0.3271 -0.76946,-0.2189 -1.75096,-0.2189 z"
+         id="path6058"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15720);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15722);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 313.45001,354.3545 c -1.30672,-0.6533 -0.21887,2.9165 -0.21887,4.3774 0,1.4585 -0.69263,1.8489 0.21887,3.0642 0.67542,0.9006 1.82262,-0.8019 2.40756,-1.0943 0.64316,-0.3216 0.43775,-2.3762 0.43775,-3.0642 0,-1.1288 -0.47296,-2.2591 -0.87548,-3.0642 -0.3476,-0.6952 -1.5332,-0.3062 -1.96983,-0.2189 z"
+         id="path6060"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15715);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15717);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 286.52901,355.0112 c 0.005,-0.01 0.43775,2.7401 0.43775,3.7207 0,0.7272 0.2512,2.1316 0.43774,3.0642 0.27499,1.375 -1.11378,1.0944 -2.1887,1.0944 -1.18288,0 -1.82613,-0.9757 -2.40757,-1.751 -0.45456,-0.6061 0.0624,-3.095 0.21887,-3.7208 0.26746,-1.0698 1.30479,-1.6373 1.96983,-1.9698 0.66704,-0.3335 0.33994,-0.1993 1.53208,-0.4377 z"
+         id="path6062"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15710);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15712);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 281.71388,356.1055 c 0.6803,-0.3401 0,2.4463 0,3.2831 0,1.286 0.56615,1.4941 0,2.6264 -0.45368,0.9074 -2.66305,-0.3466 -2.84531,-0.4377 -0.88294,-0.4415 -0.87548,-1.8298 -0.87548,-2.8454 0,-1.0756 0.90523,-2.3076 1.09435,-3.0641 0.54382,-2.1753 2.03383,-0.3031 2.62644,0.4377 z"
+         id="path6064"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15705);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15707);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 286.96676,356.7621 c 0.67061,-1.0711 0.64562,-1.8029 2.1887,-2.1887 0.10363,-0.026 1.9092,1.9462 1.96982,2.1887 0.25681,1.0272 -0.0674,2.5757 0.21888,3.7208 0.38298,1.532 -0.19642,1.9095 -1.31323,2.1887 -1.55186,0.388 -1.83358,0.3261 -2.18869,-1.0943 -0.21664,-0.8666 -0.49573,-2.2018 -0.65661,-2.8454 -0.15899,-0.6359 -0.21887,-1.2953 -0.21887,-1.9698 z"
+         id="path6066"
+         sodipodi:nodetypes="cssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15700);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15702);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 277.99309,355.23 c 0.30374,0.7875 0.21887,3.2666 0.21887,4.8152 0,1.6966 -0.69128,1.5321 -2.18869,1.5321 -1.19592,0 -1.5321,-0.9752 -1.5321,-2.1887 0,-1.4735 -0.12386,-2.1599 0.65662,-3.7208 0.51911,-1.0382 0.94608,-1.3838 1.53208,-1.9698 0.47562,-0.4757 1.06342,0.9075 1.31322,1.532 z"
+         id="path6068"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15695);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15697);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 279.74405,363.5471 c -0.82541,-0.8254 0,2.3346 0,3.5019 0,1.3283 0.42718,1.5321 1.75096,1.5321 0.37769,0 0.98778,-2.6379 1.09435,-3.0642 0.25888,-1.0355 0.19972,-2.2653 0,-3.0642 -0.55744,-2.2297 -2.60614,0.4965 -2.84531,1.0944 z"
+         id="path6070"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15690);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15692);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 295.28381,370.1132 c -0.18849,-0.754 -0.31212,-2.9995 -0.65661,-4.3774 -0.32807,-1.3123 -0.58446,-1.6788 -1.53209,-2.6264 -1.17164,-1.1717 -1.25193,2.3199 -1.31322,2.6264 -0.23898,1.1949 0.62231,1.8326 0.87548,2.8453 0.31033,1.2413 1.04225,1.5321 2.62644,1.5321 z"
+         id="path6072"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15685);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15687);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 295.72155,370.1132 c 0.35433,1.4173 -0.21887,-2.9165 -0.21887,-4.3774 0,-1.4018 -0.38673,-1.5831 0.43774,-2.4076 0.8815,-0.8815 2.23415,1.1853 2.40757,1.5321 0.47658,0.9532 0.65661,1.3559 0.65661,2.8453 0,1.3492 -1.01677,1.4933 -1.96983,1.9698 -1.28512,0.6426 2.77827,-0.3805 -1.31322,0.4378 z"
+         id="path6074"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15680);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15682);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 299.88008,370.1132 c -0.18025,0.09 -0.21887,-3.2294 -0.21887,-4.1585 0,-1.368 0.54471,-1.4202 1.31322,-2.1887 1.00699,-1.007 2.16769,1.4311 2.40757,1.7509 0.58435,0.7792 0.13891,2.5085 0,3.0642 -0.10846,0.4338 -2.96976,1.3192 -3.50192,1.5321 z"
+         id="path6076"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15675);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15677);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 292.00076,369.6754 c -0.30236,1.2095 -0.56521,-2.5045 -1.31321,-3.5019 -1.04382,-1.3917 -0.43268,-1.8578 -1.96984,-2.6264 -0.87996,-0.44 -1.24192,1.8272 -1.53208,2.4076 -0.58801,1.176 0.62612,2.1734 1.09435,2.4075 0.86719,0.4336 1.08378,1.1985 2.1887,1.751 0.50992,0.2549 0.74733,0.2962 1.31321,0.4377"
+         id="path6078"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15670);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15672);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 286.09128,368.8 c 0.32848,0.1642 0,-3.2606 0,-4.1586 0,-1.7031 -0.15149,-1.3132 -1.96983,-1.3132 -1.25671,0 -1.09435,2.1269 -1.09435,3.2831 0,1.5273 0.0734,1.8971 1.09435,2.4075 0.92781,0.4639 0.80708,0.6532 1.96983,-0.2188 z"
+         id="path6080"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15665);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15667);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 304.69521,369.4566 c 1.19078,0.5954 0.0612,-2.7489 0.65661,-3.9397 0.49117,-0.9823 1.89526,-1.3132 2.84531,-1.3132 1.38584,0 1.09435,1.177 1.09435,2.4076 0,0.7945 -1.20425,1.6419 -1.75096,2.1887 -0.56969,0.5696 -1.95018,0.6566 -2.84531,0.6566 z"
+         id="path6082"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15660);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15662);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 310.16696,368.1434 c -0.51598,0.5159 0.0934,-2.1248 0.65661,-4.3774 0.29551,-1.1821 1.61383,-0.8551 2.40757,-0.6566 1.23099,0.3077 0.46128,2.3604 0.21887,2.8453 -0.62313,1.2462 -1.88768,2.1887 -3.28305,2.1887 z"
+         id="path6084"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15657);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 296.02557,258.78565 c -0.41271,1.13494 0.61905,3.55271 0.61905,5.381 0,0.83393 -3.2379,4.66722 -2.78575,5.57152 0.65156,1.30312 2.42312,2.42312 2.78575,2.78575 0.24679,0.24679 -5.68363,-0.76926 -6.5001,1.85718 -0.69911,2.24892 -3.12929,-2.00116 -5.3682,-1.44143 -1.53312,0.38328 -4.45315,5.73304 -5.77483,6.39389 -1.91714,0.95857 -3.79036,-2.37548 -4.3334,-0.20332 -0.3806,1.52239 -0.26902,2.62373 -0.61906,4.02387 -0.63508,2.54032 1.01496,-0.94658 -3.09529,-0.26154 -1.87375,0.31229 -2.1667,-0.78128 -2.1667,3.40481 0,0.099 -3.83343,1.95248 -4.3334,2.78576 -0.96946,1.61577 -4.51483,3.49626 -5.05717,5.66563 -0.70823,2.83291 -6.68343,-0.16073 -8.14244,1.29828"
+         id="path6086"
+         sodipodi:nodetypes="csssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15654);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 296.34457,273.3023 c 1.34129,-1.34129 10.4793,-1.45111 11.21915,0.0286 0.89719,1.79438 2.27028,3.28075 3.09528,2.78576 1.22911,-0.73747 3.20956,-1.23812 4.64293,-1.23812 2.97865,0 4.34001,2.48943 5.57152,4.95246 0.88611,1.77221 3.18551,-1.23811 5.57152,-1.23811 2.44536,0 3.64188,1.21844 3.09528,3.40481 -0.23661,0.94646 3.03279,2.1042 3.71435,2.78576 1.73735,1.73734 -0.66973,3.31477 2.1667,4.02387 2.60749,0.65187 7.51341,2.3427 9.1312,2.74715"
+         id="path6088"
+         sodipodi:nodetypes="csssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15651);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 270.77039,302.4824 c 2.27011,0.11564 7.30726,-1.31322 10.94349,-1.31322 3.80977,0 6.46028,-0.27177 9.63028,1.31322 0.59136,0.29569 1.18298,0.5915 1.75095,0.87549"
+         id="path6090"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15648);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 304.47634,303.35789 c 1.57353,-1.29251 4.94821,-3.06418 7.44158,-3.06418 2.77109,0 5.08038,0 7.87931,0 1.75096,0 3.50192,0 5.25288,0"
+         id="path6092"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6094"
+         d="m 293.25412,227.66838 11.55532,40.20735 24.23598,-34.72425 c -10.59996,14.80135 -25.20225,26.64899 -35.7913,-5.4831 z"
+         style="fill:url(#linearGradient15643);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15645);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15638);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15640);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 318.16684,227.83066 0.98112,41.82336 32.24966,-27.44293 c -14.00703,11.62937 -31.13648,19.38661 -33.23078,-14.38043 z"
+         id="path6096"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6098"
+         d="m 248.13358,237.88382 28.39487,30.72274 6.04161,-41.91245 c -2.81581,17.98639 -10.53449,35.13325 -34.43648,11.18971 z"
+         style="fill:url(#linearGradient15633);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15635);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15628);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15630);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 230.60126,257.30277 35.48526,22.15742 -5.21289,-42.02356 c 2.02185,18.09284 -0.90715,36.66739 -30.27237,19.86614 z"
+         id="path6100"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6102"
+         d="m 268.27121,285.3712 19.12142,-37.20924 17.05423,38.75963 c -7.53362,-16.57358 -19.56571,-31.02425 -36.17565,-1.55039 z"
+         style="fill:url(#linearGradient15623);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15625);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15618);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15620);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 284.59509,281.25603 21.40166,-35.94614 14.60721,39.74651 c -6.48681,-17.01059 -17.59556,-32.18256 -36.00887,-3.80037 z"
+         id="path6104"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6106"
+         d="m 297.02597,279.3501 29.04326,-30.11059 5.14694,42.03173 c -2.43182,-18.04233 -9.78329,-35.34982 -34.1902,-11.92114 z"
+         style="fill:url(#linearGradient15613);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15615);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15608);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15610);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 307.60394,277.11554 37.80066,-17.92391 -10.01723,41.14378 c 4.09179,-17.73968 3.32114,-36.52795 -27.78343,-23.21987 z"
+         id="path6108"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15603);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15605);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 257.50529,291.24819 11.44885,-40.23777 24.3278,34.65995 c -10.6391,-14.77323 -25.27269,-26.58217 -35.77665,5.57782 z"
+         id="path6110"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15598);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15600);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 270.5978,229.99304 19.12141,37.20924 17.05424,-38.75963 c -7.53362,16.57358 -19.56572,31.02426 -36.17565,1.55039 z"
+         id="path6112"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6114"
+         d="m 336.65171,235.07786 -4.68459,41.57176 35.66504,-22.82895 c -15.45121,9.62804 -33.47245,14.99721 -30.98045,-18.74281 z"
+         style="fill:url(#linearGradient15593);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15595);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6116"
+         d="m 220.47161,274.93054 40.01404,12.20784 -15.92188,-39.23835 c 6.6401,16.95134 8.62317,35.65055 -24.09216,27.03051 z"
+         style="fill:url(#linearGradient15588);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15590);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6118"
+         d="m 368.86548,270.24866 -39.51439,13.73932 35.99906,22.29849 c -15.35948,-9.7737 -27.98882,-23.70543 3.51533,-36.03781 z"
+         style="fill:url(#linearGradient15583);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15585);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15578);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15580);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 227.77298,267.76809 38.50086,16.36579 -37.41725,19.82685 c 15.98204,-8.71855 29.51977,-21.76933 -1.08361,-36.19264 z"
+         id="path6120"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6122"
+         d="m 222.15737,288.80469 40.31413,-11.17708 -16.92347,38.81689 c 7.07287,-16.77538 9.5351,-35.41755 -23.39066,-27.63981 z"
+         style="fill:url(#linearGradient15573);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15575);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path6124"
+         d="m 239.3013,303.82526 10.87963,-40.3954 24.8147,34.31304 c -10.8466,-14.62155 -25.64545,-26.22272 -35.69433,6.08236 z"
+         style="fill:url(#linearGradient15568);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15570);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15563);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15565);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 372.38205,292.03058 -36.84371,-19.81659 7.91921,41.59858 c -3.18749,-17.92426 -1.46564,-36.64933 28.9245,-21.78199 z"
+         id="path6126"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15558);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15560);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 356.72591,248.70282 -24.08415,34.20688 42.2474,-2.88312 c -18.17692,1.01913 -36.56127,-2.93165 -18.16325,-31.32376 z"
+         id="path6128"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6132"
+         width="200"
+         height="200"
+         x="400"
+         y="200.00018" />
+      <path
+         style="fill:url(#linearGradient15552);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15554);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 444.64308,363.2002 -0.13021,14.9791 26.53885,17.206 78.57817,-1.4108 -0.0945,-12.8464 -25.39943,-20.3262 -79.49289,2.3983 z"
+         id="path6134"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15547);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15549);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 477.9202,290.04855 c -0.78273,0.33332 -1.22931,1.52657 -1.25644,3.74263 -0.28954,23.65111 -5.70227,66.29772 -8.38114,74.73662 l 11.29311,7.3619 39.72545,-5.8243 c 0,0 -14.12777,-45.10611 -29.28227,-67.54866 -2.46301,-0.29956 -4.81607,-0.9631 -6.99907,-1.93659 -2.48033,-2.99697 -4.26147,-6.58906 -5.09964,-10.5316 z"
+         id="path6136"
+         sodipodi:nodetypes="cscccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15542);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15544);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 512.67904,292.87729 c -4.48992,5.96152 -11.6282,9.82078 -19.65948,9.82078 -2.78914,0 -5.47434,-0.46372 -7.97465,-1.32008 3.29782,34.41721 -4.31656,72.78061 -3.43671,74.57701 l 44.54423,-0.8631 c 0,0 -12.68007,-47.50843 -8.44766,-75.01948 -2.64109,-1.84574 -3.02972,-6.07668 -5.02573,-7.19513 z"
+         id="path6138"
+         sodipodi:nodetypes="csccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15539);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 449.63561,367.7936 22.83147,14.7011 -0.41505,8.9112"
+         id="path6140"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15536);stroke-width:3.74868512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 475.78753,382.3593 67.10037,-0.794"
+         id="path6142"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15531);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15533);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 475.62633,273.17292 13.37874,-0.32825 0,-9.51898 9.03065,-2.29768 0.66894,21.33564 -25.41961,-0.32824 2.34128,-8.86249 z"
+         id="path6144"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient15526);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15528);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 510.79439,218.7427 -33.53197,0.76884 2.75676,22.83296 c -10.28268,2.77007 -22.88418,14.24819 -24.98823,26.7134 l -30.30959,-2.33552 1.38207,31.05079 10.41361,3.77165 21.69933,-4.91765 c 7.33035,18.30544 21.76366,22.25285 30.98955,25.41509 23.83138,8.16837 45.02394,-7.95447 50.38295,-25.76324 l 27.27198,0.44244 1.38208,-31.51499 -11.31528,-2.65466 -19.2456,2.0599 c -5.02237,-10.33746 -8.82929,-16.18616 -22.39406,-21.62893 l 1.68509,-20.46843 -6.17869,-3.77165 z m -9.29021,41.56063 c 0.0524,-9.9e-4 0.10274,6.6e-4 0.1552,0 0.10576,-0.001 0.21174,0 0.31781,0 3.55932,0 6.94444,0.75544 9.99972,2.11792 3.52343,4.25735 5.63917,9.71967 5.63917,15.67409 0,13.5807 -11.01924,24.60273 -24.59652,24.60273 -3.55932,0 -6.94444,-0.75545 -9.99972,-2.11792 -3.52343,-4.25735 -5.63917,-9.71968 -5.63917,-15.67409 0,-13.42197 10.76517,-24.34921 24.12351,-24.60273 z"
+         id="path6146"
+         sodipodi:nodetypes="ccccccccscccccccccsscsscsc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:none;stroke:url(#linearGradient16637);stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path6148"
+         sodipodi:cx="401.99997"
+         sodipodi:cy="321.00003"
+         sodipodi:rx="160"
+         sodipodi:ry="162"
+         d="m 561.99997,321.00003 a 160,162 0 1 1 -320,0 160,162 0 1 1 320,0 z"
+         transform="matrix(0.23650491,0,0,0.23210126,406.42903,209.93821)" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15522);stroke-width:1.87434208;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 481.53721,222.77846 5.97109,2.6647 24.83235,-0.80931"
+         id="path6150"
+         sodipodi:nodetypes="ccc"
+         inkscape:transform-center-x="-54.316399"
+         inkscape:transform-center-y="-325.38268"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.98999999;fill:url(#linearGradient15517);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15519);stroke-width:3.18607593;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 511.97691,262.42125 c 3.52343,4.25735 5.63917,9.71967 5.63917,15.67409 0,13.5807 -11.01924,24.60273 -24.59652,24.60273 -3.55932,0 -6.94444,-0.75545 -9.99972,-2.11792 4.51273,5.45271 11.33298,8.92864 18.95735,8.92864 13.57728,0 24.59651,-11.02202 24.59652,-24.60273 0,-10.02049 -5.99748,-18.65001 -14.5968,-22.48481 z m -33.71674,15.94971 c -0.0222,0.0806 -0.0452,0.15844 -0.0665,0.23935 0.0212,-0.0803 0.0445,-0.15939 0.0665,-0.23935 z m -0.86472,7.44174 c 0.002,0.0455 0.005,0.0924 0.007,0.13781 -0.002,-0.046 -0.006,-0.0917 -0.007,-0.13781 z m 0.007,0.20309 c 0.002,0.0453 0.005,0.0925 0.007,0.13781 -0.002,-0.046 -0.005,-0.0918 -0.007,-0.13781 z m 0.007,0.15957 c 0.002,0.0399 0.005,0.0762 0.007,0.11605 -0.002,-0.0391 -0.005,-0.0769 -0.007,-0.11605 z m 0.0517,0.73257 c 0.003,0.0408 0.004,0.0826 0.007,0.12331 -0.003,-0.0405 -0.004,-0.0828 -0.007,-0.12331 z m 0.0443,0.51498 c 0.008,0.0789 0.0208,0.15343 0.0296,0.2321 -0.009,-0.078 -0.0216,-0.15392 -0.0296,-0.2321 z m 0.0813,0.72531 c 0.005,0.0393 0.0168,0.0768 0.0222,0.11605 -0.005,-0.0401 -0.0169,-0.0759 -0.0222,-0.11605 z m 1.52989,5.84605 c 0.009,0.0229 0.013,0.0497 0.0222,0.0725 -0.01,-0.0244 -0.0125,-0.0481 -0.0222,-0.0725 z m 3.03761,5.47614 c 0.0219,0.0297 0.0445,0.0574 0.0665,0.087 -0.0218,-0.0294 -0.0448,-0.0575 -0.0665,-0.087 z"
+         id="path6152"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15514);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 429.42607,270.96088 6.93437,3.09149 0.0997,21.77714"
+         id="path6154"
+         sodipodi:nodetypes="ccc"
+         inkscape:transform-center-x="325.65783"
+         inkscape:transform-center-y="52.246822"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15511);stroke-width:1.87434077;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 540.23498,270.66935 561.3644,268.3548"
+         id="path6156"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-x="-54.316399"
+         inkscape:transform-center-y="-325.38267"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15506);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15508);stroke-width:3.34277487;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 500.93301,261.75824 c -2.52758,0.0324 -4.95354,0.50508 -7.20341,1.33883 l 0.47451,1.22241 0,13.24603 -13.49735,0 -0.2768,-0.27812 c -0.61261,2.02617 -0.94244,4.17549 -0.94244,6.40311 0,1.97502 0.25902,3.89021 0.74472,5.71106 l 13.97187,-0.24577 0,14.90178 -0.22408,0.31692 c 2.26265,0.80667 4.70124,1.24828 7.23638,1.24828 2.70146,0 4.57504,-0.7314 6.96183,-1.64208 l -0.26588,-0.751 0.21089,0 -0.42178,-14.0739 14.4332,0.46567 c 0.52438,-1.88661 0.80404,-3.87601 0.80404,-5.93096 0,-2.42955 -0.39011,-4.76802 -1.1138,-6.95287 l -14.12344,0 0.84358,-12.41815 0.71836,-1.00251 c -2.48998,-1.00402 -5.20337,-1.55873 -8.047,-1.55873 -0.0937,0 -0.18997,-10e-4 -0.2834,0 z"
+         id="path6158"
+         sodipodi:nodetypes="ccccccsccccscccccsccccsc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15501);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15503);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 487.80573,289.91319 0.19593,10.83194 6.02044,3.28241 -0.66894,-13.78611 -5.54743,-0.32824 z"
+         id="path6160"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15496);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15498);stroke-width:3.74868417;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 508.75453,272.3871 c 1.65554,0 8.51418,0 8.51418,0 l 5.67612,4.17782 -15.13632,0 0.94602,-4.17782 z"
+         id="path6162"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15493);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 488.6767,244.20917 -1.43407,-15.7425"
+         id="path6164"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-x="325.65781"
+         inkscape:transform-center-y="52.246821"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15490);stroke-width:1.87434018;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 459.28547,274.47935 -19.49537,0.013"
+         id="path6166"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-x="325.6578"
+         inkscape:transform-center-y="52.246795"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6168"
+         width="200"
+         height="200"
+         x="600"
+         y="200.00018" />
+      <path
+         style="fill:url(#linearGradient15484);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15486);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 674.71354,263.83693 c -12.77326,15.42725 -21.90477,47.67484 -6.32406,75.24164 12.89327,22.81193 -29.3334,28.96603 -27.55711,44.37953 24.74833,-0.048 93.80866,-0.6305 117.91538,0.2121 1.46084,-14.4293 -39.65165,-13.9542 -26.77986,-48.3153 8.45325,-22.56586 10.96916,-69.25335 -4.9956,-85.00509 -10.46733,-10.32766 -29.67181,-13.79285 -52.25875,13.48712 z"
+         id="path6170"
+         sodipodi:nodetypes="csccsss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15479);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15481);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 649.34173,392.157 c -3.1901,-5.2817 5.24386,-29.5188 10.66827,-32.9828 4.92746,-3.1468 29.89762,30.8832 30.51798,33.874 l -41.18625,-0.8912 z"
+         id="path6172"
+         sodipodi:nodetypes="cscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15476);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 653.68459,387.8142 c 0.0447,0.8967 0.18384,-7.5335 1.21806,-10.1238 1.25671,-3.4207 2.51536,-9.0827 4.79737,-11.9076 0.81398,-0.9605 2.84456,1.9273 3.73709,2.5497 1.88741,1.2477 8.0548,16.0831 9.07687,18.5291 0.72821,1.4269 -0.94705,1.6693 -1.95332,1.4744 -1.83868,-0.025 -16.22484,0.1393 -16.87607,-0.5218 z"
+         id="path6174"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15473);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 681.68651,276.43314 c -2.65715,0.0546 -5.1027,0.84341 -7.08475,2.65773 -5.36237,4.90858 -12.53117,34.63622 -1.51007,53.71134 3.89323,6.73833 9.59001,19.95849 24.38175,23.79969 6.48032,-12.87413 7.34723,-10.48588 15.57248,-24.79339 10.30904,-17.93219 -0.0539,-34.5536 -6.80196,-42.47398 -4.20734,-4.93826 -15.44546,-12.96705 -24.36761,-12.90139 -0.064,4.7e-4 -0.12607,-10e-4 -0.18984,0 z m 19.60877,24.89016 c 0.01,0.008 10.53854,2.34291 1.46019,5.26519 -3.22035,1.03661 -7.86703,0.64697 -7.11889,-1.65986 1.02226,-3.15207 5.64862,-3.6128 5.6587,-3.60533 z M 681.543,301.18279 c 3.48107,2.08864 7.91279,3.90628 3.97441,4.89087 -4.25858,1.06464 -6.16141,1.39852 -8.63453,-1.00082 -2.75625,-2.674 -0.54283,-2.12818 4.66012,-3.89005 z"
+         id="path6176"
+         sodipodi:nodetypes="csscsssccssscssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15468);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15470);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 704.17792,396.1887 -6.09713,-0.6723 67.54748,-143.25084 c 0,0 -6.32091,-8.69659 -18.7416,-13.84722 -8.33752,-3.45741 -25.29633,-6.14344 -25.29633,-6.14344 0.71297,-4.77403 24.66955,-5.30189 38.65346,-0.17075 12.47849,4.57877 16.0878,11.24596 15.17481,17.35936 L 704.17792,396.1887 z"
+         id="path6178"
+         sodipodi:nodetypes="cccscscc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15463);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15465);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 644.01991,359.4042 c -2.30196,-0.7719 -6.60341,-2.7148 -8.13701,-2.1014 -1.93844,0.7754 -1.93608,3.5078 -1.40066,4.0432 1.3131,1.3131 4.87434,2.1276 7.2744,2.1276 3.14052,0 1.67168,-4.1877 0.37722,-4.4466"
+         id="path6180"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15458);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15460);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 643.71141,367.0171 c 2.9152,0 -4.07412,-1.6784 -7.68163,-2.7091 -3.29082,-0.9403 -1.54159,2.8751 -0.53858,4.5934 0.62498,1.0707 7.01831,1.4872 8.22021,1.8878 0.76379,0.2546 -0.93955,-1.3167 -1.50885,-1.886 -0.56929,-0.5693 1.0059,-1.2574 1.50885,-1.8861 z"
+         id="path6182"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15453);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15455);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 643.55155,372.9726 c -0.93569,-0.9357 -3.14562,-1.95 -4.52654,-2.6405 -1.95561,-0.9778 -2.91039,3.0697 -2.64047,4.1493 0.23396,0.9359 4.6193,1.7209 5.06536,1.8324 2.1619,0.5405 1.85108,-2.339 2.10165,-3.3412 z"
+         id="path6184"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15448);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15450);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 647.86073,360.2273 c 0.18287,0.046 2.80617,3.3938 4.0846,4.4808 1.54636,1.3149 3.01249,2.5843 4.03883,4.637 1.8572,3.7144 6.53381,9.3305 -0.26672,2.53 -1.4319,-1.4319 -5.27392,-2.8038 -6.45527,-4.1035 -1.00325,-1.1038 -2.97513,-3.1473 -3.59999,-3.7722 -1.31653,-1.3165 -0.0739,-3.3176 2.19855,-3.7721 z"
+         id="path6186"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15443);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15445);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 646.39765,366.8609 c -1.63941,-1.6394 4.97518,2.0869 6.61459,3.7263 1.16793,1.168 3.5151,4.0486 4.03884,4.5723 0.0783,0.078 -3.61956,-0.021 -3.92836,-0.1752 -2.33758,-1.1688 -7.03559,-3.1696 -8.61113,-4.3513 -0.35907,-0.2693 -0.77618,-2.5642 -0.7539,-2.5865"
+         id="path6188"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15438);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15440);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 645.21663,377.2934 c -1.61257,-1.2095 0.0145,-4.4935 1.96999,-4.0046 5.0887,1.2722 10.09714,5.0771 7.06491,5.0771 -2.9249,0 -6.6752,0.1073 -9.0349,-1.0725 z"
+         id="path6190"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15433);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15435);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 646.79074,353.0147 c -0.81687,-0.046 -5.67489,-1.882 -7.38782,-1.9786 -1.2484,-0.07 -2.60499,0.927 -3.60617,1.359 -1.87098,0.8073 3.71547,3.634 3.74533,3.6433 1.35594,0.4214 2.6965,1.4976 4.12749,0.8802 0.69749,-0.301 2.6943,-3.2755 3.12117,-3.9039 z"
+         id="path6192"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15428);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15430);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 633.71147,350.6266 c 4.98869,-1.3866 -4.72572,-2.7504 -7.40987,-4.0631 -4.11025,-2.01012 -5.07459,-0.66565 -3.84751,1.8684 0.51381,1.0611 2.18283,1.939 3.04611,2.4961 1.185,0.7647 3.41438,1.4809 4.82107,1.7552 2.26632,0.4418 2.82329,0.8512 3.3902,-2.0566 z"
+         id="path6194"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15423);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15425);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 648.97127,355.9315 c 3.7e-4,-1.8671 7.48043,8.5788 9.77178,10.2973 2.51727,1.888 0.42175,4.4386 -3.53193,0.4849 -1.27978,-1.2798 -3.173,-2.7717 -4.85763,-3.7342 -1.35754,-0.7756 -3.00244,-3.6043 -3.79072,-5.1809 -0.59626,-1.1925 2.04244,-0.037 2.4085,-1.8671 z"
+         id="path6196"
+         sodipodi:nodetypes="cssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15418);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15420);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 662.67158,371.5396 c -0.64727,-1.2946 1.44746,2.9731 0.80018,4.2676 -0.74792,1.4959 -4.03461,-0.9568 -4.33211,-1.5517 -0.66209,-1.3242 1.04667,-2.8093 0.2588,-2.9826 -1.45731,-0.3206 2.82858,0.1778 3.27313,0.2667 z"
+         id="path6198"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15413);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15415);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 657.91905,376.2842 c 0.1195,-0.1195 5.14249,0.2117 2.24687,2.6673 -2.54392,2.1573 -4.28353,1.9852 -4.28353,-0.1458 0,-0.9311 0.8107,-1.9085 2.03666,-2.5215 z"
+         id="path6200"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15408);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15410);stroke-width:2.13382673;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 664.94322,377.2946 c 0,-1.5528 3.10929,3.336 1.8671,4.2676 -1.01862,0.764 -3.85624,1.1235 -5.2374,1.1235 -1.1862,0 1.19554,-2.3046 0.96181,-3.4675 -0.35162,-1.7495 2.35199,-1.8671 2.40849,-1.9236 z"
+         id="path6202"
+         sodipodi:nodetypes="csssc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6242"
+         width="200"
+         height="200"
+         x="1000"
+         y="200.00018" />
+      <path
+         style="fill:url(#linearGradient15402);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15404);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1063.6698,314.76727 c 0.1488,-8.90473 4.1315,-17.27881 10.3811,-23.36574 4.8424,-4.71635 10.3046,-7.95336 16.7098,-9.88881 5.906,-1.78461 13.8622,-1.65879 19.7432,0.0378 7.1569,2.0646 12.5558,4.84878 18.243,9.65035 8.6223,7.27958 11.6795,20.83653 9.2329,25.44638 -0.9836,4.90028 -6.8972,21.55358 -9.2036,28.91007 -1.9073,4.54828 -1.7174,9.71038 -1.9829,14.56928 0.6835,5.5572 -1.7905,10.8576 -4.6653,15.4226 -2.9976,3.2079 -7.1603,4.557 -9.8035,7.9908 -3.6295,4.7149 -8.3462,0.3064 -11.9212,1.1297 -4.5361,-0.7368 -9.2588,4.1155 -12.2244,-1.3689 -2.9019,-5.3667 -9.9856,-7.8092 -13.5512,-12.868 -3.5877,-2.4916 -2.3257,-7.4647 -2.4935,-11.2163 0.4368,-6.7006 0.104,-13.64396 -2.8606,-19.7914 -0.2903,-0.85043 -4.528,-17.2008 -5.6038,-24.65778 z"
+         id="path6244"
+         sodipodi:nodetypes="cssssccccscscccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15397);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15399);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1074.5501,317.15958 c -0.8862,4.70145 0.3047,10.63426 -4.7896,13.38539 -3.4186,3.17773 -5.9596,10.87769 -1.851,15.43649 6.9801,3.34104 12.3205,1.61174 13.8967,10.74144 0.7627,8.1647 8.9043,8.6659 13.5729,8.1997 5.1242,0.083 12.3302,0.2987 17.205,-0.048 6.7297,-0.248 4.1261,-13.8543 11.4363,-14.1073 7.0714,-0.8671 10.374,-7.20195 9.9983,-13.4065 -2.0669,-5.26459 -5.8872,-9.7533 -4.3456,-16.01272"
+         id="path6246"
+         sodipodi:nodetypes="ccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15394);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 1108.7216,324.92275 c -2.3333,2.84465 -2.7518,3.90021 -3.3476,7.6248 0.056,2.43563 3.0549,5.51312 5.0816,6.57714 2.9136,1.65048 5.6676,1.6278 9.0354,0.86744 1.8496,-0.36124 4.2763,-1.6453 4.5373,-3.64312 0.4721,-2.35106 1.497,-9.63238 0.3777,-10.78769 -1.5307,-1.33098 -7.0975,-2.5647 -8.983,-3.01537 -1.1184,-0.56788 -5.765,1.41469 -6.7014,2.3768 z"
+         id="path6248"
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15391);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 1079.916,323.78693 c -2.1317,2.20277 -2.9807,3.93176 -2.5635,8.28002 0.2984,2.56527 0.4908,5.36749 2.4872,7.0963 6.7866,1.14012 12.8626,-0.85446 13.9577,-2.95524 2.2568,-2.73569 2.9457,-4.58466 3.041,-7.99002 -0.3448,-3.52119 -3.5648,-6.43521 -6.7831,-5.98346 -2.9388,0.35785 -5.5253,-0.84505 -10.1393,1.5524 z"
+         id="path6250"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15388);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         d="m 1101.0227,332.95437 c -0.8716,0.28718 -1.5707,2.50287 -1.9754,3.33644 -1.5214,3.71662 -3.8054,9.47545 -2.8135,12.22659 1.1729,0.7341 3.4583,-1.24217 4.3248,-0.93843 1.0447,0.24613 2.314,1.52033 3.9659,1.23443 1.2911,0.5564 0.1027,-9.92499 -1.4017,-12.2511 -0.6708,-1.74541 -1.0086,-3.96757 -2.1001,-3.60793 z"
+         id="path6252"
+         sodipodi:nodetypes="ccccccs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15385);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1081.4978,354.2753 c 2.0571,5.313 -0.2949,11.3406 4.3118,13.367 4.8979,1.4645 9.495,2.0786 14.5842,1.953 6.4302,-1.2219 12.4784,1.3603 16.4213,-4.0003 1.4766,-3.3047 0.7468,-9.0115 3.2273,-11.7656"
+         id="path6254"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15380);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15382);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1098.336,357.8844 c -0.2924,0.3054 -1.2797,1.0073 -1.7247,1.8972 -0.3324,0.6649 -0.3735,2.5288 -0.5174,3.1044 -0.3067,1.227 0.1621,1.6333 1.0348,2.0697 0.7931,0.3964 1.6854,0.1059 2.2421,-0.1725 0.7777,-0.3889 0.6701,-1.1281 0.8624,-1.8972 0.2005,-0.8021 0,-1.9335 0,-2.7595 0,-1.058 -0.098,-1.4778 -0.6899,-2.0696 -0.4979,-0.4979 -0.01,-0.4126 -1.2073,-0.1725 z"
+         id="path6258"
+         sodipodi:nodetypes="csssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15375);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15377);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1101.268,357.8844 c -0.01,-0.01 -0.7399,1.9246 -0.8624,2.4146 -0.192,0.768 0.3729,1.6129 0.1725,2.4145 -0.2824,1.1295 -0.499,1.5615 0.1725,1.8972 0.8876,0.4438 1.3588,0.4691 2.2421,0.6899 1.0572,0.2643 1.7135,-0.56 2.0696,-1.0348 0.4459,-0.5946 -0.2422,-2.0038 -0.345,-2.4146 -0.2342,-0.9369 -0.5943,-1.5337 -1.0348,-2.4146 -0.2523,-0.5046 -1.161,-0.9139 -1.5522,-1.2072 -0.2477,-0.1858 -0.5749,-0.23 -0.8623,-0.345 z"
+         id="path6260"
+         sodipodi:nodetypes="cssssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15370);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15372);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1105.0623,358.5743 c -0.8739,-0.6554 0,2.1846 0,3.2769 0,0.8239 0.032,1.8517 0.1725,2.4146 0.1253,0.5012 1.713,0.4282 2.0696,0.5174 1.0999,0.275 1.8468,-0.4169 2.2421,-1.2073 0.3644,-0.7288 -0.5174,-1.7737 -0.5174,-2.587 0,-1.3456 -0.549,-2.1117 -1.0349,-2.7595 -0.6871,-0.9163 -2.3857,-0.092 -2.9319,0.3449 z"
+         id="path6262"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15365);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15367);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1110.2363,358.0569 c 0,0 -0.3449,2.3448 -0.3449,3.1044 0,0.9975 -0.1581,1.5809 0.1725,2.2421 0.1932,0.3865 1.8229,0.4683 2.0696,0.345 0.9989,-0.4995 0.8623,-2.3649 0.8623,-3.4494 0,-0.715 -0.9727,-1.8662 -1.3797,-2.0696 -0.5155,-0.2578 -0.6063,-0.1725 -1.3798,-0.1725 z"
+         id="path6264"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15360);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15362);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1113.5133,357.712 c -1.0297,-0.5149 -0.1725,2.2981 -0.1725,3.4493 0,1.1493 -0.5458,1.4569 0.1725,2.4146 0.5322,0.7096 1.4362,-0.6319 1.8971,-0.8624 0.5068,-0.2534 0.3449,-1.8724 0.3449,-2.4145 0,-0.8895 -0.3726,-1.7802 -0.6898,-2.4146 -0.2739,-0.5478 -1.2082,-0.2413 -1.5522,-0.1724 z"
+         id="path6266"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15355);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15357);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1092.2996,358.2294 c 0,-0.01 0.345,2.1592 0.345,2.9319 0,0.573 0.1979,1.6797 0.3449,2.4146 0.2167,1.0835 -0.8777,0.8623 -1.7247,0.8623 -0.9321,0 -1.439,-0.7688 -1.8972,-1.3797 -0.3581,-0.4776 0.049,-2.4389 0.1725,-2.932 0.2108,-0.843 1.0282,-1.2902 1.5522,-1.5522 0.5256,-0.2628 0.2679,-0.1571 1.2073,-0.3449 z"
+         id="path6268"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15350);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15352);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1088.5053,359.0917 c 0.5361,-0.268 0,1.9277 0,2.587 0,1.0135 0.4461,1.1774 0,2.0697 -0.3575,0.715 -2.0985,-0.2732 -2.2421,-0.345 -0.6957,-0.3479 -0.6899,-1.4419 -0.6899,-2.2421 0,-0.8476 0.7133,-1.8184 0.8624,-2.4145 0.4285,-1.7142 1.6026,-0.2388 2.0696,0.3449 z"
+         id="path6270"
+         sodipodi:nodetypes="csssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15345);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15347);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1092.6446,359.6091 c 0.5284,-0.8441 0.5087,-1.4207 1.7246,-1.7247 0.082,-0.02 1.5045,1.5336 1.5523,1.7247 0.2023,0.8095 -0.053,2.0296 0.1724,2.932 0.3018,1.2072 -0.1547,1.5046 -1.0348,1.7247 -1.2229,0.3057 -1.4449,0.2569 -1.7247,-0.8624 -0.1707,-0.6828 -0.3906,-1.735 -0.5174,-2.2421 -0.1253,-0.5011 -0.1724,-1.0207 -0.1724,-1.5522 z"
+         id="path6272"
+         sodipodi:nodetypes="cssssssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15340);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15342);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1085.5733,358.4018 c 0.2394,0.6206 0.1725,2.574 0.1725,3.7943 0,1.337 -0.5447,1.2073 -1.7247,1.2073 -0.9424,0 -1.2073,-0.7684 -1.2073,-1.7247 0,-1.161 -0.098,-1.7019 0.5174,-2.9319 0.4091,-0.8182 0.7455,-1.0905 1.2073,-1.5523 0.3748,-0.3747 0.838,0.7152 1.0348,1.2073 z"
+         id="path6274"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15335);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15337);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1086.9531,364.9556 c -0.6504,-0.6504 0,1.8397 0,2.7595 0,1.0468 0.3366,1.2073 1.3797,1.2073 0.2977,0 0.7784,-2.0786 0.8624,-2.4145 0.204,-0.816 0.1573,-1.7851 0,-2.4146 -0.4393,-1.7571 -2.0536,0.3912 -2.2421,0.8623 z"
+         id="path6276"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15330);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15332);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1099.1983,370.1297 c -0.1485,-0.5941 -0.2459,-2.3636 -0.5174,-3.4494 -0.2585,-1.0341 -0.4605,-1.3229 -1.2072,-2.0696 -0.9233,-0.9232 -0.9865,1.8281 -1.0348,2.0696 -0.1884,0.9416 0.4903,1.4441 0.6898,2.2421 0.2445,0.9781 0.8213,1.2073 2.0696,1.2073 z"
+         id="path6278"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15325);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15327);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1099.5433,370.1297 c 0.2792,1.1169 -0.1725,-2.2982 -0.1725,-3.4494 0,-1.1046 -0.3047,-1.2475 0.345,-1.8971 0.6946,-0.6946 1.7605,0.9339 1.8971,1.2072 0.3755,0.7511 0.5174,1.0685 0.5174,2.2422 0,1.0631 -0.8012,1.1767 -1.5522,1.5522 -1.0127,0.5063 2.1893,-0.2999 -1.0348,0.3449 z"
+         id="path6280"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15320);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15322);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1102.8202,370.1297 c -0.142,0.071 -0.1725,-2.5447 -0.1725,-3.2769 0,-1.078 0.4293,-1.1191 1.0348,-1.7247 0.7935,-0.7935 1.7082,1.1277 1.8972,1.3798 0.4605,0.6139 0.1095,1.9766 0,2.4145 -0.085,0.3419 -2.3402,1.0396 -2.7595,1.2073 z"
+         id="path6282"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15315);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15317);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1096.6113,369.7848 c -0.2382,0.953 -0.4454,-1.9736 -1.0348,-2.7595 -0.8225,-1.0967 -0.3409,-1.464 -1.5522,-2.0697 -0.6934,-0.3467 -0.9786,1.4399 -1.2073,1.8972 -0.4633,0.9267 0.4934,1.7127 0.8623,1.8971 0.6834,0.3417 0.8541,0.9445 1.7247,1.3798 0.4019,0.2009 0.5889,0.2335 1.0349,0.3449"
+         id="path6284"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15310);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15312);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1091.9547,369.0949 c 0.2588,0.1294 0,-2.5694 0,-3.2769 0,-1.3421 -0.1194,-1.0348 -1.5523,-1.0348 -0.9902,0 -0.8623,1.676 -0.8623,2.587 0,1.2035 0.058,1.4949 0.8623,1.8972 0.7312,0.3655 0.636,0.5147 1.5523,-0.1725 z"
+         id="path6286"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15305);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15307);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1106.6145,369.6123 c 0.9383,0.4691 0.048,-2.1661 0.5174,-3.1044 0.387,-0.7741 1.4935,-1.0349 2.2421,-1.0349 1.092,0 0.8623,0.9276 0.8623,1.8972 0,0.6261 -0.9489,1.2939 -1.3797,1.7247 -0.4489,0.4489 -1.5367,0.5174 -2.2421,0.5174 z"
+         id="path6288"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15300);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15302);stroke-width:1.82857144;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1110.9262,368.5775 c -0.4066,0.4066 0.074,-1.6743 0.5174,-3.4494 0.2329,-0.9315 1.2717,-0.6738 1.8972,-0.5174 0.97,0.2425 0.3635,1.8601 0.1725,2.2421 -0.4911,0.982 -1.4875,1.7247 -2.5871,1.7247 z"
+         id="path6290"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15297);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1099.4875,283.41592 c -0.3252,0.89433 0.4878,0.99841 0.4878,2.43909 0,0.65713 -2.5514,3.67775 -2.1951,4.39034 0.5134,1.02685 1.9094,1.90941 2.1951,2.19514 0.1945,0.19449 -5.927,-0.60617 -6.5703,1.46347 -0.5509,1.77213 -2.4659,-1.57691 -4.2302,-1.13585 -1.208,0.30203 -3.509,4.51762 -4.5505,5.03835 -1.5107,0.75536 -2.9868,-1.87186 -3.4147,-0.1602 -0.2999,1.19963 -0.212,2.06748 -0.4878,3.1708 -0.5005,2.00176 0.7998,-0.74592 -2.4391,-0.20611 -1.4765,0.2461 -1.7074,-0.61564 -1.7074,2.68299 0,0.078 -3.0207,1.53854 -3.4146,2.19517 -0.764,1.27323 -1.0361,1.67435 -1.4635,3.3838 -0.5581,2.23234 -4.1858,0.95403 -5.3355,2.10374"
+         id="path6292"
+         sodipodi:nodetypes="csssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15294);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1098.527,293.79319 c 1.0569,-1.05695 2.1139,-2.11387 3.1708,-3.1708 1.0569,-1.05694 -2.1139,2.11385 -3.1708,3.1708 -1.1382,1.13822 2.4489,-2.12694 3.4147,-3.41471 1.3658,-1.82099 4.0513,0.54135 4.6343,1.70735 0.707,1.41396 1.789,2.58523 2.439,2.19517 0.9686,-0.58112 2.5292,-0.97563 3.6586,-0.97563 2.3472,0 3.42,1.96166 4.3904,3.90251 0.6982,1.39651 2.5101,-0.97562 4.3903,-0.97562 1.927,0 2.8698,0.96012 2.4391,2.68298 -0.1865,0.74581 2.3898,1.6581 2.9269,2.19517 1.369,1.36901 -0.5278,2.61202 1.7073,3.17079 2.0547,0.51368 5.9206,1.84604 7.1954,2.16475"
+         id="path6294"
+         sodipodi:nodetypes="cssssssssssss"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15291);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1079.8819,316.8369 c 1.7888,0.0911 5.7581,-1.03481 8.6234,-1.03481 3.0021,0 5.0907,-0.21417 7.5886,1.03481 0.466,0.23299 0.9322,0.4661 1.3798,0.68988"
+         id="path6296"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15288);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 1106.442,317.52678 c 1.24,-1.0185 3.8992,-2.41456 5.864,-2.41456 2.1836,0 4.0033,0 6.2088,0 1.3798,0 2.7595,0 4.1393,0"
+         id="path6298"
+         sodipodi:nodetypes="cssc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect6206"
+         width="200"
+         height="200"
+         x="800"
+         y="200.00018" />
+      <path
+         style="fill:none;stroke:url(#linearGradient15284);stroke-width:1.82857144;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 845.34562,318.52553 c 1.11825,1.92054 1.6663,2.99722 4.42397,3.68663 1.61062,0.40266 1.10599,-2.63788 1.10599,-4.42396 0,-2.79429 0.64245,-3.0862 2.58064,-4.0553 1.86484,-0.93242 2.92728,2.16793 3.31797,2.94931 0.9281,1.8562 3.4449,0.97906 4.42397,0 1.32498,-1.32499 1.10599,-2.95142 1.10599,-5.16129 0,-0.70941 -1.84332,-1.45433 -1.84332,-3.68664 0,-0.54862 4.31499,-0.36866 5.16129,-0.36866 0.31562,0 3.14836,3.88568 3.31797,4.0553 1.44244,1.44244 3.35128,0.67072 4.0553,-0.73733 0.9283,-1.8566 -1.35187,-3.07225 -2.58064,-3.68664 -1.209,-0.60449 -1.23748,-3.47523 -1.47466,-4.42396 -0.4215,-1.68601 3.67106,-0.15681 5.16129,0.73733 2.23792,1.34275 1.15195,2.93782 4.0553,2.21198 2.24591,-0.56148 1.32055,-2.96591 0.73733,-4.42396 -0.38726,-0.96816 -1.74566,-1.27933 -2.21198,-2.21198"
+         id="path6208"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15279);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15281);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 917.1099,367.7124 c -6.5118,4.473 2.61918,12.1603 -3.60237,17.0491 -6.3053,5.7411 -2.26825,4.3732 -10.12279,5.9718 -5.43331,1.4539 -23.59717,2.084 -18.19594,-1.7656 7.15768,-5.123 10.0254,-13.4998 15.90766,-19.616 3.61005,-2.6713 18.8562,-15.5328 16.01344,-1.6393 z"
+         id="path6210"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15274);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15276);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 953.57426,361.9462 c 0.14482,-1.8207 1.58721,-3.5849 0.77074,-5.4293 -0.7782,-1.3913 -1.38926,-3.3476 -0.22674,-4.7084 1.95942,-2.0993 4.94736,-2.4974 7.43713,-3.6806 1.39795,-0.50972 2.811,-0.98019 4.24503,-1.37827 1.65224,0.39703 2.20701,2.34927 2.00014,3.84967 -0.14215,3.5736 -0.66896,7.1541 -0.28305,10.7276 0.11812,2.3185 -0.16122,4.6618 0.33666,6.9513 0.20925,1.2562 0.43227,2.6652 -0.41171,3.756 -0.92333,1.4682 -2.88184,2.1409 -4.48756,1.431 -1.8442,-0.5922 -2.8009,-2.4007 -4.20808,-3.5741 -1.56636,-1.2574 -3.68875,-1.8695 -4.8861,-3.5463 -0.69463,-1.3679 -0.31849,-2.9412 -0.28646,-4.3986 z"
+         id="path6212"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15269);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15271);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 955.00897,364.0229 c 1.64588,-1.3012 -1.57206,-1.029 1.40136,-1.5899 2.97342,-0.5609 6.23749,0.7943 7.93009,3.3078 0.82449,0.9865 1.66644,2.326 3.03633,2.5002 2.58316,-0.111 2.33757,-3.2289 3.49549,-4.7034 1.48922,-1.127 2.70719,0.6014 2.20637,2.0248 -0.14998,1.9513 0.4963,3.7658 1.34611,5.4594 0.45921,1.8816 0.23638,3.9572 1.33595,5.65 1.92136,4.023 1.80606,8.5865 1.65561,12.9338 -1.85587,0.3491 -1.25197,-2.6743 -1.91177,-3.8118 -0.40031,-2.3341 -0.0677,-4.7989 -0.76159,-7.0653 -1.36405,-1.6811 -3.29733,0.8892 -2.31842,2.3191 -0.15701,1.9317 -1.2804,3.928 -2.57941,5.2291 0.0355,-1.299 -0.48809,-3.1487 -2.19683,-2.834 -2.27367,0.6026 0.14389,3.3746 -1.72862,4.1941 -1.67377,0.1398 -2.39906,-2.021 -3.05529,-3.2586 -0.96773,-2.5609 -1.20987,-5.3282 -2.20445,-7.8847 -1.04811,-2.803 -1.61211,-6.0597 -4.00177,-8.0878 -1.42953,-0.7242 -3.29504,-3.0816 -1.64916,-4.3828 z"
+         id="path6214"
+         sodipodi:nodetypes="ccccccccccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path6216"
+         d="m 953.20205,336.52978 c -0.11474,-1.82286 1.06302,-3.77367 -0.007,-5.48372 -0.96755,-1.26691 -1.84976,-3.11689 -0.89186,-4.62871 1.64206,-2.35584 4.54339,-3.1735 6.84031,-4.69765 1.31159,-0.70272 2.64367,-1.36875 4.0068,-1.96608 1.69183,0.15882 2.51773,2.01275 2.52563,3.52726 0.36585,3.55774 0.35189,7.17673 1.24044,10.65945 0.44557,2.27829 0.50121,4.63752 1.31859,6.83334 0.38522,1.21389 0.80571,2.57703 0.12487,3.77647 -0.70588,1.58429 -2.54927,2.52779 -4.2394,2.05269 -1.90953,-0.32484 -3.11292,-1.97948 -4.67223,-2.9416 -1.72877,-1.02262 -3.9165,-1.32774 -5.33944,-2.81781 -0.88151,-1.25564 -0.73218,-2.86636 -0.90706,-4.31364 z"
+         style="fill:url(#linearGradient15264);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15266);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15259);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15261);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 953.80836,339.40875 c 0.83312,-0.54815 -0.60808,-1.80761 1.00447,-1.71545 3.29829,-1.1931 7.0967,0.21187 9.223,2.90325 1.13088,1.5657 3.9174,1.90156 4.47772,-0.3488 0.4249,-1.36666 0.48847,-4.84297 2.73345,-3.61085 1.30785,1.09416 0.36455,2.87824 1.16355,4.21569 0.75529,1.76012 1.99164,3.31781 2.25565,5.26827 0.30516,1.84054 1.60628,3.19424 2.38069,4.81944 1.60963,3.3808 2.01148,7.1575 2.37746,10.8377 -1.90114,0.065 -1.78878,-2.3271 -2.30704,-3.6088 -0.85445,-1.9058 -0.73147,-4.1098 -1.48928,-6.0645 -0.60382,-2.4841 -3.58457,-0.1473 -2.58104,1.6637 0.89103,1.6548 -0.8122,5.0203 -1.57571,5.4193 0.2371,-1.9343 -3.19937,-3.4421 -3.36294,-0.9721 0.29575,1.2012 0.52494,3.9191 -1.50034,2.9568 -2.38456,-1.5958 -3.11838,-4.567 -4.17044,-7.0732 -1.00937,-2.5946 -2.31471,-5.0608 -3.62299,-7.5126 -0.89451,-1.57781 -2.23009,-2.91214 -3.89772,-3.64769 -1.05952,-0.73319 -2.29368,-2.34531 -1.10849,-3.53016 z"
+         id="path6218"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15254);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15256);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 897.27688,258.98919 c 3.4177,4.77828 27.94089,36.04178 12.34916,51.22112 -6.98535,7.21672 -15.88179,9.83871 -25.99981,9.11112 -9.0356,3.38229 -41.79586,23.08085 -52.00055,28.00473 -3.87756,0.54274 -10.46957,-1.49628 -10.01299,-4.45918 4.57708,-2.38349 8.84027,-2.23142 11.67666,-5.62515 6.02828,-1.40318 12.1608,-5.39016 14.724,-13.6596 5.70526,-1.40377 25.8808,-14.773 32.23282,-20.77046 3.04325,-3.54256 8.4774,-7.30113 10.61219,-11.5061 2.23198,-5.19015 1.0306,-19.12504 -0.88366,-25.4059 7.49108,9.22389 -0.88344,-14.20077 7.30218,-6.91058 z"
+         id="path6220"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15249);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15251);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 892.10863,233.36621 c 3.39497,-0.39792 7.7696,2.2625 6.41988,6.0886 -0.54246,3.31765 -3.01656,6.14022 -6.25356,7.05328 -3.57719,1.90155 -8.03741,1.09927 -11.50071,3.06337 -2.82773,3.62785 3.80316,13.18097 6.65285,12.89879 -0.64213,5.4988 -0.91929,23.3462 -1.37817,25.82933 -0.94585,3.89168 -11.97094,11.93327 -16.85216,15.41152 -2.64905,3.54229 -8.05098,4.51964 -10.59573,0.30141 -2.62384,-2.88943 0.89753,-25.56846 3.5515,-32.70699 1.46025,-4.05328 7.36062,-25.8253 12.29749,-30.79516 1.69199,-1.13286 13.55301,-6.85189 17.65861,-7.14415 z"
+         id="path6222"
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15244);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15246);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 879.5372,236.59392 c -0.90931,-1.17854 -13.87962,8.80199 -17.22388,12.79517 -6.13736,7.65052 -14.10562,17.77013 -17.37377,23.85776 -3.52873,3.52843 -19.21286,22.42504 -24.66145,40.04002 1.76484,-1.06394 10.0905,-10.19232 12.66318,-11.43011 3.20232,-3.2743 -3.92234,13.6658 -6.94107,18.28818 -3.1389,1.8005 -3.48479,5.47955 -4.69674,8.88085 -0.99839,3.33746 -2.29579,6.81278 -0.40179,9.94766 3.61758,-1.46867 7.19287,-5.39812 11.80419,-6.12377 1.46888,-4.02072 2.58824,-12.01154 9.49046,-12.80172 6.81628,-1.02543 12.98094,-4.49749 18.01108,-9.13024 3.47641,-3.69162 19.1766,-14.05102 19.00863,-15.07389 -5.72928,1.37587 -11.95139,4.53102 -18.02495,3.81004 2.85362,-4.02431 17.85762,-19.63045 20.72661,-24.78603 1.57862,-4.78738 3.45896,-9.48633 5.66656,-14.03479 1.64788,-4.00011 5.83299,-7.20769 0.26725,-12.30742 -1.80003,-0.92086 -2.14987,3.50069 -3.84176,5.89271 -2.97877,4.73423 -12.52263,4.68031 -14.00038,-1.35599 -1.6553,-6.77673 10.13042,-15.68742 9.52783,-16.46843 z"
+         id="path6224"
+         sodipodi:nodetypes="ccccccccccccccccccs"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15239);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15241);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 914.44597,244.10255 c 1.44896,2.74012 4.24007,4.5793 7.20285,5.31399 2.50799,1.76531 -0.32688,5.25623 1.6578,7.29135 1.96279,2.02618 3.35229,4.59257 3.88939,7.35703 1.39227,3.07691 2.94105,6.15414 3.36391,9.54877 1.12761,3.4983 4.48713,5.47103 6.81942,8.10746 1.48979,1.65008 3.23923,3.27033 3.96315,5.41628 0.70078,2.28062 -1.59626,3.11472 -3.36414,2.80025 -1.30006,0.91035 0.27936,5.38029 -2.3584,3.87491 -2.26056,-1.84198 -2.90432,-4.90921 -2.57583,-7.67852 -0.18861,-3.36588 -2.20609,-6.22187 -3.36573,-9.29022 -2.13219,-3.44143 -5.31407,-6.34528 -9.1875,-7.66058 -2.45547,-0.93569 -4.88646,-2.37478 -6.05894,-4.83621 -1.72425,-2.52192 -3.25934,-5.297 -3.41067,-8.4218 -0.58356,-3.93121 -0.42474,-8.31975 2.13014,-11.57173 0.34396,-0.31907 0.85937,-0.37461 1.29455,-0.25098 z"
+         id="path6226"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15234);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15236);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 929.87584,262.96128 c 1.88582,-1.37809 4.24811,-0.13242 6.33727,-0.56127 2.90689,-0.27827 6.18287,-0.44841 8.63327,1.43038 2.18978,2.34425 3.73351,5.28537 4.35934,8.43385 0.76416,2.30997 2.49881,4.08107 3.92564,5.98059 0.86253,1.48511 1.29674,3.64529 0.046,5.0338 -1.43568,1.0594 -3.12203,-0.35551 -3.86762,-1.59777 -1.13407,-1.4752 -2.115,-3.452 -3.7136,-4.34316 -1.61927,0.65209 0.50534,2.76361 -0.0751,4.08459 -0.0309,1.68517 0.48941,3.34167 1.29843,4.80679 0.50729,1.59278 -0.58679,4.07523 -2.52589,3.65041 -1.63025,-0.52388 -1.69391,-2.47448 -1.99732,-3.88067 -0.71637,-2.40961 -3.66528,-2.96942 -4.87202,-5.04124 -2.95297,-4.67848 -6.27702,-9.40963 -7.23346,-14.97438 -0.14446,-1.00288 -0.20934,-2.01475 -0.31497,-3.02192 z"
+         id="path6228"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15229);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15231);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 946.04044,310.47545 c -0.11473,-1.82287 1.06302,-3.77367 -0.007,-5.48372 -0.96755,-1.26691 -1.84975,-3.11689 -0.89186,-4.62871 1.64206,-2.35584 4.5434,-3.1735 6.84031,-4.69765 1.31159,-0.70273 2.64368,-1.36875 4.0068,-1.96608 1.69183,0.15881 2.51773,2.01276 2.52563,3.52726 0.36585,3.55774 0.3519,7.17673 1.24044,10.65944 0.44557,2.2783 0.50121,4.63753 1.3186,6.83335 0.38521,1.21389 0.8057,2.57703 0.12487,3.77647 -0.70589,1.58429 -2.54927,2.52779 -4.23941,2.05269 -1.90953,-0.32485 -3.11291,-1.97948 -4.67222,-2.9416 -1.72877,-1.02262 -3.91651,-1.32774 -5.33945,-2.81781 -0.88151,-1.25564 -0.73218,-2.86636 -0.90706,-4.31364 z"
+         id="path6230"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15224);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15226);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 946.05783,315.65363 c 0.67636,-0.73285 -1.026,-1.60765 0.5612,-1.90703 2.9133,-1.95317 6.93841,-1.50551 9.65091,0.59378 1.47502,1.24682 4.26033,0.90091 4.26151,-1.41816 0.0828,-1.4288 -0.69366,-4.81787 1.78217,-4.1634 1.53308,0.74653 1.04779,2.70543 2.14569,3.81076 1.1574,1.52607 2.73286,2.73971 3.45936,4.56896 0.73994,1.71265 2.32908,2.71269 3.4725,4.10321 2.37731,2.89294 3.67792,6.46131 4.92047,9.94472 -1.82928,0.52185 -2.29712,-1.8272 -3.10911,-2.94602 -1.28876,-1.64356 -1.70084,-3.81222 -2.90761,-5.52657 -1.18495,-2.26515 -3.51429,0.72143 -2.10372,2.23702 1.26374,1.39115 0.42222,5.06794 -0.22254,5.63933 -0.2363,-1.93443 -3.93495,-2.56919 -3.49812,-0.13258 0.57665,1.0944 1.45442,3.6769 -0.74313,3.23136 -2.69899,-0.9738 -4.12755,-3.68037 -5.75287,-5.85897 -1.60519,-2.27468 -3.46665,-4.35337 -5.3275,-6.41741 -1.24856,-1.31558 -2.86647,-2.28851 -4.66226,-2.60026 -1.20504,-0.45609 -2.79149,-1.72308 -1.92695,-3.15874 z"
+         id="path6232"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15219);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15221);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 962.44999,298.96429 c 2.10305,0.98621 2.20678,3.92503 4.38211,4.83765 1.31702,0.95523 2.33377,3.04425 1.23154,4.50475 -1.42093,1.55816 -3.63013,-0.43203 -3.74971,-2.08598 -0.278,-2.5918 -3.15494,-3.44784 -4.49777,-5.35785 -0.48993,-0.62284 -0.66136,-2.21889 -1.697,-1.91388 0.59459,1.46498 1.78152,3.64432 0.13687,4.8879 -2.23882,0.60058 -2.85338,-2.18039 -4.18014,-3.25278 -1.79672,-1.22637 -4.05629,1.24301 -2.01722,2.62817 1.17445,0.54775 1.46696,3.3305 -0.25622,2.42891 -1.67795,-1.05566 -2.44586,-3.16635 -4.37155,-3.91102 -2.15137,-1.0706 -4.84316,-1.44553 -6.2974,-3.56844 -1.32455,-1.61127 -2.66219,-3.24189 -3.6879,-5.06002 -0.43522,-2.16629 2.32931,-2.25723 3.73306,-1.64712 1.62627,0.35037 3.6449,1.03843 5.04582,-0.23429 1.45925,-1.7036 0.0626,-4.52818 1.99176,-5.9734 2.07511,-1.24859 3.36858,1.291 4.57528,2.46001 1.66488,0.95721 4.07776,0.65092 5.16948,2.51235 0.94318,1.75549 1.81254,3.56092 3.04657,5.14274 0.63988,1.09193 1.79025,2.23495 1.44242,3.6023 z"
+         id="path6234"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15214);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15216);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 902.9348,244.34747 c -1.95065,-1.58391 -5.03144,-2.1142 -7.12287,-0.49953 -3.62634,1.3407 -5.81751,7.27982 -2.58747,9.26979 1.50728,1.45343 5.67739,1.86915 7.2076,0.87776 3.57878,0.98093 5.35584,3.67556 7.12153,4.09007 1.95842,1.11529 2.50062,3.48171 3.54965,5.31705 0.79244,1.52533 1.65497,3.23101 3.22058,4.06995 1.8516,0.42007 3.29611,-1.43452 1.98662,-2.55398 -1.70313,-1.56987 -1.78446,-14.9342 -2.1849,-19.53547 -0.0769,-1.84467 -3.49723,-3.43052 -4.35722,-1.82399 -1.54142,1.61347 -2.31937,9.89663 -1.92855,7.49382 -0.6182,-2.012 -3.2554,-5.2408 -4.90497,-6.70547 z"
+         id="path6236"
+         sodipodi:nodetypes="cccccccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15209);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15211);stroke-width:3.65714288;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 965.88904,378.6716 c -14.74923,-8.1134 -24.88511,-12.9831 -38.77368,-20.6784 -8.06218,-3.5985 -9.28754,10.3095 -6.28,16.6372 3.19977,6.7322 -9.94552,9.4389 -0.25859,15.9756 9.16491,2.0107 31.29307,2.6534 47.19504,2.5839 9.57944,1.9446 40.50729,-10.0914 17.82897,-17.8479 -7.02175,-1.7005 -12.58113,5.5967 -19.71174,3.3296 z"
+         id="path6238"
+         sodipodi:nodetypes="ccscccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient15204);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient15206);stroke-width:0.22857143px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 866.72811,267.28129 c -0.92834,2.08876 0.85795,3.80725 1.84332,4.79262 0.92808,0.92808 2.91051,1.46496 4.42396,1.84332 1.60762,0.40191 3.40592,-0.45714 5.07281,-0.45714 2.19032,0 2.66913,-3.23063 2.66913,-5.07281 0,-1.75147 -2.39826,-3.32186 -2.94931,-4.42397 -0.64935,-1.2987 -4.17779,-1.15474 -4.96959,-1.94654 -0.5564,-0.5564 -4.46335,1.60384 -6.09032,5.26452 z"
+         id="path6240"
+         sodipodi:nodetypes="csssssss"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/MaurizioMonge/spatial.svg
+++ b/projects/gui/res/chessboard/MaurizioMonge/spatial.svg
@@ -1,0 +1,1279 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="1200"
+   height="400"
+   id="svg2722"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   version="1.0"
+   sodipodi:docname="spatial.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <title
+     id="title3747">Spatial Chess Piece Set</title>
+  <defs
+     id="defs2724">
+    <linearGradient
+       id="linearGradientWhitePiecesBorder">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7935" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop7937" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientWhitePieces">
+      <stop
+         id="stop7929"
+         offset="0"
+         style="stop-color:#ede3de;stop-opacity:1;" />
+      <stop
+         id="stop7931"
+         offset="1"
+         style="stop-color:#d0b090;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPiecesBorder">
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="0"
+         id="stop7192" />
+      <stop
+         style="stop-color:#808080;stop-opacity:1;"
+         offset="1"
+         id="stop7194" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradientBlackPieces">
+      <stop
+         id="stop2268"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop2270"
+         offset="1"
+         style="stop-color:#505070;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2472"
+       gradientUnits="userSpaceOnUse"
+       x1="163.1134"
+       y1="776.63849"
+       x2="702.69696"
+       y2="778.81091"
+       gradientTransform="scale(0.22857143,0.22857143)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2475"
+       gradientUnits="userSpaceOnUse"
+       x1="150.07878"
+       y1="255.25356"
+       x2="694.0072"
+       y2="740.0625"
+       gradientTransform="scale(0.22857143,0.22857143)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2483"
+       x1="375.06781"
+       y1="176.41568"
+       x2="535.5755"
+       y2="308.93436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="scale(0.22857143,0.22857143)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2361"
+       x1="199"
+       y1="789.83331"
+       x2="661.66669"
+       y2="789.83331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2363"
+       x1="166.78125"
+       y1="239.89061"
+       x2="718.88538"
+       y2="746.55731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2371"
+       x1="285.63937"
+       y1="287.11978"
+       x2="466.66666"
+       y2="587.11981"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2413"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2416"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2419"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2422"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2425"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2428"
+       gradientUnits="userSpaceOnUse"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2275"
+       gradientUnits="userSpaceOnUse"
+       x1="322.64999"
+       y1="156.50154"
+       x2="501.10233"
+       y2="209.83487"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,3.58095)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2278"
+       gradientUnits="userSpaceOnUse"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,0.91429)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2281"
+       gradientUnits="userSpaceOnUse"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,0.91429)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2284"
+       gradientUnits="userSpaceOnUse"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,598.17143,0.91429)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2287"
+       gradientUnits="userSpaceOnUse"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,602.28571,0.91429)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2513"
+       x1="163.67708"
+       y1="244.15625"
+       x2="741.16382"
+       y2="814.15625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.45714,2.74286)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPieces"
+       id="linearGradient2232"
+       x1="250.33334"
+       y1="541.66669"
+       x2="671.33337"
+       y2="718.33331"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17655"
+       x1="265.33334"
+       y1="605"
+       x2="644.66669"
+       y2="605"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17657"
+       x1="827.92651"
+       y1="104.44271"
+       x2="974.56012"
+       y2="104.44271"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17659"
+       x1="681.69147"
+       y1="32.30088"
+       x2="717.96625"
+       y2="32.30088"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17661"
+       x1="644.22748"
+       y1="93.363823"
+       x2="754.01538"
+       y2="93.363823"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17663"
+       x1="656.23303"
+       y1="150.81651"
+       x2="737.67212"
+       y2="150.81651"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17665"
+       x1="699.29651"
+       y1="174.58551"
+       x2="766.55627"
+       y2="174.58551"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17667"
+       x1="632.22473"
+       y1="174.58551"
+       x2="699.48456"
+       y2="174.58551"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17669"
+       x1="539.12384"
+       y1="171.96191"
+       x2="564.87622"
+       y2="171.96191"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17671"
+       x1="435.50476"
+       y1="178.81903"
+       x2="530.97144"
+       y2="178.81903"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17673"
+       x1="540.64764"
+       y1="59.123825"
+       x2="573.25714"
+       y2="59.123825"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17675"
+       x1="481.21906"
+       y1="55.885723"
+       x2="518.01904"
+       y2="55.885723"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17677"
+       x1="426.74286"
+       y1="58.552391"
+       x2="466.20953"
+       y2="58.552391"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17679"
+       x1="452.26666"
+       y1="125.40951"
+       x2="550.40002"
+       y2="125.40951"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17681"
+       x1="245.48573"
+       y1="180.53334"
+       x2="351.2381"
+       y2="180.53334"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17683"
+       x1="218.3119"
+       y1="95.213097"
+       x2="382.98334"
+       y2="95.213097"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17685"
+       x1="252.33662"
+       y1="96.103577"
+       x2="353.14285"
+       y2="96.103577"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17687"
+       x1="43.504772"
+       y1="180.95239"
+       x2="156.87621"
+       y2="180.95239"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17689"
+       x1="19.407007"
+       y1="119.72302"
+       x2="182.46497"
+       y2="119.72302"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientBlackPiecesBorder"
+       id="linearGradient17691"
+       x1="72.322746"
+       y1="53.730625"
+       x2="129.8656"
+       y2="53.730625"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17743"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200)"
+       x1="375.06781"
+       y1="176.41568"
+       x2="535.5755"
+       y2="308.93436" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17745"
+       gradientUnits="userSpaceOnUse"
+       x1="72.322746"
+       y1="53.730625"
+       x2="129.8656"
+       y2="53.730625"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200)"
+       x1="150.07878"
+       y1="255.25356"
+       x2="694.0072"
+       y2="740.0625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17749"
+       gradientUnits="userSpaceOnUse"
+       x1="19.407007"
+       y1="119.72302"
+       x2="182.46497"
+       y2="119.72302"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,0,200)"
+       x1="163.1134"
+       y1="776.63849"
+       x2="702.69696"
+       y2="778.81091" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17753"
+       gradientUnits="userSpaceOnUse"
+       x1="43.504772"
+       y1="180.95239"
+       x2="156.87621"
+       y2="180.95239"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17755"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="285.63937"
+       y1="287.11978"
+       x2="466.66666"
+       y2="587.11981" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17757"
+       gradientUnits="userSpaceOnUse"
+       x1="252.33662"
+       y1="96.103577"
+       x2="353.14285"
+       y2="96.103577"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="166.78125"
+       y1="239.89061"
+       x2="718.88538"
+       y2="746.55731" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17761"
+       gradientUnits="userSpaceOnUse"
+       x1="218.3119"
+       y1="95.213097"
+       x2="382.98334"
+       y2="95.213097"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,200,200)"
+       x1="199"
+       y1="789.83331"
+       x2="661.66669"
+       y2="789.83331" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17765"
+       gradientUnits="userSpaceOnUse"
+       x1="245.48573"
+       y1="180.53334"
+       x2="351.2381"
+       y2="180.53334"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17767"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17769"
+       gradientUnits="userSpaceOnUse"
+       x1="452.26666"
+       y1="125.40951"
+       x2="550.40002"
+       y2="125.40951"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17771"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17773"
+       gradientUnits="userSpaceOnUse"
+       x1="426.74286"
+       y1="58.552391"
+       x2="466.20953"
+       y2="58.552391"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17775"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17777"
+       gradientUnits="userSpaceOnUse"
+       x1="481.21906"
+       y1="55.885723"
+       x2="518.01904"
+       y2="55.885723"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17779"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17781"
+       gradientUnits="userSpaceOnUse"
+       x1="540.64764"
+       y1="59.123825"
+       x2="573.25714"
+       y2="59.123825"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17783"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17785"
+       gradientUnits="userSpaceOnUse"
+       x1="435.50476"
+       y1="178.81903"
+       x2="530.97144"
+       y2="178.81903"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17787"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,400,200)"
+       x1="88.715729"
+       y1="286.24783"
+       x2="772.14215"
+       y2="750.5813" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17789"
+       gradientUnits="userSpaceOnUse"
+       x1="539.12384"
+       y1="171.96191"
+       x2="564.87622"
+       y2="171.96191"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17791"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,602.28571,200.91429)"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17793"
+       gradientUnits="userSpaceOnUse"
+       x1="632.22473"
+       y1="174.58551"
+       x2="699.48456"
+       y2="174.58551"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17795"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,598.17143,200.91429)"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17797"
+       gradientUnits="userSpaceOnUse"
+       x1="699.29651"
+       y1="174.58551"
+       x2="766.55627"
+       y2="174.58551"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17799"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,200.91429)"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17801"
+       gradientUnits="userSpaceOnUse"
+       x1="656.23303"
+       y1="150.81651"
+       x2="737.67212"
+       y2="150.81651"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17803"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,200.91429)"
+       x1="130.98332"
+       y1="444.83487"
+       x2="720.01697"
+       y2="623.16821" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17805"
+       gradientUnits="userSpaceOnUse"
+       x1="644.22748"
+       y1="93.363823"
+       x2="754.01538"
+       y2="93.363823"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17807"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,600,203.58095)"
+       x1="322.64999"
+       y1="156.50154"
+       x2="501.10233"
+       y2="209.83487" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17809"
+       gradientUnits="userSpaceOnUse"
+       x1="681.69147"
+       y1="32.30088"
+       x2="717.96625"
+       y2="32.30088"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22857143,0,0,0.22857143,800.45714,202.74286)"
+       x1="163.67708"
+       y1="244.15625"
+       x2="741.16382"
+       y2="814.15625" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17813"
+       gradientUnits="userSpaceOnUse"
+       x1="827.92651"
+       y1="104.44271"
+       x2="974.56012"
+       y2="104.44271"
+       gradientTransform="translate(0,200)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePieces"
+       id="linearGradient17815"
+       gradientUnits="userSpaceOnUse"
+       x1="250.33334"
+       y1="541.66669"
+       x2="671.33337"
+       y2="718.33331" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradientWhitePiecesBorder"
+       id="linearGradient17817"
+       gradientUnits="userSpaceOnUse"
+       x1="265.33334"
+       y1="605"
+       x2="644.66669"
+       y2="605" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="119.07594"
+     inkscape:cy="323.82747"
+     inkscape:document-units="px"
+     inkscape:current-layer="WhitePieces"
+     showgrid="false"
+     inkscape:window-width="1566"
+     inkscape:window-height="828"
+     inkscape:window-x="111"
+     inkscape:window-y="329"
+     showguides="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5039" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Spatial Chess Piece Set</dc:title>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Graphic arts by Maurizio Monge.
+SVG version adapted to the CuteChess GUI by alwey.</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2017-10-29</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>(C) 2006, 2011 Maurizio Monge</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>Ilari Pihlajisto, Arto Jonsson, alwey</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>http://poisson.phc.unipi.it/~monge/chess_art.php</dc:source>
+        <dc:description>Chess piece set &quot;Spatial&quot; by Maurizio Monge.</dc:description>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="BlackPieces"
+     inkscape:groupmode="layer"
+     id="BlackPieces">
+    <g
+       id="k"
+       inkscape:label="#BlackKing">
+      <rect
+         y="0"
+         x="0"
+         height="200"
+         width="200"
+         id="rect8054"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4417"
+         d="m 92.1156,25.14491 0,13.62857 -17.96428,0 0,15.55 17.96428,0 0,27.99286 14.34286,0 0,-27.99286 21.57857,0 0,-15.55 -21.57857,0 0,-13.62857 -14.34286,0 z"
+         style="fill:url(#linearGradient2483);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17691);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccscsccsc"
+         id="path4423"
+         d="m 116.7685,105.41059 c 45.6543,-24.41897 31.02431,22.10128 8.36721,36.48227 -14.59749,9.26537 -22.22965,-25.69457 -14.48571,-51.95 l -19.56429,0.23571 c 7.21432,23.23396 2.81457,58.938 -13.05714,51.71429 C 49.75695,129.02555 39.24695,81.68205 84.38469,105.43227 58.3013,52.11164 17.67351,72.50058 21.48571,99.6 c 4.14121,29.43815 37.73984,55.92746 37.05715,67.72857 l 84.30714,0 C 141.4993,153.65548 179.40131,125.53604 180.61429,98.8 181.77855,72.641 136.63157,52.38136 116.7685,105.41059 z"
+         style="fill:url(#linearGradient2475);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17689);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <rect
+         y="173.33334"
+         x="45.333344"
+         height="15.238094"
+         width="109.71429"
+         id="rect4429"
+         style="fill:url(#linearGradient2472);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17687);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="q"
+       inkscape:label="#BlackQueen">
+      <rect
+         y="0"
+         x="200"
+         height="200"
+         width="200"
+         id="rect8054-3"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc"
+         id="path4435"
+         d="m 351.31429,34.26429 c -47.85856,143.39987 -55.2529,143.66612 -97.14286,0.67857 -0.25771,58.27118 7.49175,99.25943 18.72143,123 l 54.41428,0 c 12.30698,-23.85133 21.84012,-65.09315 24.00715,-123.67857 z"
+         style="fill:url(#linearGradient2371);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17685);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc"
+         id="path4433"
+         d="m 302.54762,24.48095 c -17.36795,94.11121 -8.84667,194.98248 -82.40714,42.58572 2.51734,46.59316 13.44436,79.60587 32.82142,98.87857 l 91.9,0 c 19.74371,-19.03196 31.7104,-51.53341 36.29286,-97.65 -70.24868,152.42869 -64.15014,50.38385 -78.60714,-43.81429 z"
+         style="fill:url(#linearGradient2363);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17683);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <rect
+         y="173.10477"
+         x="247.3143"
+         height="14.857148"
+         width="102.09524"
+         id="rect4429-1"
+         style="fill:url(#linearGradient2361);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17681);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="r"
+       inkscape:label="#BlackRook">
+      <rect
+         y="0"
+         x="400"
+         height="200"
+         width="200"
+         id="rect8054-2"
+         style="fill:none;stroke:none" />
+      <rect
+         y="70.552368"
+         x="454.09525"
+         height="109.71428"
+         width="94.476204"
+         id="rect1316"
+         style="fill:url(#linearGradient2428);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17679);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="40.076202"
+         x="428.57144"
+         height="36.952377"
+         width="35.809528"
+         id="rect2191"
+         style="fill:url(#linearGradient2425);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17677);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="48.076202"
+         x="483.04761"
+         height="15.619044"
+         width="33.142853"
+         id="rect2193"
+         style="fill:url(#linearGradient2422);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17675);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="31.314301"
+         x="542.4762"
+         height="55.619049"
+         width="28.952374"
+         id="rect2195"
+         style="fill:url(#linearGradient2419);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17673);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="171.19998"
+         x="437.33334"
+         height="15.238094"
+         width="91.809525"
+         id="rect4521"
+         style="fill:url(#linearGradient2416);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17671);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+      <rect
+         y="157.10477"
+         x="540.95239"
+         height="29.714285"
+         width="22.095238"
+         id="rect4523"
+         style="fill:url(#linearGradient2413);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17669);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    </g>
+    <g
+       id="b"
+       inkscape:label="#BlackBishop">
+      <rect
+         y="0"
+         x="600"
+         height="200"
+         width="200"
+         id="rect8054-1"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2203"
+         d="m 697.65596,158.07329 c -1.22313,2.44625 -63.60263,33.02444 -63.60263,33.02444 l 51.54461,-6.52334 12.05802,-26.5011 z"
+         style="fill:url(#linearGradient2287);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17667);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient2284);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17665);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 701.12507,158.07329 c 1.22312,2.44625 63.60263,33.02444 63.60263,33.02444 l -54.59223,-6.52334 -9.0104,-26.5011 z"
+         id="path2205" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient2281);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17663);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 675.03331,142.22256 c -1.37551,2.75102 -16.9717,19.31718 -16.9717,19.31718 l 77.78194,5.35345 -19.82495,-32.15336 -40.98529,7.48273 z"
+         id="path2237"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccc"
+         id="path2201"
+         d="m 698.71979,35.63264 c -1.3755,2.75102 -52.66374,115.46237 -52.66374,115.46237 L 752.18681,141.74693 698.71979,35.63264 z m 10.32205,35.74563 8.10502,17.76035 -41.81033,41.4087 c 0,0 32.3298,-56.41804 33.70531,-59.16905 z"
+         style="fill:url(#linearGradient2278);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17661);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path2199"
+         d="m 699.17989,16.75058 c -1.37551,2.75101 -15.65983,26.07067 -15.65983,26.07067 l 32.61761,5.02993 -16.95778,-31.1006 z"
+         style="fill:url(#linearGradient2275);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17659);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="n"
+       inkscape:label="#BlackKnight">
+      <rect
+         y="0"
+         x="800"
+         height="200"
+         width="200"
+         id="rect8054-29"
+         style="fill:none;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssscccccsccssc"
+         id="path4618"
+         d="m 886.00254,20.22922 c -0.38571,26.59625 0.97294,16.55231 -15.81037,4.27446 2.59012,17.34932 0.83202,17.92092 -3.65158,25.3449 -2.45377,4.06296 -4.6162,16.85608 -6.15158,19.67596 -9.30365,17.08709 -30.67072,39.3941 -30.63386,46.66632 0.0467,9.20542 10.99488,17.4454 21.00958,7.71103 -9.36939,13.71566 18.91836,-0.0622 30.77285,-8.52211 15.69174,9.65995 37.61437,-0.9107 38.02187,-16.4317 7.14077,35.10764 -59.5404,41.20523 -63.10231,86.74289 49.69674,11.34467 77.37707,-25.61697 107.66824,2.96523 15.48475,-44.89767 16.91373,-119.94615 -55.07284,-148.08412 -9.78397,-3.82434 -13.89416,-13.66176 -23.05,-20.34286 z m -0.30032,49.52554 c -1.62694,2.30834 -5.04835,6.07614 -8.05031,5.52444 -2.77559,-0.5101 -3.89238,-1.45087 -4.02046,-4.73784 -0.10785,-2.76752 9.69853,-2.67825 12.07077,-0.7866 z"
+         style="fill:url(#linearGradient2513);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17657);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    </g>
+    <g
+       id="p"
+       inkscape:label="#BlackPawn">
+      <rect
+         y="0"
+         x="1000"
+         height="200"
+         width="200"
+         id="rect8054-9"
+         style="fill:none;stroke:none" />
+      <path
+         transform="matrix(0.22857143,0,0,0.22857143,996.95238,0.38095)"
+         d="m 636.66667,605 a 181.66667,185 0 1 1 -363.33334,0 181.66667,185 0 1 1 363.33334,0 z"
+         sodipodi:ry="185"
+         sodipodi:rx="181.66667"
+         sodipodi:cy="605"
+         sodipodi:cx="455"
+         id="path1351"
+         style="opacity:0.98999999;fill:url(#linearGradient2232);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17655);stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         sodipodi:type="arc" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="WhitePieces"
+     inkscape:label="WhitePieces">
+    <g
+       id="K"
+       inkscape:label="#WhiteKing">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17693"
+         width="200"
+         height="200"
+         x="0"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient17743);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17745);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         d="m 92.1156,225.14491 0,13.62857 -17.96428,0 0,15.55 17.96428,0 0,27.99286 14.34286,0 0,-27.99286 21.57857,0 0,-15.55 -21.57857,0 0,-13.62857 -14.34286,0 z"
+         id="path17695"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient17747);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17749);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 116.7685,305.41059 c 45.6543,-24.41897 31.02431,22.10128 8.36721,36.48227 -14.59749,9.26537 -22.22965,-25.69457 -14.48571,-51.95 l -19.56429,0.23571 c 7.21432,23.23396 2.81457,58.938 -13.05714,51.71429 C 49.75695,329.02555 39.24695,281.68205 84.38469,305.43227 58.3013,252.11164 17.67351,272.50058 21.48571,299.6 c 4.14121,29.43815 37.73984,55.92746 37.05715,67.72857 l 84.30714,0 c -1.3507,-13.67309 36.55131,-41.79253 37.76429,-68.52857 1.16426,-26.159 -43.98272,-46.41864 -63.84579,6.61059 z"
+         id="path17697"
+         sodipodi:nodetypes="csccscsccsc"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="fill:url(#linearGradient17751);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17753);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17699"
+         width="109.71429"
+         height="15.238094"
+         x="45.333344"
+         y="373.33334" />
+    </g>
+    <g
+       id="Q"
+       inkscape:label="#WhiteQueen">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17701"
+         width="200"
+         height="200"
+         x="200"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient17755);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17757);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 351.31429,234.26429 c -47.85856,143.39987 -55.2529,143.66612 -97.14286,0.67857 -0.25771,58.27118 7.49175,99.25943 18.72143,123 l 54.41428,0 c 12.30698,-23.85133 21.84012,-65.09315 24.00715,-123.67857 z"
+         id="path17703"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient17759);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17761);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 302.54762,224.48095 c -17.36795,94.11121 -8.84667,194.98248 -82.40714,42.58572 2.51734,46.59316 13.44436,79.60587 32.82142,98.87857 l 91.9,0 c 19.74371,-19.03196 31.7104,-51.53341 36.29286,-97.65 -70.24868,152.42869 -64.15014,50.38385 -78.60714,-43.81429 z"
+         id="path17705"
+         sodipodi:nodetypes="cccccc"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="fill:url(#linearGradient17763);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17765);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17707"
+         width="102.09524"
+         height="14.857148"
+         x="247.3143"
+         y="373.10477" />
+    </g>
+    <g
+       id="R"
+       inkscape:label="#WhiteRook">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17709"
+         width="200"
+         height="200"
+         x="400"
+         y="200" />
+      <rect
+         style="fill:url(#linearGradient17767);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17769);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17711"
+         width="94.476204"
+         height="109.71428"
+         x="454.09525"
+         y="270.55237" />
+      <rect
+         style="fill:url(#linearGradient17771);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17773);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17713"
+         width="35.809528"
+         height="36.952377"
+         x="428.57144"
+         y="240.0762" />
+      <rect
+         style="fill:url(#linearGradient17775);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17777);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17715"
+         width="33.142853"
+         height="15.619044"
+         x="483.04761"
+         y="248.0762" />
+      <rect
+         style="fill:url(#linearGradient17779);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17781);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17717"
+         width="28.952374"
+         height="55.619049"
+         x="542.4762"
+         y="231.3143" />
+      <rect
+         style="fill:url(#linearGradient17783);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17785);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17719"
+         width="91.809525"
+         height="15.238094"
+         x="437.33334"
+         y="371.19998" />
+      <rect
+         style="fill:url(#linearGradient17787);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17789);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="rect17721"
+         width="22.095238"
+         height="29.714285"
+         x="540.95239"
+         y="357.10477" />
+    </g>
+    <g
+       id="B"
+       inkscape:label="#WhiteBishop">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17723"
+         width="200"
+         height="200"
+         x="600"
+         y="200" />
+      <path
+         sodipodi:nodetypes="cccc"
+         style="fill:url(#linearGradient17791);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17793);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 697.65596,358.07329 c -1.22313,2.44625 -63.60263,33.02444 -63.60263,33.02444 l 51.54461,-6.52334 12.05802,-26.5011 z"
+         id="path17725"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path17727"
+         d="m 701.12507,358.07329 c 1.22312,2.44625 63.60263,33.02444 63.60263,33.02444 l -54.59223,-6.52334 -9.0104,-26.5011 z"
+         style="fill:url(#linearGradient17795);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17797);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path17729"
+         d="m 675.03331,342.22256 c -1.37551,2.75102 -16.9717,19.31718 -16.9717,19.31718 l 77.78194,5.35345 -19.82495,-32.15336 -40.98529,7.48273 z"
+         style="fill:url(#linearGradient17799);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17801);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient17803);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17805);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 698.71979,235.63264 c -1.3755,2.75102 -52.66374,115.46237 -52.66374,115.46237 l 106.13076,-9.34808 -53.46702,-106.11429 z m 10.32205,35.74563 8.10502,17.76035 -41.81033,41.4087 c 0,0 32.3298,-56.41804 33.70531,-59.16905 z"
+         id="path17731"
+         sodipodi:nodetypes="cccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient17807);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17809);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 699.17989,216.75058 c -1.37551,2.75101 -15.65983,26.07067 -15.65983,26.07067 l 32.61761,5.02993 -16.95778,-31.1006 z"
+         id="path17733"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="N"
+       inkscape:label="#WhiteKnight">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17735"
+         width="200"
+         height="200"
+         x="800"
+         y="200" />
+      <path
+         style="fill:url(#linearGradient17811);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17813);stroke-width:3.65714288;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="m 886.00254,220.22922 c -0.38571,26.59625 0.97294,16.55231 -15.81037,4.27446 2.59012,17.34932 0.83202,17.92092 -3.65158,25.3449 -2.45377,4.06296 -4.6162,16.85608 -6.15158,19.67596 -9.30365,17.08709 -30.67072,39.3941 -30.63386,46.66632 0.0467,9.20542 10.99488,17.4454 21.00958,7.71103 -9.36939,13.71566 18.91836,-0.0622 30.77285,-8.52211 15.69174,9.65995 37.61437,-0.9107 38.02187,-16.4317 7.14077,35.10764 -59.5404,41.20523 -63.10231,86.74289 49.69674,11.34467 77.37707,-25.61697 107.66824,2.96523 15.48475,-44.89767 16.91373,-119.94615 -55.07284,-148.08412 -9.78397,-3.82434 -13.89416,-13.66176 -23.05,-20.34286 z m -0.30032,49.52554 c -1.62694,2.30834 -5.04835,6.07614 -8.05031,5.52444 -2.77559,-0.5101 -3.89238,-1.45087 -4.02046,-4.73784 -0.10785,-2.76752 9.69853,-2.67825 12.07077,-0.7866 z"
+         id="path17737"
+         sodipodi:nodetypes="ccssscccccsccssc"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="P"
+       inkscape:label="#WhitePawn">
+      <rect
+         style="fill:none;stroke:none"
+         id="rect17739"
+         width="200"
+         height="200"
+         x="1000"
+         y="200" />
+      <path
+         sodipodi:type="arc"
+         style="opacity:0.98999999;fill:url(#linearGradient17815);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient17817);stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         id="path17741"
+         sodipodi:cx="455"
+         sodipodi:cy="605"
+         sodipodi:rx="181.66667"
+         sodipodi:ry="185"
+         d="m 636.66667,605 a 181.66667,185 0 1 1 -363.33334,0 181.66667,185 0 1 1 363.33334,0 z"
+         transform="matrix(0.22857143,0,0,0.22857143,996.95238,200.38095)" />
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/chessboard.qrc
+++ b/projects/gui/res/chessboard/chessboard.qrc
@@ -1,5 +1,13 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource>
 	<file>default.svg</file>
+	<file>MaurizioMonge/celtic.svg</file>
+	<file>MaurizioMonge/eyes.svg</file>
+	<file>MaurizioMonge/fantasy.svg</file>
+	<file>MaurizioMonge/fantasy_alt.svg</file>
+	<file>MaurizioMonge/freak.svg</file>
+	<file>MaurizioMonge/prmi.svg</file>
+	<file>MaurizioMonge/skulls.svg</file>
+	<file>MaurizioMonge/spatial.svg</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This PR includes eight SVG piece sets for standard chess by Maurizio Monge published [here](http://poisson.phc.unipi.it/~monge/chess_art.php). The piece sets are already in use by Wikipedia, Xboard, PyChess and others. I adapted the SVG files to use CuteChess compatible index strings and added license metadata for [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/), which is GPL V3 one-way-compatible.

_Remark to users_: To use the piece set with cutechess GUI one has to wait for a GUI patch for piece selection. 

Adventurous users may try to rename `default.svg `to `default.svg.orig` and copy a new piece set to `default.svg` instead (within directory `projects/gui/res/chessboard`). Then recompile the GUI. The sets only contain the 6 standard piece types, so you will see void squares when trying out Crazyhouse or Capablanca chess, for example.

HTH



![sp1](https://user-images.githubusercontent.com/6425738/32148303-1d1abd42-bcf5-11e7-9646-6b9f8cd1b423.png)
