### PR TITLE
Maintainance for ModernBoard and ChancellorBoard

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -117,7 +117,7 @@ Super-Andernach Chess
 Three Kings Chess
 .It twokings
 Two Kings Each Chess (Wild 9)
-.it twokingssymmetric
+.It twokingssymmetric
 Symmetrized Wild 9
 .It standard
 Standard Chess (default)

--- a/projects/lib/src/board/chancellorboard.cpp
+++ b/projects/lib/src/board/chancellorboard.cpp
@@ -16,13 +16,15 @@
 */
 
 #include "chancellorboard.h"
+#include "westernzobrist.h"
 
 
 namespace Chess {
 
 ChancellorBoard::ChancellorBoard()
-	: CapablancaBoard()
+	: WesternBoard(new WesternZobrist())
 {
+	setPieceType(Chancellor, tr("chancellor"), "C", KnightMovement | RookMovement);
 }
 
 Board* ChancellorBoard::copy() const
@@ -55,6 +57,12 @@ int ChancellorBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
 	Q_ASSERT(castlingSide != NoCastlingSide);
 	// QueenSide denotes lower file side, towards a-rook
 	return castlingSide == QueenSide ? 2 : 6; // c-file and g-file
+}
+
+void ChancellorBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+	moves.append(Move(sourceSquare, targetSquare, Chancellor));
 }
 
 } // namespace Chess

--- a/projects/lib/src/board/chancellorboard.h
+++ b/projects/lib/src/board/chancellorboard.h
@@ -18,7 +18,7 @@
 #ifndef CHANCELLORBOARD_H
 #define CHANCELLORBOARD_H
 
