### PR TITLE
support Gryphon Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -55,10 +55,14 @@ Capablanca Chess
 Capablanca Random Chess
 .It chancellor
 Chancellor Chess (9x9)
+.It changeover
+Change-Over Chess
 .It checkless
 Checkless Chess
 .It chessgi
 Chessgi / Drop Chess
+.It circulargryphon
+Circular Gryphon Chess
 .It coregal
 Co-regal Chess
 .It crazyhouse
@@ -79,6 +83,8 @@ Gothic Chess
 Grid Chess
 .It gridolina
 Berolina Grid Chess
+.It gryphon
+Gryphon Chess
 .It horde
 Horde Chess (v2)
 .It janus
@@ -99,6 +105,8 @@ Modern Chess (9x9)
 Pocket Knight Chess
 .It racingkings
 Racing Kings Chess
+.It simplifiedgryphon
+Simplified Gryphon Chess
 .It slippedgrid
 Slipped Grid Chess
 .It suicide

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -20,8 +20,10 @@ Options:
 			'capablanca': Capablanca Chess
 			'caparandom': Capablanca Random Chess
 			'chancellor': Chancellor Chess (9x9)
+			'changeover': Change-Over Chess
 			'checkless': Checkless Chess
 			'chessgi': Chessgi (Drop Chess)
+			'circulargryphon': Circular Gryphon Chess
 			'coregal': Co-regal Chess
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'discplacedgrid': Displaced Grid Chess
@@ -32,6 +34,7 @@ Options:
 			'gothic': Gothic Chess
 			'grid': Grid Chess
 			'gridolina': Berolina Grid Chess
+			'gryphon': Gryphon Chess
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
 			'kinglet': Kinglet Chess
@@ -43,6 +46,7 @@ Options:
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
 			'slippedgrid': Slipped Grid Chess
+			'simplifiedgryphon': Simplified Gryphon Chess
 			'suicide': Suicide Chess (Losing Chess)
 			'superandernach': Super-Andernach Chess
 			'threekings': Three Kings Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -12,6 +12,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/capablancaboard.cpp \
     $$PWD/coregalboard.cpp \
     $$PWD/extinctionboard.cpp \
+    $$PWD/gryphonboard.cpp \
     $$PWD/threekingsboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
@@ -57,6 +58,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/capablancaboard.h \
     $$PWD/coregalboard.h \
     $$PWD/extinctionboard.h \
+    $$PWD/gryphonboard.h \
     $$PWD/threekingsboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -33,6 +33,7 @@
 #include "giveawayboard.h"
 #include "gothicboard.h"
 #include "gridboard.h"
+#include "gryphonboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
 #include "kingofthehillboard.h"
@@ -60,8 +61,10 @@ REGISTER_BOARD(BerolinaBoard, "berolina")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(ChancellorBoard, "chancellor")
+REGISTER_BOARD(ChangeOverBoard, "changeover")
 REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
+REGISTER_BOARD(CircularGryphonBoard, "circulargryphon")
 REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
@@ -73,6 +76,7 @@ REGISTER_BOARD(GiveawayBoard, "giveaway")
 REGISTER_BOARD(GothicBoard, "gothic")
 REGISTER_BOARD(GridBoard, "grid")
 REGISTER_BOARD(BerolinaGridBoard, "gridolina")
+REGISTER_BOARD(GryphonBoard, "gryphon")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
@@ -82,6 +86,7 @@ REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")

