### PR TITLE
Use better name on interface for Symmetrical Two Kings Each variant

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -97,8 +97,6 @@ Pocket Knight Chess
 Racing Kings Chess
 .It slippedgrid
 Slipped Grid Chess
-.it sortland9
-Symmetrized Wild 9
 .It suicide
 Suicide Chess (Losing Chess Variant)
 .It superandernach
@@ -107,6 +105,8 @@ Super-Andernach Chess
 Three Kings Chess
 .It twokings
 Two Kings Each Chess (Wild 9)
+.it twokingssymmetric
+Symmetrized Wild 9
 .It standard
 Standard Chess (default)
 .El

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -41,11 +41,11 @@ Options:
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
 			'slippedgrid': Slipped Grid Chess
-			'sortland9': Symmetrical Two Kings Each Chess
 			'suicide': Suicide Chess (Losing Chess)
 			'superandernach': Super-Andernach Chess
 			'threekings': Three Kings Chess
 			'twokings': Two Kings Each Chess (Wild 9)
+			'twokingssymmetric': Symmetrical Two Kings Each Chess
 			'standard': Standard Chess (default).
   -concurrency N	Set the maximum number of concurrent games to N
   -draw movenumber=NUMBER movecount=COUNT score=SCORE

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -79,12 +79,12 @@ REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
-REGISTER_BOARD(TwoKingsSymmetricalBoard, "sortland9")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")
 REGISTER_BOARD(SuperAndernachBoard, "superandernach")
 REGISTER_BOARD(ThreeKingsBoard, "threekings")
 REGISTER_BOARD(TwoKingsEachBoard, "twokings")
+REGISTER_BOARD(TwoKingsSymmetricalBoard, "twokingssymmetric")
 
 
 ClassRegistry<Board>* BoardFactory::registry()

--- a/projects/lib/src/board/twokingseachboard.cpp
+++ b/projects/lib/src/board/twokingseachboard.cpp
@@ -190,7 +190,7 @@ Board* TwoKingsSymmetricalBoard::copy() const
 
 QString TwoKingsSymmetricalBoard::variant() const
 {
-	return "sortland9";
+	return "twokingssymmetric";
 }
 
 bool TwoKingsSymmetricalBoard::isSymmetrical() const

--- a/projects/lib/src/board/twokingseachboard.h
+++ b/projects/lib/src/board/twokingseachboard.h
@@ -84,7 +84,7 @@ class LIB_EXPORT TwoKingsEachBoard : public WesternBoard
  * When a side's kings are on the same file the king closer to its own
  * base rank is royal.
  *
- * Symmetry suggested by Jon Åsvang, Norway 2017.
+ * Symmetry suggested by Abdul-Rahman Sibahi in 2007 and Jon Åsvang in 2017.
  *
  * \sa TwoKingsEachBoard
  */

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -854,7 +854,7 @@ void tst_Board::perft_data() const
 		<< 4
 		<< Q_UINT64_C(36828);
 
-	variant = "sortland9";
+	variant = "twokingssymmetric";
 	QTest::newRow("twokings symmetrical variant, startpos")
 		<< variant
 		<< "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1"


### PR DESCRIPTION
#The id `sortland9` for the symmetrical version of _Two Kings Each Chess_ (ICC Wild/9) has been chosen ad-hoc. Recently _Two Kings Each Chess_ (`twokings`) has been added to Multi-Variant [Stockfish](https://github.com/ddugovic/stockfish/) and the symmetrical version will also be included. It was [suggested](https://github.com/ddugovic/stockfish/issues/431) to use `twokingssymmetric`, a more chess-related variant identifier. As far as I know, no third party engines are affected by this change.

This id change would help testing the symmetrical variant in multi-variant Fishtest, too.