-#include "capablancaboard.h"
+#include "westernboard.h"
 
 namespace Chess {
 
@@ -41,19 +41,28 @@ namespace Chess {
  * \sa CapablancaBoard
  * \sa ModernBoard
  */
-class LIB_EXPORT ChancellorBoard : public CapablancaBoard
+class LIB_EXPORT ChancellorBoard : public WesternBoard
 {
 	public:
 		/*! Creates a new ChancellorBoard object. */
 		ChancellorBoard();
 
-		// Inherited from CapablancaBoard
+		// Inherited from WesternBoard
 		virtual Board* copy() const;
 		virtual QString variant() const;
 		virtual QString defaultFenString() const;
 		virtual int width() const;
 		virtual int height() const;
+	protected:
+		enum ChancellorPieceType
+		{
+			Chancellor = 8 //!< Chancellor (knight + rook)
+		};
+		// Inherited from WesternBoard
 		virtual int castlingFile(CastlingSide castlingSide) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
 };
 
 } // namespace Chess

--- a/projects/lib/src/board/modernboard.cpp
+++ b/projects/lib/src/board/modernboard.cpp
@@ -16,15 +16,15 @@
 */
 
 #include "modernboard.h"
-
+#include "westernzobrist.h"
 
 namespace Chess {
 
 ModernBoard::ModernBoard()
-	: CapablancaBoard()
+	: WesternBoard(new WesternZobrist())
 {
-	// rename Archbishop to Minister to comply notation, but use "A" graphics 
-	setPieceType(Archbishop, tr("minister"), "M",
+	// Use Minister "M" symbol for notation and Archbishop graphics
+	setPieceType(Minister, tr("minister"), "M",
 		     KnightMovement | BishopMovement, "A");
 }
 
@@ -60,10 +60,17 @@ int ModernBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
 	return castlingSide == QueenSide ? 2 : 6; // c-file and g-file
 }
 
+void ModernBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+	moves.append(Move(sourceSquare, targetSquare, Minister));
+}
+
+
 // Variant's SAN notation for castling moves: O-M-O (left) and O-Q-O (right).
 QString ModernBoard::sanMoveString(const Move& move)
 {
-	QString str = CapablancaBoard::sanMoveString(move);
+	QString str = WesternBoard::sanMoveString(move);
 
 	if (!str.startsWith("O-O"))
 		return str;
@@ -82,11 +89,11 @@ Move ModernBoard::moveFromSanString(const QString& str)
 {
 	bool isWhite = (sideToMove() == Side::White);
 	if (str.startsWith("O-M-O"))
-		return CapablancaBoard::moveFromSanString(isWhite ? "O-O-O":"O-O");
+		return WesternBoard::moveFromSanString(isWhite ? "O-O-O":"O-O");
 	if (str.startsWith("O-Q-O"))
-		return CapablancaBoard::moveFromSanString(isWhite ? "O-O":"O-O-O");
+		return WesternBoard::moveFromSanString(isWhite ? "O-O":"O-O-O");
 
-	return CapablancaBoard::moveFromSanString(str);
+	return WesternBoard::moveFromSanString(str);
 }
 
 } // namespace Chess

--- a/projects/lib/src/board/modernboard.h
+++ b/projects/lib/src/board/modernboard.h
@@ -18,7 +18,7 @@
 #ifndef MODERNBOARD_H
 #define MODERNBOARD_H
 
-#include "capablancaboard.h"
+#include "westernboard.h"
 
 namespace Chess {
 
@@ -36,26 +36,36 @@ namespace Chess {
  * This variant was introduced in 1964 (Madrid) by Gabriel Maura, Puerto Rico.
  *
  * \note Rules: https://en.wikipedia.org/wiki/Modern_Chess_(chess_variant)
+ * This board implements the rules of 1964 and does not support Bishop
+ * adjustment moves.
  *
  * \sa CapablancaBoard
  * \sa ChancellorBoard
- * TODO: clarify FEN notation
  */
-class LIB_EXPORT ModernBoard : public CapablancaBoard
+class LIB_EXPORT ModernBoard : public WesternBoard
 {
 	public:
 		/*! Creates a new ModernBoard object. */
 		ModernBoard();
 
-		// Inherited from CapablancaBoard
+		// Inherited from WesternBoard
 		virtual Board* copy() const;
 		virtual QString variant() const;
 		virtual QString defaultFenString() const;
 		virtual int width() const;
 		virtual int height() const;
-		virtual int castlingFile(CastlingSide castlingSide) const;
 		virtual QString sanMoveString(const Move& move);
 		virtual Move moveFromSanString(const QString& str);
+	protected:
+		enum ModernChessPieceType
+		{
+			Minister = 7 //!< Minister = Archbishop (knight + bishop)
+		};
+		// Inherited from WesternBoard
+		virtual int castlingFile(CastlingSide castlingSide) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
 };
 
 } // namespace Chess

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -304,6 +304,31 @@ void tst_Board::moveStrings_data() const
 		<< "Kg1 Be6 Bxe6 Qxe6 Re1 O-O-O"
 		<< "r1b1kbmr/pmp2ppp/1p1p1q2/4p3/2B1P3/1P6/P1PPMPPP/RMBQK2R w KQkq - 0 1"
 		<< "2kr1bmr/pmp2ppp/1p1pq3/4p3/4P3/1P6/P1PPMPPP/RMBQR1K1 w - - 0 4";
+	QTest::newRow("chancellor castling san")
+		<< "chancellor"
+		<< "O-O O-O-O"
+		<< "r3k3r/ppp3ppp/9/9/9/9/9/PPP3PPP/R3K3R w KQkq - 0 1"
+		<< "2kr4r/ppp3ppp/9/9/9/9/9/PPP3PPP/R4RK2 w - - 0 2";
+	QTest::newRow("chancellor castling lan")
+		<< "chancellor"
+		<< "e1g1 e9c9"
+		<< "r3k3r/ppp3ppp/9/9/9/9/9/PPP3PPP/R3K3R w KQkq - 0 1"
+		<< "2kr4r/ppp3ppp/9/9/9/9/9/PPP3PPP/R4RK2 w - - 0 2";
+	QTest::newRow("modern castling san1")
+		<< "modern"
+		<< "O-Q-O O-M-O"
+		<< "r1bqk3r/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B1K3R w KQkq - 0 1"
+		<< "r1bq1rk2/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B2RK2 w - - 0 2";
+	QTest::newRow("modern castling san2")
+		<< "modern"
+		<< "O-O O-O"
+		<< "r1bqk3r/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B1K3R w KQkq - 0 1"
+		<< "r1bq1rk2/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B2RK2 w - - 0 2";
+	QTest::newRow("modern castling lan")
+		<< "modern"
+		<< "e1g1 e9g9"
+		<< "r1bqk3r/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B1K3R w KQkq - 0 1"
+		<< "r1bq1rk2/ppp3ppp/2n3n2/2mbpp3/3p5/3B1P3/P1NQPMN2/1PPP2PPP/R1B2RK2 w - - 0 2";
 	QTest::newRow("circular gryphon san")
 		<< "circulargryphon"
 		<< "Qxa7 e3 a5 Kb4 Nc6 Nc4+ Ke7 Ba6 Ng4 h4 Be2"
@@ -834,6 +859,11 @@ void tst_Board::perft_data() const
 		<< "rnbqkcnbr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBQKCNBR w KQkq - 0 1"
 		<< 4 // 4 plies: 436656, 5 plies: 13466196, 6 plies: 412625522
 		<< Q_UINT64_C(436656);
+	QTest::newRow("chancellor promotion")
+		<< variant
+		<< "4k4/1P7/K8/9/9/9/9/9/9 w - - 0 1"
+		<< 2
+		<< Q_UINT64_C(37);
 
 	variant = "modern";
 	QTest::newRow("modern startpos")
@@ -841,6 +871,11 @@ void tst_Board::perft_data() const
 		<< "rnbqkmbnr/ppppppppp/9/9/9/9/9/PPPPPPPPP/RNBMKQBNR w KQkq - 0 1"
 		<< 4 // 4 plies: 433729, 5 plies: 13403293, 6 plies: 411178941
 		<< Q_UINT64_C(433729);
+	QTest::newRow("modern promotion")
+		<< variant
+		<< "4k4/1P7/K8/9/9/9/9/9/9 w - - 0 1"
+		<< 2
+		<< Q_UINT64_C(39);
 
 	variant = "pocketknight";
 	QTest::newRow("pocketknight startpos")


### PR DESCRIPTION
The proposed changes prevent both setup of and promotion to wrong piece types. Currently a Pawn can promote to Archbishop in _Chancellor Chess_ and to Chancellor in _Modern Chess_. These are illegal conversions.

`ModernBoard` and `ChancellorBoard` are now derived from `WesternBoard` instead of `CapablancaBoard`.

This patch also adds test cases for castling and promotion.
While there I made a small fix in the manual page.
