### PR TITLE
Fix deletion of pgn data before signal emission

### DIFF
--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -601,8 +601,6 @@ void Tournament::onGameFinished(ChessGame* game)
 
 	writeEpd(game);
 	writePgn(pgn, gameNumber);
-	if (m_pgnCleanup)
-		delete pgn;
 
 	Chess::Result::Type resultType(game->result().type());
 	bool crashed = (resultType == Chess::Result::Disconnection ||
@@ -618,6 +616,9 @@ void Tournament::onGameFinished(ChessGame* game)
 	}
 
 	emit gameFinished(game, gameNumber, iWhite, iBlack);
+
+	if (m_pgnCleanup)
+		delete pgn;
 
 	if (areAllGamesFinished() || (m_stopping && m_gameData.isEmpty()))
 	{


### PR DESCRIPTION
Fixes a bug in the library where tournament pgn data are deleted before
the gameFinished signal is emitted, denying handlers access to data.
The fix deletes the pgn data immediately after sending the signal
instead.