### PR TITLE
Resolve problems when importing PGN data containing capital Variant tag values

### DIFF
--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -391,7 +391,7 @@ QString PgnGame::variant() const
 {
 	if (m_tags.contains("Variant"))
 	{
-		QString variant(m_tags.value("Variant"));
+		QString variant(m_tags.value("Variant").toLower());
 		if ("chess" != variant && "normal" != variant)
 			return variant;
 	}


### PR DESCRIPTION
like "Antichess" into the game database.

The GUI crashes with segmentation fault when importing a PGN game with some Capital letters in its Variant tag. This only occurs when the "Variant" tag matches a supported variant in lower case.

This patch supports the work done on #121. 