--- a/projects/lib/src/board/gryphonboard.cpp
+++ b/projects/lib/src/board/gryphonboard.cpp
@@ -1,0 +1,314 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gryphonboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+GryphonBoard::GryphonBoard()
+	: WesternBoard(new WesternZobrist()),
+	  m_start(0),
+	  m_end(120),
+	  m_pieceStack()
+{
+}
+
+Board* GryphonBoard::copy() const
+{
+	return new GryphonBoard(*this);
+}
+
+QString GryphonBoard::variant() const
+{
+	return "gryphon";
+}
+
+QString GryphonBoard::defaultFenString() const
+{
+	return "rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w - - 0 1";
+}
+
+void GryphonBoard::vInitialize()
+{
+	WesternBoard::vInitialize();
+
+	m_start = (width() + 2) * 2;
+	m_end = arraySize() - m_start;
+}
+
+bool GryphonBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings <= 15 && blackKings <= 15;
+}
+
+bool GryphonBoard::inCheck(Side side, int square) const
+{
+	if (square != 0)
+		return WesternBoard::inCheck(side, square);
+
+	const Piece kingPiece(side, King);
+
+	// test whether any king is in check
+	for (int sq = m_start; sq < m_end; sq++)
+	{
+		if (pieceAt(sq) == kingPiece
+		&&  WesternBoard::inCheck(side, sq))
+			return true;
+	}
+	return false;
+}
+
+int GryphonBoard::successorType(int type, bool reversed) const
+{
+	static const QList<int> types = {Pawn, Knight, Bishop, Rook, Queen, King};
+	static const int length = types.length();
+
+	int index = types.indexOf(type);
+	index = reversed ? index - 1 : index + 1;
+	index = qMin( qMax(0, index), length - 1);
+	return types[index];
+}
+
+void GryphonBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	WesternBoard::vMakeMove(move, transition);
+
+	int target = move.targetSquare();
+	Piece piece = pieceAt(target);
+	m_pieceStack.push_back(Piece(piece));
+
+	if (move.promotion() != Piece::NoPiece)
+		  return;
+
+	int srcType = piece.type();
+	int tgtType = successorType(srcType, false);
+
+	if (srcType != tgtType)
+	{
+		piece.setType(tgtType);
+		setSquare(target, piece);
+	}
+}
+
+void GryphonBoard::vUndoMove(const Move& move)
+{
+	int target = move.targetSquare();
+	Piece piece = pieceAt(target);
+	Piece oldpiece = m_pieceStack.pop();
+	Q_ASSERT(oldpiece.side() == piece.side());
+	piece.setType(oldpiece.type());
+	setSquare(target, piece);
+
+	WesternBoard::vUndoMove(move);
+}
+
+bool GryphonBoard::isLegalPosition()
+{
+	if (!WesternBoard::isLegalPosition())
+		return false;
+
+	int count[2][King+1] = {{0, 15, 4, 4, 4, 2, 15},
+				{0, 15, 4, 4, 4, 2, 15}};
+
+	for (int sq = m_start; sq < m_end; sq++)
+	{
+		Piece piece = pieceAt(sq);
+		if (piece.isValid()
+		&&  --count[piece.side()][piece.type()] < 0)
+			// too many pieces of this type
+			return false;
+	}
+
+	return true;
+}
+
+void GryphonBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					 int pieceType,
+					 int square) const
+{
+	// return early if successor of pieceType is already fully occupied
+	Side side = sideToMove();
+	int successor = successorType(pieceType);
+	static const int count[King+1] = {0, 15, 4, 4, 4, 2, 15};
+	int cnt = count[successor];
+
+	for (int sq = m_start; sq < m_end; sq++)
+	{
+		if (pieceAt(sq) == Piece(side, successor) && --cnt < 1)
+			return;
+	}
+
+	WesternBoard::generateMovesForPiece(moves, pieceType, square);
+}
+
+
+
+SimplifiedGryphonBoard::SimplifiedGryphonBoard()
+	: GryphonBoard(),
+	  m_captures {0, 0}
+{
+}
+
+Board* SimplifiedGryphonBoard::copy() const
+{
+	return new SimplifiedGryphonBoard(*this);
+}
+
+QString SimplifiedGryphonBoard::variant() const
+{
+	return "simplifiedgryphon";
+}
+
+QString SimplifiedGryphonBoard::defaultFenString() const
+{
+	return "4k3/pppppppp/8/8/8/8/PPPPPPPP/4K3 w - - 0 1";
+}
+
+void SimplifiedGryphonBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const
+{
+	if (pieceType != King)
+		return GryphonBoard::generateMovesForPiece(moves, pieceType, square);
+
+	QVarLengthArray< Move > newmoves;
+	GryphonBoard::generateMovesForPiece(newmoves, King, square);
+
+	for (const Move move: newmoves)
+	{
+		Square srcSq = chessSquare(move.sourceSquare());
+		Square tgtSq = chessSquare(move.targetSquare());
+		int rrank = tgtSq.rank() - srcSq.rank();
+
+		if (sideToMove() == Side::Black)
+			rrank = -rrank;
+
+		// side without captures must not move king backward or sideways
+		if (m_captures[sideToMove()] > 0 || rrank > 0)
+			moves.append(move);
+	}
+}
+
+void SimplifiedGryphonBoard::vMakeMove(const Move& move,
+				       BoardTransition* transition)
+{
+	if (captureType(move) != Piece::NoPiece)
+		m_captures[sideToMove()]++;
+
+	GryphonBoard::vMakeMove(move, transition);
+}
+
+void SimplifiedGryphonBoard::vUndoMove(const Move& move)
+{
+	GryphonBoard::vUndoMove(move);
+
+	if (captureType(move) != Piece::NoPiece)
+		m_captures[sideToMove()]--;
+}
+
+
+
+CircularGryphonBoard::CircularGryphonBoard()
+	: GryphonBoard()
+{
+}
+
+Board* CircularGryphonBoard::copy() const
+{
+	return new CircularGryphonBoard(*this);
+}
+
+QString CircularGryphonBoard::variant() const
+{
+	return "circulargryphon";
+}
+
+QString CircularGryphonBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+}
+
+bool CircularGryphonBoard::kingsCountAssertion(int whiteKings,
+					       int blackKings) const
+{
+	return WesternBoard::kingsCountAssertion(whiteKings, blackKings);
+}
+
+bool CircularGryphonBoard::inCheck(Side side, int square) const
+{
+	return WesternBoard::inCheck(side, square);
+}
+
+int CircularGryphonBoard::successorType(int type, bool reversed) const
+{
+	static const QList<int> types = {Pawn, Knight, Bishop, Rook, Queen};
+	static const int length = types.length();
+
+	if (type == King)
+		  return King;
+
+	int index = types.indexOf(type);
+	index = reversed ? index - 1 : index + 1;
+	// circular index: prevent underflow and overflow
+	index = (index + length) % length;
+	return types[index];
+}
+
+
+
+ChangeOverBoard::ChangeOverBoard()
+	: CircularGryphonBoard()
+{
+}
+
+Board* ChangeOverBoard::copy() const
+{
+	return new ChangeOverBoard(*this);
+}
+
+QString ChangeOverBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1";
+}
+
+QString ChangeOverBoard::variant() const
+{
+	return "changeover";
+}
+
+int ChangeOverBoard::successorType(int type, bool reversed) const
+{
+	// Change-Over Chess does the changes the other way round
+	return CircularGryphonBoard::successorType(type, !reversed);
+}
+/*
+ * This variant does not have the restriction to two sets of regular pieces.
+ */
+void ChangeOverBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					    int pieceType,
+					    int square) const
+{
+	WesternBoard::generateMovesForPiece(moves, pieceType, square);
+}
+
+bool ChangeOverBoard::isLegalPosition()
+{
+	return WesternBoard::isLegalPosition();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/gryphonboard.h
+++ b/projects/lib/src/board/gryphonboard.h
@@ -1,0 +1,207 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GRYPHONBOARD_H
+#define GRYPHONBOARD_H
+
+#include "westernboard.h"
+#include <QStack>
+
+namespace Chess {
+
+/*!
+ * \brief A board for Gryphon Chess
+ *
+ * Gryphon Chess is also known as Complicacious Chess [Multiple Kings].
+ * Moved pieces (except for Kings) change their type at the end of a
+ * move. A Pawn becomes a Knight, a Knight transforms to a Bishop,
+ * Bishop changes to Rook, Rook to Queen, Queen to King.
+ *
+ * The Kings are omitted from the initial setup. A side must never have
+ * more than four Knights, four Bishops, four Rooks, and two Queens.
+ * There can be fifteen Kings for a side, and giving mate to any King
+ * wins.
+ *
+ * Introduced by Vernon R. Parton, UK, in 1961 and amended in 1974.
+ *
+ * \sa CircularGryphonBoard
+ * \sa SimplifiedGryphonBoard
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/V._R._Parton#Gryphon_Chess
+ */
+class LIB_EXPORT GryphonBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new GryphonBoard object. */
+		GryphonBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual void vInitialize();
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual bool isLegalPosition();
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+
+		/*!
+		 *  Returns new piece type after moving a piece of \a type.
+		 *  For an undo move \a reversed must be set to true, the default
+		 *  value is false.
+		 */
+		virtual int successorType(int type,
+					  bool reversed = false) const;
+
+	private:
+		int m_start;
+		int m_end;
+		QStack<Piece> m_pieceStack;
+};
+
+
+/*!
+ * \brief A board for Simplified Gryphon Chess
+ *
+ * Simplified Gryphon Chess initially has one King and eight Pawns per
+ * side on their ususal positions, and all other pieces are absent.
+ *
+ * The rules are those of Gryphon Chess. However, a side must not move
+ * their King sidewards or backwards until a capture of an opponent
+ * piece has been made.
+ *
+ * Introduced by Vernon R. Parton, UK, in 1961 and modified in 1974.
+ *
+ * \sa GryphonBoard
+ * \sa CircularGryphonBoard
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/V._R._Parton#Gryphon_Chess
+ */
+class LIB_EXPORT SimplifiedGryphonBoard : public GryphonBoard
+{
+	public:
+		/*! Creates a new SimplifiedGryphonBoard object. */
+		SimplifiedGryphonBoard();
+
+		// Inherited from GryphonBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+
+	private:
+		int m_captures[2];
+};
+
+
+/*!
+ * \brief A board for Circular Gryphon Chess
+ *
+ * Circular Gryphon Chess is a single king variant of Gryphon Chess.
+ * Moved pieces (except for Kings) change their type at the end of the
+ * move in a circular path:
+ * A Pawn becomes a Knight, a Knight transforms to a Bishop, Bishop
+ * changes to Rook, Rook to Queen, Queen to Pawn.
+ *
+ * This variant uses a standard setup. A side must never have more
+ * than four Knights, four Bishops, four Rooks, and two Queens.
+ * There is one King per side, and giving mate to the King
+ * wins. To standard chess this variant is closer than Gryphon Chess.
+ *
+ * Introduced by Vernon R. Parton, UK, in 1961 and amended in 1974.
+ *
+ * \sa GryphonBoard
+ * \sa SimplifiedGryphonBoard
+ * \sa ChangeOverBoard
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/V._R._Parton#Gryphon_Chess
+ */
+class LIB_EXPORT CircularGryphonBoard : public GryphonBoard
+{
+	public:
+		/*! Creates a new CircularGryphonBoard object. */
+		CircularGryphonBoard();
+
+		// Inherited from GryphonBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool inCheck(Side side,
+				     int square = 0) const;
+		virtual int successorType(int type,
+					  bool reversed = false) const;
+};
+
+
+
+/*!
+ * \brief A board for Change-Over Chess
+ *
+ * Change-Over Chess was introduced by L. Russel Chauvenet, USA, in 1943.
+ *
+ * Moved pieces (except for Kings) change their type at the end of the
+ * move in a circular path in opposite way to Circular Gryphon Chess.
+ * A Pawn becomes a Queen, a Queen transforms to a Rook, Rook
+ * changes to Bishop, Bishop to Knight, Knight to Pawn.
+ *
+ * This variant uses a standard setup and giving mate to the King wins.
+ * The number of Queens, Rooks, Bishops and Knights are not restricted
+ * in contrast to Circular Gryphon Chess.
+ *
+ * \sa CircularGryphonBoard
+ */
+class LIB_EXPORT ChangeOverBoard : public CircularGryphonBoard
+{
+	public:
+		/*! Creates a new ChangeOverBoard object. */
+		ChangeOverBoard();
+
+		// Inherited from GryphonBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		virtual int successorType(int type,
+					  bool reversed = false) const;
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+		virtual bool isLegalPosition();
+};
+
+} // namespace Chess
+#endif // GRYPHONBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -304,6 +304,11 @@ void tst_Board::moveStrings_data() const
 		<< "Kg1 Be6 Bxe6 Qxe6 Re1 O-O-O"
 		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
 		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
