### PR TITLE
Support medieval chess: Shatranj and Courier

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -65,6 +65,8 @@ Chessgi / Drop Chess
 Circular Gryphon Chess
 .It coregal
 Co-regal Chess
+.It courier
+Courier Chess (Medieval)
 .It crazyhouse
 Crazyhouse (Drop Chess Variant)
 .It displacedgrid
@@ -105,6 +107,8 @@ Modern Chess (9x9)
 Pocket Knight Chess
 .It racingkings
 Racing Kings Chess
+.It shatranj
+Shatranj
 .It simplifiedgryphon
 Simplified Gryphon Chess
 .It slippedgrid

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -22,6 +22,7 @@ Options:
 			'chancellor': Chancellor Chess (9x9)
 			'changeover': Change-Over Chess
 			'checkless': Checkless Chess
+			'courier': Courier Chess
 			'chessgi': Chessgi (Drop Chess)
 			'circulargryphon': Circular Gryphon Chess
 			'coregal': Co-regal Chess
@@ -45,6 +46,7 @@ Options:
 			'modern': Modern Chess (9x9)
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
+			'shatranj': Shatranj
 			'slippedgrid': Slipped Grid Chess
 			'simplifiedgryphon': Simplified Gryphon Chess
 			'suicide': Suicide Chess (Losing Chess)

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -733,6 +733,8 @@ void Board::generateHoppingMoves(int sourceSquare,
 	for (int i = 0; i < offsets.size(); i++)
 	{
 		int targetSquare = sourceSquare + offsets[i];
+		if (!isValidSquare(chessSquare(targetSquare)))
+			continue;
 		Piece capture = pieceAt(targetSquare);
 		if (capture.isEmpty() || capture.side() == opSide)
 			moves.append(Move(sourceSquare, targetSquare));

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -40,6 +40,8 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/pocketknightboard.cpp \
     $$PWD/chancellorboard.cpp \
     $$PWD/modernboard.cpp \
+    $$PWD/shatranjboard.cpp \
+    $$PWD/courierboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -86,6 +88,8 @@ HEADERS += $$PWD/board.h \
     $$PWD/pocketknightboard.h \
     $$PWD/chancellorboard.h \
     $$PWD/modernboard.h \
+    $$PWD/shatranjboard.h \
+    $$PWD/courierboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -26,6 +26,7 @@
 #include "checklessboard.h"
 #include "chessgiboard.h"
 #include "coregalboard.h"
+#include "courierboard.h"
 #include "crazyhouseboard.h"
 #include "embassyboard.h"
 #include "extinctionboard.h"
@@ -44,6 +45,7 @@
 #include "modernboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
+#include "shatranjboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
 #include "threekingsboard.h"
@@ -66,6 +68,7 @@ REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(CircularGryphonBoard, "circulargryphon")
 REGISTER_BOARD(CoRegalBoard, "coregal")
+REGISTER_BOARD(CourierBoard, "courier")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
 REGISTER_BOARD(EmbassyBoard, "embassy")
@@ -86,6 +89,7 @@ REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(ShatranjBoard, "shatranj")
 REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(StandardBoard, "standard")

--- a/projects/lib/src/board/courierboard.cpp
+++ b/projects/lib/src/board/courierboard.cpp
@@ -1,0 +1,107 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "courierboard.h"
+
+namespace Chess {
+
+CourierBoard::CourierBoard()
+	: ShatranjBoard()
+{
+	// Use Bishop's and Queen's names but set to old movements:
+	// War Elephant (Alfil) and Counselor (Ferz)
+	setPieceType(Bishop, tr("bishop"), "E", AlfilMovement);
+	setPieceType(Queen, tr("queen"), "F", FerzMovement);
+	// Introduce Courier, the modern Bishop piece
+	setPieceType(Courier, tr("courier"), "B", BishopMovement);
+	// Mann moves like King but is no royal piece
+	setPieceType(Mann, tr("mann"), "M", FerzMovement | WazirMovement);
+	// Schleich moves as Wazir
+	setPieceType(Schleich, tr("schleich"), "W", WazirMovement);
+	// King, Rook, Knight and Pawn as in standard chess
+	// but without special moves: pawn double step, en passant and castling
+}
+
+Board* CourierBoard::copy() const
+{
+	return new CourierBoard(*this);
+}
+
+QString CourierBoard::variant() const
+{
+	return "courier";
+}
+
+int CourierBoard::width() const
+{
+	return 12;
+}
+
+/*
+ * Basic starting position:
+ * rnebmkfwbenr/pppppppppppp/12/12/12/12/PPPPPPPPPPPP/RNEBMKFWBENR w - - 0 1
+ * Traditional effective starting position after ceremonial moves of rook and
+ * queen pawns and of the queens all by two squares:
+ * rnebmk1wbenr/1ppppp1pppp1/6f5/p5p4p/P5P4P/6F5/1PPPPP1PPPP1/RNEBMK1WBENR w - - 0 1
+ */
+QString CourierBoard::defaultFenString() const
+{
+	return "rnebmk1wbenr/1ppppp1pppp1/6f5/p5p4p/"
+	"P5P4P/6F5/1PPPPP1PPPP1/RNEBMK1WBENR w - - 0 1";
+}
+
+void CourierBoard::vInitialize()
+{
+	ShatranjBoard::vInitialize();
+
+	m_arwidth = width() + 2;
+
+	m_wazirOffsets.resize(4);
+	m_wazirOffsets[0] = -m_arwidth;
+	m_wazirOffsets[1] = -1;
+	m_wazirOffsets[2] = 1;
+	m_wazirOffsets[3] = m_arwidth;
+}
+
+void CourierBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	Chess::ShatranjBoard::generateMovesForPiece(moves, pieceType, square);
+	if (pieceHasMovement(pieceType, WazirMovement))
+		generateHoppingMoves(square, m_wazirOffsets, moves);
+}
+
+bool CourierBoard::inCheck(Side side, int square) const
+{
+	Piece piece;
+	Side opSide = side.opposite();
+	if (square == 0)
+		square = kingSquare(side);
+
+	// Wazir attacks by Schleich, Mann
+	for (int i = 0; i < m_wazirOffsets.size(); i++)
+	{
+		piece = pieceAt(square + m_wazirOffsets[i]);
+		if (piece.side() == opSide
+		&&  pieceHasMovement(piece.type(), WazirMovement))
+			return true;
+	}
+	return ShatranjBoard::inCheck(side, square);
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/courierboard.h
+++ b/projects/lib/src/board/courierboard.h
@@ -1,0 +1,93 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COURIERBOARD_H
+#define COURIERBOARD_H
+
+#include "shatranjboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Courier Chess
+ *
+ * Courier Chess is a 12x8 board variant that has been popular in medieval
+ * Europe, especially in the countries of the Holy Roman Empire (esp. Germany,
+ * Netherlands) from the 12th to the 18th century alongside Shatranj and
+ * then Chess (influencing the transformation from the former to the latter).
+ *
+ * The Queen and the Bishop in Courier Chess have the old Shatranj movements
+ * of the Ferz (Counselor, one square diagonally) and the Alfil (War Elephant,
+ * leaps two squares diagonally). King, Rook, and Knight have normal moves.
+ * There are additional pieces: Every side has one Mann who moves like a King,
+ * and one Schleich with Wazir movement (one square forward, backward, left
+ * or right). Every side has two Currier or Courier pieces with modern Bishop
+ * movement. Courier Chess has no Pawn double step option and no castling. A
+ * Pawn can only promote to Queen.
+ *
+ * The effective starting position has the white Queen and Rook Pawns on
+ * ranks 4 (introducing ceremonial double steps from rank 2) and the Queen
+ * moves to g4 from g2. The black pieces do mirrorwise.
+ *
+ * A side wins if their opponent cannot make a legal move (mate or stalemate),
+ * or has no pieces left besides their "bare" King. However, a bare King is
+ * given one chance to get level by the next move: Two bare kings is a draw.
+ *
+ * \sa ShatranjBoard
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Courier_chess
+ */
+class LIB_EXPORT CourierBoard : public ShatranjBoard
+{
+	public:
+		/*! Creates a new CourierBoard object. */
+		CourierBoard();
+
+		// Inherited from ShatranjBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Special piece types for Courier variants. */
+		enum CourierPieceType
+		{
+			//!< Currier, Courier (diagonal slider) is modern Bishop
+			Courier = King + 1,
+			//!< Mann moves like King
+			Mann,
+			//!< Schleich moves like Wazir (1 square orthog.)
+			Schleich
+		};
+
+		/*! Movement mask for Wazir moves. (Schleich) */
+		static const unsigned WazirMovement = 64;
+
+		// Inherited from ShatranjBoard
+		virtual void vInitialize();
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+	private:
+		int m_arwidth;
+		QVarLengthArray<int> m_wazirOffsets;
+};
+
+} // namespace Chess
+#endif // COURIERBOARD_H

--- a/projects/lib/src/board/shatranjboard.cpp
+++ b/projects/lib/src/board/shatranjboard.cpp
@@ -1,0 +1,202 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "shatranjboard.h"
+
+namespace Chess {
+
+ShatranjBoard::ShatranjBoard()
+	: StandardBoard()
+{
+	setPieceType(Ferz, tr("ferz"), "Q", FerzMovement, "F");
+	setPieceType(Alfil, tr("alfil"), "B", AlfilMovement, "E");
+}
+
+Board* ShatranjBoard::copy() const
+{
+	return new ShatranjBoard(*this);
+}
+
+QString ShatranjBoard::variant() const
+{
+	return "shatranj";
+}
+
+QString ShatranjBoard::defaultFenString() const
+{
+	return "rnbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBKQBNR w - - 0 1";
+}
+
+bool ShatranjBoard::hasCastling() const
+{
+	return false;
+}
+
+bool ShatranjBoard::pawnHasDoubleStep() const
+{
+	return false;
+}
+
+void ShatranjBoard::vInitialize()
+{
+	StandardBoard::vInitialize();
+
+	m_arwidth = width() + 2;
+
+	m_ferzOffsets.resize(4);
+	m_ferzOffsets[0] = -m_arwidth - 1;
+	m_ferzOffsets[1] = -m_arwidth + 1;
+	m_ferzOffsets[2] = m_arwidth - 1;
+	m_ferzOffsets[3] = m_arwidth + 1;
+
+	m_alfilOffsets.resize(4);
+	m_alfilOffsets[0] = -2 * m_arwidth - 2;
+	m_alfilOffsets[1] = -2 * m_arwidth + 2;
+	m_alfilOffsets[2] = 2 * m_arwidth - 2;
+	m_alfilOffsets[3] = 2 * m_arwidth + 2;
+}
+
+void ShatranjBoard::addPromotions(int sourceSquare,
+				 int targetSquare,
+				 QVarLengthArray<Move>& moves) const
+{
+	moves.append(Move(sourceSquare, targetSquare, Ferz));
+}
+
+void ShatranjBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	Chess::StandardBoard::generateMovesForPiece(moves, pieceType, square);
+	if (pieceHasMovement(pieceType, FerzMovement))
+		generateHoppingMoves(square, m_ferzOffsets, moves);
+	if (pieceHasMovement(pieceType, AlfilMovement))
+		generateHoppingMoves(square, m_alfilOffsets, moves);
+}
+
+bool ShatranjBoard::inCheck(Side side, int square) const
+{
+	Piece piece;
+	Side opSide = side.opposite();
+	if (square == 0)
+		square = kingSquare(side);
+
+	// Ferz attacks
+	for (int i = 0; i < m_ferzOffsets.size(); i++)
+	{
+		piece = pieceAt(square + m_ferzOffsets[i]);
+		if (piece.side() == opSide
+		&&  pieceHasMovement(piece.type(), FerzMovement))
+			return true;
+	}
+	// Alfil attacks
+	for (int i = 0; i < m_alfilOffsets.size(); i++)
+	{
+		int target = square + m_alfilOffsets[i];
+		if (!isValidSquare(chessSquare(target)))
+			continue;
+		piece = pieceAt(target);
+		if (piece.side() == opSide
+		&&  pieceHasMovement(piece.type(), AlfilMovement))
+			return true;
+	}
+	return StandardBoard::inCheck(side, square);
+}
+
+Result ShatranjBoard::result()
+{
+	Side side = sideToMove();
+
+	// mate or stalemate
+	if (!canMove())
+	{
+		Side winner = side.opposite();
+		bool check = inCheck(side);
+		QString str{ tr("%1 %2")
+			     .arg(winner.toString())
+			     .arg(check ? "mates" : "wins by stalemate") };
+		return Result(Result::Win, winner, str);
+	}
+
+	// bare king
+	if (bareKing(side))
+	{
+		if (bareKing(side.opposite()))
+		{
+			QString str{ tr("Both kings bare") };
+			return Result(Result::Draw, Side::NoSide, str);
+		}
+		if (!canBareOpponentKing())
+		{
+			Side winner = side.opposite();
+			QString str{ tr("Bare king") };
+			return Result(Result::Win, winner, str);
+		}
+	}
+	if (bareKing(side.opposite())) //forfeited chance
+	{
+		Side winner = side;
+		QString str{ tr("Bare king") };
+		return Result(Result::Win, winner, str);
+	}
+
+	// 70 moves rule
+	if (reversibleMoveCount() >= 140)
+	{
+		QString str{ tr("Draw by seventy moves rule") };
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+	{
+		QString str{ tr("Draw by 3-fold repetition") };
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	return Result();
+}
+
+bool ShatranjBoard::bareKing(Side side, int count) const
+{
+	for (int i = 0; count < 2 && i < arraySize(); i++)
+	{
+		if (side == pieceAt(i).side())
+			++count;
+	}
+	return count < 2;
+}
+
+bool ShatranjBoard::canBareOpponentKing()
+{
+	Side side = sideToMove();
+	// too many pieces at strong side?
+	if (!bareKing(side.opposite(), -1))
+		return false;
+
+	QVarLengthArray<Move>moves;
+	generateMovesForPiece(moves, King, kingSquare(side));
+	for (const auto &m: moves)
+	{
+		if (captureType(m) != Piece::NoPiece
+		&&  isLegalMove(m))
+			return true;
+	}
+	return false;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/shatranjboard.h
+++ b/projects/lib/src/board/shatranjboard.h
@@ -1,0 +1,107 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHATRANJBOARD_H
+#define SHATRANJBOARD_H
+
+#include "standardboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Shatranj
+ *
+ * Shatranj evolved from the Indian game Chaturanga and is the immediate
+ * ancestor of standard chess.
+ *
+ * This game spread from India to Persia (named Chatrang, Shatrang) and
+ * then to Arabia as Shatranj. Shatranj rules, theory and problems (mansubat)
+ * are well documented. The game had stable rules and was popular for nine
+ * centuries in Arabia (about AD 650-1500). There were Arabian professional
+ * master players, player grades and handicap play.
+ *
+ * Spanish and Italian players changed some rules of the game during the
+ * 15th and 16th century resulting in the much faster modern chess.
+ *
+ * Focussing on the differences to standard chess:
+ *
+ * Instead of the Queen Shatranj has the Ferz (Counselor) which only moves
+ * one square diagonally. There are no Bishops but Alfils (War Elephants),
+ * which leap two squares diagonally. The kings may start either on the d-file
+ * or e-file, facing each other. Shatranj has no pawn double steps and
+ * no castling. A Pawn can only promote to Ferz.
+ *
+ * A side wins if their opponent cannot make a legal move (mate or stalemate),
+ * or has no pieces left besides their "bare" King. However a bare King is
+ * given one chance to get level by the next move: Two bare kings is a draw.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Shatranj
+ */
+class LIB_EXPORT ShatranjBoard : public StandardBoard
+{
+	public:
+		/*! Creates a new ShatranjBoard object. */
+		ShatranjBoard();
+
+		// Inherited from StandardBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		/*! Special piece types for Shatranj variants. */
+		enum ShatranjPieceType
+		{
+			//!< Ferz (leaps 1 square diag.) overrides Queen
+			Ferz = Queen,
+			//!< Alfil (leaps 2 squares diag.) overrides Bishop
+			Alfil = Bishop
+		};
+
+		/*! Movement mask for Ferz moves. */
+		static const unsigned FerzMovement = 16;
+		/*! Movement mask for Alfil moves. */
+		static const unsigned AlfilMovement = 32;
+
+		// Inherited from StandardBoard
+		virtual bool hasCastling() const;
+		virtual bool pawnHasDoubleStep() const;
+		virtual void vInitialize();
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+
+		/*!
+		 * Returns true if the side to move can bare the opponent king with this move
+		 * and the rules allow a counter bare king move else false.
+		 */
+		virtual bool canBareOpponentKing();
+	private:
+		int m_arwidth;
+		QVarLengthArray<int> m_ferzOffsets;
+		QVarLengthArray<int> m_alfilOffsets;
+		int pieceCount(Side side) const;
+		bool bareKing(Side side, int count = 0) const;
+};
+
+} // namespace Chess
+#endif // SHATRANJBOARD_H

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -117,6 +117,24 @@ class LIB_EXPORT WesternBoard : public Board
 		 */
 		virtual bool kingCanCapture() const;
 		/*!
+		* Returns true if castling is allowed.
+		* The default value is true.
+		* \sa ShatranjBoard
+		*/
+		virtual bool hasCastling() const;
+		/*!
+		 * Returns true if pawns have an initial double step option.
+		 * The default value is true.
+		 * \sa ShatranjBoard
+		 */
+		virtual bool pawnHasDoubleStep() const;
+		/*!
+		 * Returns true if a pawn can be captured en passant after
+		 * an initial double step.
+		 * The default value is the value of pawnHasDoubleStep().
+		 */
+		virtual bool hasEnPassantCaptures() const;
+		/*!
 		 * Adds pawn promotions to a move list.
 		 *
 		 * This function is called when a pawn can promote by
@@ -229,6 +247,9 @@ class LIB_EXPORT WesternBoard : public Board
 		int m_enpassantTarget;
 		int m_reversibleMoveCount;
 		bool m_kingCanCapture;
+		bool m_hasCastling;
+		bool m_pawnHasDoubleStep;
+		bool m_hasEnPassantCaptures;
 		bool m_pawnAmbiguous;
 		QVector<MoveData> m_history;
 		CastlingRights m_castlingRights;

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -579,6 +579,68 @@ void tst_Board::results_data() const
 		<< variant
 		<< "8/8/8/8/2k5/4kK2/5K2/2q5 w - - 0 1"
 		<< "0-1";
+
+	variant = "shatranj";
+
+	QTest::newRow("shatranj ongoing bk bare")
+		<< variant
+		<< "8/4k3/5R2/8/4K3/8/8/8 b - - 0 1"
+		<< "*";
+	QTest::newRow("shatranj white win bk bare1")
+		<< variant
+		<< "8/4k3/5R2/8/4K3/8/8/8 w - - 0 1"
+		<< "1-0";
+	QTest::newRow("shatranj draw both kings bare")
+		<< variant
+		<< "8/8/5k2/8/4K3/8/8/8 w - - 0 1"
+		<< "1/2-1/2";
+	QTest::newRow("shatranj white win bk bare2")
+		<< variant
+		<< "8/3k4/5R2/8/4K3/8/8/8 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("shatranj white win bk bare3")
+		<< variant
+		<< "8/4k3/5R2/8/4K3/2P5/8/8 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("shatranj black win wk bare1")
+		<< variant
+		<< "8/8/7k/8/2K5/8/2q5/8 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("shatranj black win wk bare2")
+		<< variant
+		<< "8/8/7k/8/2K5/2q5/8/4q3 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("shatranj white mates")
+		<< variant
+		<< "r3k3/2PB1RN1/1n4P1/4PK2/1p3p2/1P6/Pp3P2/8 b - - 0 1"
+		<< "1-0";
+	QTest::newRow("shatranj black mates")
+		<< variant
+		<< "7r/8/4bkqK/8/8/8/7R/8 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("shatranj white king stalemated")
+		<< variant
+		<< "8/8/5kqK/8/8/8/8/8 w - - 0 1"
+		<< "0-1";
+	QTest::newRow("shatranj black king stalemated")
+		<< variant
+		<< "8/8/8/8/8/8/5KQk/8 b - - 0 1"
+		<< "1-0";
+
+	variant = "courier";
+
+	QTest::newRow("courier ongoing bk bare")
+		<< variant
+		<< "12/4k7/5W6/12/4K7/12/12/12 b - - 0 1"
+		<< "*";
+	QTest::newRow("courier white win bk bare1")
+		<< variant
+		<< "12/4k7/5W6/12/4K7/12/12/12 w - - 0 1"
+		<< "1-0";
+	QTest::newRow("courier white win bk bare2")
+		<< variant
+		<< "12/4k7/5W6/12/4K7/11E/12/12 b - - 0 1"
+		<< "1-0";
 }
 
 void tst_Board::results()
@@ -961,6 +1023,25 @@ void tst_Board::perft_data() const
 		<< "knbqkbnk/pppppppp/8/8/8/8/PPPPPPPP/KNBQKBNK w - - 0 1"
 		<< 5 // 4 plies: 199514, 5 plies: 4971357, 6 plies: 123493813
 		<< Q_UINT64_C(4971357);
+
+	variant = "shatranj";
+	QTest::newRow("shatranj startpos")
+		<< variant
+		<< "rnbkqbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBKQBNR w - - 0 1"
+		<< 5 // 4 plies: 68122, 5 plies: 1164248, 6 plies: 19864709
+		<< Q_UINT64_C(1164248);
+
+	variant = "courier";
+	QTest::newRow("courier startpos")
+		<< variant
+		<< "rnebmkfwbenr/pppppppppppp/12/12/12/12/PPPPPPPPPPPP/RNEBMKFWBENR w - - 0 1"
+		<< 5 // 4 plies: 180571, 5 plies: 4139349, 6 plies: 94789147
+		<< Q_UINT64_C(4139349);
+	QTest::newRow("courier traditional")
+		<< variant
+		<< "rnebmk1wbenr/1ppppp1pppp1/6f5/p5p4p/P5P4P/6F5/1PPPPP1PPPP1/RNEBMK1WBENR w - - 0 1"
+		<< 4 // 4 plies: 500337, 5 plies: 14144849, 6 plies: 400324148
+		<< Q_UINT64_C(500337);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
#This patch provides support of the medieval games _Shatranj_ and _Courierspiel_.

_Shatranj_ is a descendant of the old Indian game _Chaturanga_ and the predecessor of modern Chess. It spread from Persia via Turkey and Arab countries to Europe and was popular for almost a millenium. This game is slower than chess, There is no powerful Queen, but a Counselor (Ferz), who can only move one square diagonally. There no sliding Bishop, but a hopping Elephant (Alfil), which only can hop two squares diagonally. There are no Pawn double steps, and no castling moves. Giving mate or stalemate to the opponent King wins. Stripping the King of all his men also wins, if the opponent King does not immediately retaliate.

_Courierspiel_ is a game derived from Shatranj and was played in Central Europe alongside Shatranj or later Chess from the12th to 18th century.  It adds piece types Courier, Mann, and Schleich, redefines piece symbols and sets up a wide 12x8 board. The Courier piece already had the modern Bishop movement. Apart from this the game has the traditional rules of Shatranj.

The implementation `CourierBoard` is based on `ShatranjBoard`. `ShatranjBoard` switches off the modern rules in `WesternBoard`.  The patch was tested with Sjaak II 1.3.1a,  and 1.4.1 and with Fairy-Max / Shamax versions 4.8Q and  5.0b. Files were also transferred from and to xboard version 4.9.1. The perft tests of the cutechess variants match the Sjaak II results.

Updates: 
+ The brand new [Stockfish for Shatranj](https://github.com/ianfab/Shatranj-Stockfish/) seems to work fine with this package now.
+ I recently added testcases for stalemate and bare king rules.
+ Range overflow prevention for hopping moves and checks by Alfil 
+ Replaced fifty moves rule by a seventy moves rule adjudication.
+ Support of non standard, shortened FEN but only for variants without castling and en passant. This establishes read compatibilty with Xboard and shatranj engine output.

TODO: -


  