### PR TITLE
support Seirawan Chess (a.k.a. S-Chess)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -107,6 +107,8 @@ Modern Chess (9x9)
 Pocket Knight Chess
 .It racingkings
 Racing Kings Chess
+.It seirawan
+S-Chess (Seirawan Chess)
 .It shatranj
 Shatranj
 .It simplifiedgryphon

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -46,6 +46,7 @@ Options:
 			'modern': Modern Chess (9x9)
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
+			'seirawan': S-Chess (Seirawan Chess)
 			'shatranj': Shatranj
 			'slippedgrid': Slipped Grid Chess
 			'simplifiedgryphon': Simplified Gryphon Chess

--- a/projects/gui/src/boardview/piecechooser.cpp
+++ b/projects/gui/src/boardview/piecechooser.cpp
@@ -15,7 +15,8 @@ PieceChooser::PieceChooser(const QList<GraphicsPiece*>& pieces,
 	  m_anim(nullptr)
 {
 	for (auto piece : pieces)
-		m_pieces[piece->pieceType().side()] << piece;
+		if (piece != nullptr)
+			m_pieces[piece->pieceType().side()] << piece;
 
 	int columns = qMax(m_pieces[0].size(), m_pieces[1].size());
 	int rows = (!m_pieces[0].isEmpty() && !m_pieces[1].isEmpty()) ? 2 : 1;

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -81,6 +81,11 @@ bool Board::variantHasDrops() const
 	return false;
 }
 
+bool Board::variantHasOptionalPromotions() const
+{
+	return false;
+}
+
 QList<Piece> Board::reservePieceTypes() const
 {
 	return QList<Piece>();

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -128,6 +128,15 @@ class LIB_EXPORT Board
 		 */
 		virtual bool variantHasDrops() const;
 		/*!
+		 * Returns true if the variant allows to skip a promotion (or a
+		 * move treated as promotion) and make a normal move instead.
+		 * The default value is false, i.e. mandatory promotions.
+		 *
+		 * \sa GrandBoard
+		 * \sa SeirawanBoard
+		 */
+		virtual bool variantHasOptionalPromotions() const;
+		/*!
 		 * Returns a list of piece types that can be in the reserve,
 		 * ie. captured pieces that can be dropped on the board.
 		 *

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -19,6 +19,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/embassyboard.cpp \
     $$PWD/janusboard.cpp \
     $$PWD/knightmateboard.cpp \
+    $$PWD/seirawanboard.cpp \
     $$PWD/twokingseachboard.cpp \
     $$PWD/zobrist.cpp \
     $$PWD/westernzobrist.cpp \
@@ -67,6 +68,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/embassyboard.h \
     $$PWD/janusboard.h \
     $$PWD/knightmateboard.h \
+    $$PWD/seirawanboard.h \
     $$PWD/twokingseachboard.h \
     $$PWD/zobrist.h \
     $$PWD/westernzobrist.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -45,6 +45,7 @@
 #include "modernboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
+#include "seirawanboard.h"
 #include "shatranjboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
@@ -89,6 +90,7 @@ REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(SeirawanBoard, "seirawan")
 REGISTER_BOARD(ShatranjBoard, "shatranj")
 REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")

--- a/projects/lib/src/board/seirawanboard.cpp
+++ b/projects/lib/src/board/seirawanboard.cpp
@@ -1,0 +1,438 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "seirawanboard.h"
+#include "westernzobrist.h"
+#include "boardtransition.h"
+
+namespace Chess {
+
+SeirawanBoard::SeirawanBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Hawk, tr("hawk"), "H", KnightMovement | BishopMovement, "A");
+	setPieceType(Elephant, tr("elephant"), "E", KnightMovement | RookMovement, "C");
+
+	// following "virtual" piece types are only used for castling/channeling disambiguation
+	setPieceType(rookSquareChanneling(Hawk, forward), tr("auxhawk"), "X", 0, "A");
+	setPieceType(rookSquareChanneling(Elephant, forward), tr("auxelephant"), "Y", 0, "C");
+}
+
+Board* SeirawanBoard::copy() const
+{
+	return new SeirawanBoard(*this);
+}
+
+QString SeirawanBoard::variant() const
+{
+	return "seirawan";
+}
+
+QString SeirawanBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w BCDFGbcdfgKQkq - 0 1";
+}
+
+int SeirawanBoard::rookSquareChanneling(int promotion, direction d = forward)
+{
+	return d == forward ? promotion + 8 : promotion - 8;
+}
+
+bool SeirawanBoard::variantHasDrops() const
+{
+	return true;
+}
+
+bool SeirawanBoard::variantHasChanneling(Side side, int square) const
+{
+	int rank = chessSquare(square).rank();
+	int baserank = (side == Side::White) ? 0 : height() -1 ;
+	return  rank == baserank && !side.isNull();
+}
+
+bool SeirawanBoard::variantHasOptionalPromotions() const
+{
+	return true;
+}
+
+QList<Piece> SeirawanBoard::reservePieceTypes() const
+{
+	QList<Piece> list;
+
+	for (int i = 0; i < 2; i++)
+	{
+		list << Piece(Side::Type(i), Hawk);
+		list << Piece(Side::Type(i), Elephant);
+	}
+
+	return list;
+}
+
+void SeirawanBoard::addPromotions(int sourceSquare,
+				  int targetSquare,
+				  QVarLengthArray<Move>& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+
+	moves.append(Move(sourceSquare, targetSquare, Hawk));
+	moves.append(Move(sourceSquare, targetSquare, Elephant));
+}
+
+bool SeirawanBoard::vSetFenString(const QStringList& fen)
+{
+	m_squareMap.clear();
+	return WesternBoard::vSetFenString(fen);
+}
+
+void SeirawanBoard::insertIntoSquareMap(int square, int count)
+{
+	m_squareMap.insert(square, count);
+}
+
+void SeirawanBoard::updateSquareMap(const Move& move, int increment)
+{
+	int source = move.sourceSquare();
+	if (m_squareMap.contains(source))
+		m_squareMap[source] += increment;
+
+	int target = move.targetSquare();
+	if (m_squareMap.contains(target))
+		m_squareMap[target] += increment;
+}
+
+bool SeirawanBoard::parseCastlingRights(QChar c)
+{
+	Side side = (c.isUpper()) ? upperCaseSide() : upperCaseSide().opposite();
+	QChar ch = c.toLower();
+	QString rank = side == Side::White ? "1" : QString::number(height());
+
+	if (ch >= 'a' && ch <= 'h')
+	{
+		insertIntoSquareMap(squareIndex(ch + rank));
+		return true;
+	}
+	if (ch == 'k')
+	{
+		insertIntoSquareMap(kingSquare(side));
+		insertIntoSquareMap(squareIndex("h" + rank));
+	}
+	if (ch == 'q')
+	{
+		insertIntoSquareMap(kingSquare(side));
+		insertIntoSquareMap(squareIndex("a" + rank));
+	}
+	return WesternBoard::parseCastlingRights(c);
+}
+
+QString SeirawanBoard::vFenString(Board::FenNotation notation) const
+{
+	QString vfs = Chess::WesternBoard::vFenString(notation);
+	int reservePieceCount[2] = {0, 0};
+
+	const QList<Piece>& reserveTypes = reservePieceTypes();
+	for (const Piece& pc: reserveTypes)
+		reservePieceCount[pc.side()] += reserveCount(pc);
+
+	// prepend castling field with list of files usable for piece channeling
+	QString s;
+
+	for (int i: m_squareMap.keys())
+	{
+		if (m_squareMap[i] > 0)
+			continue;
+
+		Piece piece = pieceAt(i);
+		Side side = piece.side();
+		if (!variantHasChanneling(side, i))
+		{
+			qWarning() << "channeling map mismatch for square "
+				   << i << ": " << squareString(i);
+			continue;
+		}
+		// do not list channeling files if there are no reserve pieces
+		if (reservePieceCount[side] <= 0)
+			continue;
+
+		if (side == upperCaseSide())
+			s.append(squareString(i).mid(0,1).toUpper());
+		else
+			s.append(squareString(i).mid(0,1).toLower());
+	}
+
+	QStringList vfen = vfs.split(' ', QString::SkipEmptyParts);
+
+	if ((!vfen.isEmpty() && vfen.at(0)!= "-") || s.isEmpty())
+		s.append(vfen.at(0));
+
+	// remove redundant files which are also included in castling rights
+	struct castlingfiles {QChar castling; QChar kingfile; QChar rookfile;};
+	const castlingfiles files[4]{{'K','E','H'},{'Q','E','A'},{'k','e','h'},{'q','e','a'}};
+
+	for (const auto& token: files)
+		if (s.contains(token.castling))
+		{
+			s.remove(token.kingfile);
+			s.remove(token.rookfile);
+		}
+
+	// append the rest of the FEN string
+	for (int i = 1; i < vfen.count(); i++)
+		s.append(" ").append(vfen.at(i));
+
+	return s;
+}
+
+/*
+ * This method uses algebraic notation (LAN) of standard chess. In addition
+ * channeling moves are respresented as moves with promotions, e.g. b1c3h
+ * inserts a Hawk at the vacated square b1. Castling with channeling onto King
+ * square is coded likewise, e.g. e1g1e castles short and inserts an Elephant
+ * at square e1. However, castling with piece insertion at the rook square is
+ * represented as "Rook captures own King with promotion to reserve piece",
+ * e.g. h1e1h inserts a Hawk on h1 after castling short.
+ */
+QString SeirawanBoard::lanMoveString(const Move& move)
+{
+	int promotion = move.promotion();
+	QString str(Chess::WesternBoard::lanMoveString(move));
+
+	// normal move or channeling /wo castling
+	if (Board::lanMoveString(move) == str || !promotion)
+		return str;
+
+	// castling with channeling onto king square
+	if (promotion < rookSquareChanneling(Hawk))
+		return str + pieceSymbol(promotion).toLower();
+
+	// castling with channeling onto rook square
+	Move move1(move.targetSquare(),
+		   move.sourceSquare(),
+		   rookSquareChanneling(move.promotion(), backward));
+	return Board::lanMoveString(move1);
+}
+
+/*
+ * This method returns the same short algebraic notation (SAN) of a given move
+ * as standard chess. However, channeling moves are denoted by adding a slash
+ * and a piece symbol to the standard move notation. E.g. Nc3/H moves a Knight
+ * to c3 and inserts a Hawk at the vacated square. Castling with channeling has
+ * a similar notation, but needs disambigation: a piece from the reserve can be
+ * inserted either at the vacated king square or the rook square. E.g. O-O/Ee1
+ * castles short and drops an Elephant piece on square e1, while O-O/Eh1 castles
+ * short and drops the piece on the vacated rook square h1.
+ */
+QString SeirawanBoard::sanMoveString(const Move& move)
+{
+	QString str(WesternBoard::sanMoveString(move));
+	int promotion = move.promotion();
+	int pieceType = promotion;
+	Side side = sideToMove();
+
+	int source = move.sourceSquare();
+	Square srcSq = chessSquare(source);
+	int target = move.targetSquare();
+	int baserank = (side == Side::White) ? 0 : height() - 1;
+
+	// promotion on own baserank is channeling move
+	if (srcSq.rank() == baserank && promotion != Piece::NoPiece)
+	{
+		// use notation symbol "/" (slash) for channeling move
+		str.replace('=','/');
+		// castling moves
+		if (!str.contains('/'))
+		{
+			// internal representation of rook square channeling
+			if (promotion >= rookSquareChanneling(Hawk))
+				pieceType = rookSquareChanneling(promotion, backward);
+
+			Piece piece(side, pieceType);
+			str.append('/' + pieceSymbol(piece).toUpper());
+			if (promotion == pieceType)
+				str.append(squareString(source));
+			else
+				str.append(squareString(target));
+		}
+	}
+	return str;
+}
+
+/*
+ * This method generates a board move from SAN (see above). It accepts
+ * castling/channeling notation formats like O-O-O/Hh1 and O-O-O/Hh.
+ * Internally a channeling move is represented as move with promotion.
+ * Castling moves with channeling onto rook squares use auxiliary promotion
+ * piece types to differ from drops onto king squares.
+ */
+Move SeirawanBoard::moveFromSanString(const QString& str)
+{
+	// leave orthodox moves to WesternBoard
+	int index = str.indexOf('/');
+	if (index < 0)
+		return WesternBoard::moveFromSanString(str);
+
+	// channeling moves
+	QString s = str.left(index);
+	Move move = WesternBoard::moveFromSanString(s);
+	int promotion = pieceFromSymbol(str.mid(index + 1, 1)).type();
+
+	if (move.isNull() || promotion == 0)
+		return Move();
+
+	Piece piece = Piece(sideToMove(), promotion);
+	if (!reservePieceTypes().contains(piece) ||  reserveCount(piece) < 1)
+		return Move();
+
+	int target = move.targetSquare();
+
+	// castling with channeling onto rook square
+	if (move.sourceSquare() == kingSquare(sideToMove())
+	&&  str.mid(index + 2, 1) == squareString(target).left(1))
+		promotion = rookSquareChanneling(promotion);
+
+	// channeling moves
+	return Move(move.sourceSquare(), target, promotion );
+}
+
+Move SeirawanBoard::moveFromLanString(const QString& str)
+{
+	Move move0(Board::moveFromLanString(str));
+	Side side = sideToMove();
+	int source = move0.sourceSquare();
+	int target = move0.targetSquare();
+	int promotion = move0.promotion();
+
+	// castling move with channeling onto rook square
+	// coded as castling with promotion to auxiliary type
+	if (promotion != Piece::NoPiece
+	&&  pieceAt(source) == Piece(side, Rook)
+	&&  target == kingSquare(side))
+	{
+		return Move(target, source, rookSquareChanneling(promotion));
+	}
+
+	Move move(WesternBoard::moveFromLanString(str));
+	return Move(move.sourceSquare(), move.targetSquare(), promotion);
+}
+
+void SeirawanBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	int source = move.sourceSquare();
+	int prom = move.promotion();
+	Side side = sideToMove();
+
+	WesternBoard::vMakeMove(move, transition);
+
+	if (m_squareMap.contains(source)
+	&&  m_squareMap[source] == 0
+	&&  prom != Piece::NoPiece)
+	{
+		if (prom >= rookSquareChanneling(Hawk))
+		{
+			prom = rookSquareChanneling(prom, backward);
+			source = move.targetSquare();
+		}
+		Piece piece(side, prom);
+		if (reserveCount(piece) > 0)
+		{
+			Square csq = chessSquare(source);
+
+			if (csq.isValid())
+			{
+				removeFromReserve(piece);
+				setSquare(source, piece); // drop-in
+				if (transition != nullptr)
+					transition->addDrop(piece, csq);
+			}
+		}
+	}
+	updateSquareMap(move, +1);
+}
+
+void SeirawanBoard::vUndoMove(const Move& move)
+{
+	Side side = sideToMove();
+	int index = move.sourceSquare();
+
+	if (move.promotion() >= rookSquareChanneling(Hawk))
+		  index = move.targetSquare();
+
+	Piece piece = pieceAt(index);
+
+	updateSquareMap(move, -1);
+
+	// channeling move?
+	if ( piece.side() == side
+	&&   chessSquare(index).isValid()
+	&&   reservePieceTypes().contains(piece))
+	{
+		// undo channeling move
+		addToReserve(piece);
+		// skipped: setSquare(index, Piece());
+	}
+	WesternBoard::vUndoMove(move);
+}
+
+void SeirawanBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	if (!isValidSquare(chessSquare(square)))
+		return;
+
+	QVarLengthArray< Move > moves1, moves2;
+	WesternBoard::generateMovesForPiece(moves1, pieceType, square);
+
+	// add normal moves
+	for (Move m: moves1)
+		moves.append(m);
+
+	// return if no channeling is allowed on square
+	if (!m_squareMap.contains(square) ||  m_squareMap[square] > 0)
+		return;
+
+	// generate channeling moves as promotions on base rank
+	Side side = sideToMove();
+	for (Move m: moves1)
+	{
+		const QList<Piece>& reserveTypes = reservePieceTypes();
+		for (const Piece& pc: reserveTypes)
+		{
+			if (pc.side() == side &&  reserveCount(pc) > 0)
+				moves2.append(Move(m.sourceSquare(),
+						   m.targetSquare(),
+						   pc.type()));
+		}
+	}
+
+	// add channeling moves
+	for (Move m: moves2)
+	{
+		moves.append(m);
+		// add castling move with channeling onto rook square
+		Piece piece1 = pieceAt(m.sourceSquare());
+		Piece piece2 = pieceAt(m.targetSquare());
+
+		if (piece1.type() == King
+		&&  piece2.type() == Rook
+		&&  piece2.side() == side)
+			moves.append(Move(m.sourceSquare(),
+					  m.targetSquare(),
+					  rookSquareChanneling(m.promotion())));
+	}
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/seirawanboard.h
+++ b/projects/lib/src/board/seirawanboard.h
@@ -1,0 +1,99 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SEIRAWANBOARD_H
+#define SEIRAWANBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for S-Chess (a.k.a. Seirawan Chess)
+ *
+ * S-Chess is a variant of standard chess which adds two piece types and
+ * is played on a regular 8x8 board.
+ *
+ * The variant was introduced by Bruce Harper and Yasser Seirawan (USA, 2007)
+ * using the piece types of Capablanca chess under different names.
+ *
+ * The additional pieces are called Elephant (moves like Rook + Knight),
+ * and Hawk (Bishop + Knight). These pieces are kept in reserve at first.
+ * They may enter the board on any square of the own base rank immediately
+ * after this square has been vacated for the first time. Squares that have
+ * been vacant before can not be used for entry, nor squares where captures
+ * removed the original pieces. Only one piece may enter per move. There is
+ * no obligation to use the reserve pieces.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Seirawan_chess
+ *
+ */
+class LIB_EXPORT SeirawanBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new SeirawanBoard object. */
+		SeirawanBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Special piece types for Seirawan variants. */
+		enum SeirawanPieceType
+		{
+			Hawk = King + 1, //!< Hawk = Princess (knight + bishop)
+			Elephant	 //!< Elephant = Empress (knight + rook)
+		};
+
+		// Inherited from WesternBoard
+		virtual bool variantHasDrops() const;
+		virtual bool variantHasChanneling(Side side, int square) const;
+		virtual bool variantHasOptionalPromotions() const;
+		virtual QList< Piece > reservePieceTypes() const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual bool parseCastlingRights(QChar c);
+		virtual QString vFenString(FenNotation notation) const;
+		virtual QString lanMoveString(const Move& move);
+		virtual QString sanMoveString(const Move& move);
+		virtual Move moveFromSanString(const QString& str);
+		virtual Move moveFromLanString(const QString& str);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+	private:
+		QMap<int, int> m_squareMap;
+		void insertIntoSquareMap(int square, int count = 0);
+		void updateSquareMap(const Move& move, int increment);
+		enum direction { forward, backward };
+		/*
+		 * This method to converts reserve piece types into/from
+		 * corresponding "virtual" helper piece types. Used for
+		 * disambiguation of channeling after castling towards GUI.
+		 */
+		static int rookSquareChanneling(int promotion, direction d);
+};
+
+} // namespace Chess
+#endif // SEIRAWANBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -84,6 +84,11 @@ bool WesternBoard::hasEnPassantCaptures() const
 	return pawnHasDoubleStep();
 }
 