+	QTest::newRow("circular gryphon san")
+		<< "circulargryphon"
+		<< "Qxa7 e3 a5 Kb4 Nc6 Nc4+ Ke7 Ba6 Ng4 h4 Be2"
+		<< "8/R4k2/5n2/8/5n2/2K5/q3P2P/8 b - - 0 1"
+		<< "8/4k3/R1b5/8/1K3n1N/8/4r3/8 w - - 1 6";
 	QTest::newRow("giveaway san1")
 		<< "giveaway"
 		<< "e3"
@@ -518,6 +523,13 @@ void tst_Board::results_data() const
 		<< "8/8/8/8/pk6/KP6/2r5/8 w - - 0 1"
 		<< "1/2-1/2";
 
+	variant = "gryphon";
+
+	QTest::newRow("gryphon black win")
+		<< variant
+		<< "r1b4r/ppp2pp1/3n1b2/1RB1nK1n/2k1K3/5B2/PPPP1PPP/RNB5 w - - 0 1"
+		<< "0-1";
+
 	variant = "twokings";
 
 	QTest::newRow("twokings black win1")
@@ -547,9 +559,9 @@ void tst_Board::perft_data() const
 	QTest::addColumn<QString>("fen");
 	QTest::addColumn<int>("depth");
 	QTest::addColumn<quint64>("nodecount");
