### PR TITLE
This patch adds the Variant tag to the minimal PGN output.

### DIFF
--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -279,6 +279,12 @@ bool PgnGame::write(QTextStream& out, PgnMode mode) const
 		writeTag(out, "SetUp", m_tags["SetUp"]);
 	}
 
+	if (mode == Minimal && m_tags.contains("Variant")
+	&&  variant() != "standard")
+	{
+		writeTag(out, "Variant", m_tags["Variant"]);
+	}
+
 	QString str;
 	int lineLength = 0;
 	int movenum = 0;


### PR DESCRIPTION
Fixes issue #328.