### PR TITLE
support Chancellor Chess (9x9) and Modern Chess (9x9)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -53,6 +53,8 @@ Berolina Chess
 Capablanca Chess
 .It caparandom
 Capablanca Random Chess
+.It chancellor
+Chancellor Chess (9x9)
 .It checkless
 Checkless Chess
 .It chessgi
@@ -91,6 +93,8 @@ Knightmate
 Loop Chess (Drop Chess Variant)
 .It losers
 Loser's Chess
+.It modern
+Modern Chess (9x9)
 .It pocketknight
 Pocket Knight Chess
 .It racingkings

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -19,6 +19,7 @@ Options:
 			'berolina': Berolina Chess
 			'capablanca': Capablanca Chess
 			'caparandom': Capablanca Random Chess
+			'chancellor': Chancellor Chess (9x9)
 			'checkless': Checkless Chess
 			'chessgi': Chessgi (Drop Chess)
 			'coregal': Co-regal Chess
@@ -38,6 +39,7 @@ Options:
 			'knightmate': Knightmate
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
+			'modern': Modern Chess (9x9)
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
 			'slippedgrid': Slipped Grid Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -37,6 +37,8 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/loopboard.cpp \
     $$PWD/chessgiboard.cpp \
     $$PWD/pocketknightboard.cpp \
+    $$PWD/chancellorboard.cpp \
+    $$PWD/modernboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -80,6 +82,8 @@ HEADERS += $$PWD/board.h \
     $$PWD/loopboard.h \
     $$PWD/chessgiboard.h \
     $$PWD/pocketknightboard.h \
+    $$PWD/chancellorboard.h \
+    $$PWD/modernboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -22,6 +22,7 @@
 #include "berolinaboard.h"
 #include "capablancaboard.h"
 #include "caparandomboard.h"
+#include "chancellorboard.h"
 #include "checklessboard.h"
 #include "chessgiboard.h"
 #include "coregalboard.h"
@@ -39,6 +40,7 @@
 #include "loopboard.h"
 #include "losersboard.h"
 #include "ncheckboard.h"
+#include "modernboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
 #include "standardboard.h"
@@ -57,6 +59,7 @@ REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
+REGISTER_BOARD(ChancellorBoard, "chancellor")
 REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CoRegalBoard, "coregal")
@@ -76,6 +79,7 @@ REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
+REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")

--- a/projects/lib/src/board/chancellorboard.cpp
+++ b/projects/lib/src/board/chancellorboard.cpp
@@ -1,0 +1,60 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chancellorboard.h"
+
+
+namespace Chess {
+
+ChancellorBoard::ChancellorBoard()
+	: CapablancaBoard()
+{
+}
+
+Board* ChancellorBoard::copy() const
+{
+	return new ChancellorBoard(*this);
+}
+
+QString ChancellorBoard::variant() const
+{
+	return "chancellor";
+}
+
+QString ChancellorBoard::defaultFenString() const
+{
+	return "rnbqkcnbr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQKCNBR w KQkq - 0 1";
+}
+
+int ChancellorBoard::width() const
+{
+	return 9;
+}
+
+int ChancellorBoard::height() const
+{
+	return 9;
+}
+
+int ChancellorBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	// QueenSide denotes lower file side, towards a-rook
+	return castlingSide == QueenSide ? 2 : 6; // c-file and g-file
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/chancellorboard.h
+++ b/projects/lib/src/board/chancellorboard.h
@@ -1,0 +1,60 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHANCELLORBOARD_H
+#define CHANCELLORBOARD_H
+
+#include "capablancaboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Chancellor Chess
+ *
+ * Chancellor Chess is a variant of chess on a 9x9 board. Each side has an
+ * additional Pawn and a Chancellor piece with Rook and Knight movements.
+ * The starting base line is RNBQKCNBR. The king side bishop and knight
+ * traded places so that the bishops of a side operate on squares of different
+ * colours.
+ *
+ * The King moves two squares towards the rook when castling. Pawns may also
+ * promote to Chancellor.
+ *
+ * This variant was introduced in 1887 by Benjamin R. Foster, USA.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Chancellor_Chess
+ *
+ * \sa CapablancaBoard
+ * \sa ModernBoard
+ */
+class LIB_EXPORT ChancellorBoard : public CapablancaBoard
+{
+	public:
+		/*! Creates a new ChancellorBoard object. */
+		ChancellorBoard();
+
+		// Inherited from CapablancaBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual int width() const;
+		virtual int height() const;
+		virtual int castlingFile(CastlingSide castlingSide) const;
+};
+
+} // namespace Chess
+#endif // CHANCELLORBOARD_H