-	
+
 	QString variant = "standard";
-	
+
 	QTest::newRow("startpos")
 		<< variant
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
@@ -822,6 +834,32 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[Nn] w KQkq - 0 1"
 		<< 4  // 3 plies: 88617, 4 plies: 3071267, 5 plies: 99614985
 		<< Q_UINT64_C(3071267);
+
+	variant = "gryphon";
+	QTest::newRow("gryphon startpos")
+		<< variant
+		<< "rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQ1BNR w - - 0 1"
+		<< 5 //4 plies: 280477, 5 plies: 6778804, 6 plies: 162243917
+		<< Q_UINT64_C(6778804);
+	QTest::newRow("gryphon middlegame")
+		<< variant
+		<< "r2q2nr/p5pp/1n2rn2/2nB4/5N2/R2R2q1/P2P3P/R2Q3R w - - 0 1"
+		<< 4 //2 plies: 982, 3 plies: 27370, 4 plies: 1014040
+		<< Q_UINT64_C(1014040);
+
+	variant = "circulargryphon";
+	QTest::newRow("circulargryphon startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1"
+		<< 5 //4 plies: 243435, 5 plies: 5766940, 6 plies: 134596721
+		<< Q_UINT64_C(5766940);
+
+	variant = "simplifiedgryphon";
+	QTest::newRow("simplifiedgryphon startpos")
+		<< variant
+		<< "4k3/pppppppp/8/8/8/8/PPPPPPPP/4K3 w - - 0 1"
+		<< 5 //4 plies: 92350, 5 plies: 1993716, 6 plies: 42279298
+		<< Q_UINT64_C(1993716);
 
 	variant = "losers";
 	QTest::newRow("losers startpos")


### PR DESCRIPTION
This PR adds support of _Gryphon Chess_ by Vernon R. Parton, along with three related shape shifter chess variants.

_Gryphon Chess_ is also known as _Complicacious Chess [Multiple Kings]_. This variant was introduced by Vernon R. Parton, UK, in 1961 and amended in 1974.
 
Moved pieces (except for Kings) change their type at the end of a move. A Pawn becomes a Knight, a Knight transforms to a Bishop, Bishop changes to Rook, Rook to Queen, Queen to King. The Kings are omitted from the initial setup. A side must never have more than four Knights, four Bishops, four Rooks, and two Queens. These restrictions were made in order to play the game over the board using two complete sets of chess pieces (i.e. in most of all practical situations).

There can be fifteen Kings for a side, and giving mate to any King wins. So a side does not like to have Kings and avoids to move their Queens.

_Simplified Circular Gryphon Chess_ (by V. R. Parton) is based on the main variant but initially a side only has a King and eight Pawns on their usual squares. As long as a side has not yet captured a piece, their king may only move forwards (diagonally or straight). 

The variant _Circular Gryphon Chess_ (also by V. R. Parton) uses a standard chess set-up and has a circular path of piece transformation: Pawn->Knight->Bishop->Rook->Queen->Pawn. Kings do not change, so this variant is much more similar to standard chess

Finally, the oldest variant is _Change-Over Chess_ by L. Russel Chauvenet, USA 1943.
Here the path of transformation is opposite to that of Circular Gryphon Chess: Pawn->Queen->Rook->Bishop->Knight->Pawn. The numbers of Queens, Rooks, Bishops and Knights are not restricted - in contrast to Circular Gryphon Chess. Standard setup. Giving mate to the King wins.