+bool WesternBoard::variantHasChanneling(Side, int) const
+{
+	return false;
+}
+
 void WesternBoard::vInitialize()
 {
 	m_kingCanCapture = kingCanCapture();
@@ -936,6 +941,9 @@ void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)
 		isReversible = false;
 	}
 
+	if (promotionType != Piece::NoPiece)
+		isReversible = false;
+
 	if (transition != nullptr)
 	{
 		if (source != 0)
@@ -1001,7 +1009,12 @@ void WesternBoard::vUndoMove(const Move& move)
 	if (move.promotion() != Piece::NoPiece)
 	{
 		if (source != 0)
-			setSquare(source, Piece(side, Pawn));
+		{
+			if (variantHasChanneling(side, source))
+				setSquare(source, pieceAt(target));
+			else
+				setSquare(source, Piece(side, Pawn));
+		}
 	}
 	else
 		setSquare(source, pieceAt(target));

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -135,6 +135,14 @@ class LIB_EXPORT WesternBoard : public Board
 		 */
 		virtual bool hasEnPassantCaptures() const;
 		/*!
+		 * Returns true if a rule provides \a side to insert a reserve
+		 * piece at a vacated source \a square immediately after a move.
+		 * The default value is false.
+		 *
+		 * \sa SeirawanBoard
+		 */
+		virtual bool variantHasChanneling(Side side, int square) const;
+		/*!
 		 * Adds pawn promotions to a move list.
 		 *
 		 * This function is called when a pawn can promote by
@@ -149,6 +157,11 @@ class LIB_EXPORT WesternBoard : public Board
 		int kingSquare(Side side) const;
 		/*! Returns the current en-passant square. */
 		int enpassantSquare() const;
+		/*!
+		 * Parse castling rights given by character \a c of the FEN
+		 * token. Returns true if successful.
+		 */
+		virtual bool parseCastlingRights(QChar c);
 		/*!
 		 * Returns true if \a side has a right to castle on \a castlingSide;
 		 * otherwise returns false.
@@ -228,7 +241,6 @@ class LIB_EXPORT WesternBoard : public Board
 
 		bool canCastle(CastlingSide castlingSide) const;
 		QString castlingRightsString(FenNotation notation) const;
-		bool parseCastlingRights(QChar c);
 		CastlingSide castlingSide(const Move& move) const;
 		void setEnpassantSquare(int square,
 					int target=0);

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -358,6 +358,82 @@ void tst_Board::moveStrings_data() const
 		   "Qxd4 Bc3 Qh4+ g3 Qa4 Nf3 Qa6 Qxa6 bxa6 Ba5 h5 O-O"
 		<< "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1"
 		<< "r3kk1r/p2nppp1/p7/B6p/8/5NP1/PPP4P/R4RK1 b kq - 0 20";
+	QTest::newRow("seirawan san1")
+		<< "seirawan"
+		<< "e4 e5 Nf3 Nf6/H Bc4 Hh6 O-O/Eh1 Bd6 Nc3/H O-O/Ee8"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w bcdfgBCDFGKQkq - 0 1"
+		<< "rnbqerk1/pppp1ppp/3b1n1h/4p3/2B1P3/2N2N2/PPPP1PPP/RHBQ1RKE[-] w - - 0 6";
+	QTest::newRow("seirawan castling san1")
+		<< "seirawan"
+		<< "O-O/Ee1 O-O/Hh8"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r4rkh/pppppppp/8/8/8/8/PPPPPPPP/R3ERK1[He] w aA - 0 2";
+	QTest::newRow("seirawan castling san2")
+		<< "seirawan"
+		<< "O-O/Eh1 O-O-O/He8"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "2krh2r/pppppppp/8/8/8/8/PPPPPPPP/R4RKE[He] w hA - 0 2";
+	QTest::newRow("seirawan castling san3")
+		<< "seirawan"
+		<< "O-O-O/Ea1 O-O-O/Ea8"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "e1kr3r/pppppppp/8/8/8/8/PPPPPPPP/E1KR3R[Hh] w hH - 0 2";
+	QTest::newRow("seirawan castling san4")
+		<< "seirawan"
+		<< "O-O-O/He1 O-O/Ee8"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r3erk1/pppppppp/8/8/8/8/PPPPPPPP/2KRH2R[Eh] w aH - 0 2";
+	QTest::newRow("seirawan castling san4b")
+		<< "seirawan"
+		<< "O-O-O/He O-O/Ee"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r3erk1/pppppppp/8/8/8/8/PPPPPPPP/2KRH2R[Eh] w aH - 0 2";
+	QTest::newRow("seirawan castling san4c")
+		<< "seirawan"
+		<< "O-O-O/H O-O/E"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r3erk1/pppppppp/8/8/8/8/PPPPPPPP/2KRH2R[Eh] w aH - 0 2";
+	QTest::newRow("seirawan castling san5")
+		<< "seirawan"
+		<< "O-O-O O-O"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r4rk1/pppppppp/8/8/8/8/PPPPPPPP/2KR3R[EHeh] w aH - 0 2";
+	QTest::newRow("seirawan castling san6")
+		<< "seirawan"
+		<< "O-O-O O-O Rhg1/E Rac8/H"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "h1r2rk1/pppppppp/8/8/8/8/PPPPPPPP/2KR2RE[He] w - - 0 3";
+	QTest::newRow("seirawan lan1")
+		<< "seirawan"
+		<< "e2e4 e7e5 g1f3 g8f6h f1c4 g8h6 h1e1e f8d6 b1c3h e8g8e"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w bcdfgBCDFGKQkq - 0 1"
+		<< "rnbqerk1/pppp1ppp/3b1n1h/4p3/2B1P3/2N2N2/PPPP1PPP/RHBQ1RKE[-] w - - 0 6";
+	QTest::newRow("seirawan castling lan1")
+		<< "seirawan"
+		<< "e1g1e h8e8h"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r4rkh/pppppppp/8/8/8/8/PPPPPPPP/R3ERK1[He] w aA - 0 2";
+	QTest::newRow("seirawan castling lan2")
+		<< "seirawan"
+		<< "h1e1e e8c8h"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "2krh2r/pppppppp/8/8/8/8/PPPPPPPP/R4RKE[He] w hA - 0 2";
+	QTest::newRow("seirawan castling lan3")
+		<< "seirawan"
+		<< "a1e1e a8e8e"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "e1kr3r/pppppppp/8/8/8/8/PPPPPPPP/E1KR3R[Hh] w hH - 0 2";
+	QTest::newRow("seirawan castling lan4")
+		<< "seirawan"
+		<< "e1c1h e8g8e"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r3erk1/pppppppp/8/8/8/8/PPPPPPPP/2KRH2R[Eh] w aH - 0 2";
+	QTest::newRow("seirawan castling lan5")
+		<< "seirawan"
+		<< "e1c1 e8g8"
+		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
+		<< "r4rk1/pppppppp/8/8/8/8/PPPPPPPP/2KR3R[EHeh] w aH - 0 2";
+
 }
 
 void tst_Board::moveStrings()
@@ -1065,6 +1141,13 @@ void tst_Board::perft_data() const
 		// symmetrical variant 4 plies: 192332, 5 plies: 4629764, 6 plies: 110829475
 		<< 5
 		<< Q_UINT64_C(4629764);
+
+	variant = "seirawan";
+	QTest::newRow("seirawan startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w BCDFGbcdfgKQkq - 0 1"
+		<< 4 // 4 plies: 782599, 5 plies: 27639803, 6 plies: 967587141 (sjaakii: 967584909)
+		<< Q_UINT64_C(782599);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This PR is a suggestion to support _Seirawan Chess_ or _S-Chess_.

In 2007 Yasser Seirawan and Bruce Harper introduced a new variant of Standard Chess. Their intention was to reduce the draw rate by having Capablanca pieces but using the common 8x8 board. At start the standard chess set up is used. However, each side has in reserve a Knight+Bishop combination, called _Hawk_ (Archbishop in Capablanca Chess) and a Knight+Rook combination, called _Elephant_ (Capablanca Chess: Chancellor). One of these pieces has the option to enter the board on a square of the own base rank immediately after this square has been vacated for the first time. No piece can enter on a square that has been vacant before the move. Only one piece can enter per move. There is no obligation to use the reserve pieces at all.


![se1a](https://user-images.githubusercontent.com/6425738/34362033-30e79e28-ea70-11e7-8b96-a0c2082d1643.png)![se2a](https://user-images.githubusercontent.com/6425738/34362040-46962438-ea70-11e7-9b81-a025316537cb.png)
_Selection of reserve piece to be inserted on square b8 which has been vacated by the knight moving to c6._



`SeirawanBoard` is derived from `WesternBoard` and uses support already in place for variants with drop moves. However, _Seirawan Chess_ has a different character and needs some adjustments.

The channeling moves have been coded on the engine interface and also internally as moves with promotion to reserve pieces. This format has already has been used by Seirawan Chess engines and _Xboard_ when communicating via _CECP_, and recently also by Stockfish via UCI . As a consequence for the Cutechess GUI  a player can pick the desired piece to be inserted from the choser when making a move from the base rank.

The GUI has been extended in order to support optional promotions, so one can not only chose a promotion type but click somewhere outside the piece choser in order to select no piece at all.

The GUI also has been adapted to mirror transition sequences of making moves and undoing moves. This difference is relevant for composite moves (like channeling moves or castling with channeling).

The implementation has been tested with various Seirawan Chess engines: Sigla v2.1, xleo-83, Sjaak II 1.3.1 and 1.4.1, Fairymax 5,0b, and "Stockfish for Seirawan Chess".

Also a number of test cases have been added.
HTH

![se3a](https://user-images.githubusercontent.com/6425738/34362164-8e8d6ca0-ea71-11e7-9210-bd5e93a8edec.png)
![se4a](https://user-images.githubusercontent.com/6425738/34362165-935b9b8a-ea71-11e7-8bd7-6e15873e38c3.png)
_Selection of reserve piece to be inserted at either e1 or h1 when castling short. There are four choices: two different pieces times two target squares. Here the Elephant was selected for insertion at the rook square h1._