--- a/projects/lib/src/board/modernboard.cpp
+++ b/projects/lib/src/board/modernboard.cpp
@@ -1,0 +1,92 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "modernboard.h"
+
+
+namespace Chess {
+
+ModernBoard::ModernBoard()
+	: CapablancaBoard()
+{
+	// rename Archbishop to Minister to comply notation, but use "A" graphics 
+	setPieceType(Archbishop, tr("minister"), "M",
+		     KnightMovement | BishopMovement, "A");
+}
+
+Board* ModernBoard::copy() const
+{
+	return new ModernBoard(*this);
+}
+
+QString ModernBoard::variant() const
+{
+	return "modern";
+}
+
+QString ModernBoard::defaultFenString() const
+{
+	return "rnbqkmbnr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBMKQBNR w KQkq - 0 1";
+}
+
+int ModernBoard::width() const
+{
+	return 9;
+}
+
+int ModernBoard::height() const
+{
+	return 9;
+}
+
+int ModernBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	// QueenSide denotes lower file side, towards a-rook
+	return castlingSide == QueenSide ? 2 : 6; // c-file and g-file
+}
+
+// Variant's SAN notation for castling moves: O-M-O (left) and O-Q-O (right).
+QString ModernBoard::sanMoveString(const Move& move)
+{
+	QString str = CapablancaBoard::sanMoveString(move);
+
+	if (!str.startsWith("O-O"))
+		return str;
+
+	QString r(str.mid(str.lastIndexOf("O") + 1));
+
+	Side side = pieceAt(move.sourceSquare()).side();
+	if (str.startsWith("O-O-O"))
+		return side == Side::White ? "O-M-O" + r: "O-Q-O" + r;
+	else
+		return side == Side::White ? "O-Q-O" + r: "O-M-O" + r;
+}
+
+// This method accepts Modern Chess notation for castling and also standard chess notation. 
+Move ModernBoard::moveFromSanString(const QString& str)
+{
+	bool isWhite = (sideToMove() == Side::White);
+	if (str.startsWith("O-M-O"))
+		return CapablancaBoard::moveFromSanString(isWhite ? "O-O-O":"O-O");
+	if (str.startsWith("O-Q-O"))
+		return CapablancaBoard::moveFromSanString(isWhite ? "O-O":"O-O-O");
+
+	return CapablancaBoard::moveFromSanString(str);
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/modernboard.h
+++ b/projects/lib/src/board/modernboard.h
@@ -1,0 +1,62 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MODERNBOARD_H
+#define MODERNBOARD_H
+
+#include "capablancaboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Modern chess
+ *
+ * Modern chess is a variant of chess on a 9x9 board. Each side has an
+ * additional Pawn and a Minister piece with Bishop and Knight movements.
+ * At start the Kings have the Queens to their right (f1, d9) and the
+ * Ministers to their left.
+ *
+ * The King moves two squares towards the rook when castling. Pawns may also
+ * promote to Minister.
+ *
+ * This variant was introduced in 1964 (Madrid) by Gabriel Maura, Puerto Rico.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Modern_Chess_(chess_variant)
+ *
+ * \sa CapablancaBoard
+ * \sa ChancellorBoard
+ * TODO: clarify FEN notation
+ */
+class LIB_EXPORT ModernBoard : public CapablancaBoard
+{
+	public:
+		/*! Creates a new ModernBoard object. */
+		ModernBoard();
+
+		// Inherited from CapablancaBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual int width() const;
+		virtual int height() const;
+		virtual int castlingFile(CastlingSide castlingSide) const;
+		virtual QString sanMoveString(const Move& move);
+		virtual Move moveFromSanString(const QString& str);
+};
+
+} // namespace Chess
+#endif // MODERNBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -780,6 +780,20 @@ void tst_Board::perft_data() const
 		<< 5 //4 plies: 139774, 5 plies: 3249033, 6 plies: 74568983
 		<< Q_UINT64_C(3249033);
 
+	variant = "chancellor";
+	QTest::newRow("chancellor startpos")
+		<< variant
+		<< "rnbqkcnbr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQKCNBR w KQkq - 0 1"
+		<< 4 //4 plies: 436656, 5 plies: 13466196, 6 plies: 412625522
+		<< Q_UINT64_C(436656);
+
+	variant = "modern";
+	QTest::newRow("modern startpos")
+		<< variant
+		<< "rnbqkmbnr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBMKQBNR w KQkq - 0 1"
+		<< 4 //4 plies: 433729, 5 plies: 13403293, 6 plies: 411178941
+		<< Q_UINT64_C(433729);
+
 	variant = "pocketknight";
 	QTest::newRow("pocketknight startpos")
 		<< variant


### PR DESCRIPTION
This is a suggestion to support Chancellor Chess and Modern Chess, chess variants for a 9x9 board, also in response to enhancement request #291.

_Chancellor Chess_ was introduced in 1887 by Benjamin R. Foster. Both sides have nine Pawns and a Chancellor (Bishop+Knight) piece starting on the f-file (next to the King). A King moves two squares to either the c-file or the g-file when castling. Pawns may (also) promote to Chancellor when reaching the final rank. 

Default FEN "rnbqkcnbr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQKCNBR w KQkq - 0 1" 
![cha2](https://user-images.githubusercontent.com/6425738/32421594-8c950cae-c29a-11e7-88eb-8c1bbe0addeb.png)


Using position setup via FEN one may e.g. replace Chancellor(s) and use Queen(s) instead in order to play related variants.

FEN "rnbqkqnbr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQKQNBR w KQkq - 0 1"![xm2](https://user-images.githubusercontent.com/6425738/32421600-9d3cf8d2-c29a-11e7-99aa-87b589b261dd.png)

This is close to the requested _Minister_ variant, but a pawn may also promote to Chancellor.

-----
_Modern chess_ is a related variant of chess on a 9x9 board by Gabriel Maura, of Puerto Rico. This game was introduced in 1968, and became popular in the Spanish speaking countries in Central America, South America and Europe. 

Each side has an additional Pawn and a so-called Minister piece with Bishop and Knight movements. When the game begins the Kings have the Queens to their right (f1, d9) and the Ministers to their left.

A King moves two squares towards the rook when castling. Due to the setup, castling moves have special notations as `O-Q-O` (rhs) and `O-M-O` (lhs), respectively. Pawns are given the additional choice to promote to Minister when reaching the final rank.

![mo2](https://user-images.githubusercontent.com/6425738/32692127-c4315164-c712-11e7-8e1c-0ff4e180549b.png)

I hope this is useful.
