### PR TITLE
Fix automatic creation of ECO tags while reading EcoNode file

### DIFF
--- a/projects/lib/src/econode.cpp
+++ b/projects/lib/src/econode.cpp
@@ -118,7 +118,7 @@ void EcoNode::initialize(PgnStream& in)
 	QMap<QString, int> tmpOpenings;
 
 	PgnGame game;
-	while (game.read(in))
+	while (game.read(in, INT_MAX - 1, false))
 	{
 		current = s_root;
 		for (const PgnGame::MoveData& move : game.moves())

--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -99,16 +99,19 @@ const QVector<PgnGame::MoveData>& PgnGame::moves() const
 	return m_moves;
 }
 
-void PgnGame::addMove(const MoveData& data)
+void PgnGame::addMove(const MoveData& data, bool addEco)
 {
 	m_moves.append(data);
 
-	m_eco = (m_eco && isStandard()) ? m_eco->child(data.moveString) : nullptr;
-	if (m_eco && m_eco->isLeaf())
-	{
-		setTag("ECO", m_eco->ecoCode());
-		setTag("Opening", m_eco->opening());
-		setTag("Variation", m_eco->variation());
+	if (addEco) {
+		m_eco = (m_eco && isStandard()) ? m_eco->child(data.moveString)
+						: nullptr;
+		if (m_eco && m_eco->isLeaf())
+		{
+			setTag("ECO", m_eco->ecoCode());
+			setTag("Opening", m_eco->opening());
+			setTag("Variation", m_eco->variation());
+		}
 	}
 }
 
@@ -142,7 +145,7 @@ Chess::Board* PgnGame::createBoard() const
 	return board;
 }
 
-bool PgnGame::parseMove(PgnStream& in)
+bool PgnGame::parseMove(PgnStream& in, bool addEco)
 {
 	if (m_tags.isEmpty())
 	{
@@ -198,13 +201,13 @@ bool PgnGame::parseMove(PgnStream& in)
 
 	MoveData md = { board->key(), board->genericMove(move),
 			str, QString() };
-	addMove(md);
+	addMove(md, addEco);
 
 	board->makeMove(move);
 	return true;
 }
 
-bool PgnGame::read(PgnStream& in, int maxMoves)
+bool PgnGame::read(PgnStream& in, int maxMoves, bool addEco)
 {
 	clear();
 	if (!in.nextGame())
@@ -220,7 +223,7 @@ bool PgnGame::read(PgnStream& in, int maxMoves)
 			setTag(in.tagName(), in.tagValue());
 			break;
 		case PgnStream::PgnMove:
-			stop = !parseMove(in) || m_moves.size() >= maxMoves;
+			stop = !parseMove(in, addEco) || m_moves.size() >= maxMoves;
 			break;
 		case PgnStream::PgnComment:
 			if (!m_moves.isEmpty())

--- a/projects/lib/src/pgngame.h
+++ b/projects/lib/src/pgngame.h
@@ -84,8 +84,11 @@ class LIB_EXPORT PgnGame
 		QList< QPair<QString, QString> > tags() const;
 		/*! Returns the moves that were played in the game. */
 		const QVector<MoveData>& moves() const;
-		/*! Adds a new move to the game. */
-		void addMove(const MoveData& data);
+		/*! Adds a new move to the game.
+		 * \param data The move to add.
+		 * \param addEco Adds opening information if true.
+		 */
+		void addMove(const MoveData& data, bool addEco = true);
 		void setMove(int ply, const MoveData& data);
 
 		/*!
@@ -101,13 +104,15 @@ class LIB_EXPORT PgnGame
 		 *
 		 * \param in The PGN stream to read from.
 		 * \param maxMoves The maximum number of halfmoves to read.
+		 * \param addEco Adds opening information if true.
 		 *
 		 * \note Even if the stream contains multiple games,
 		 * only one will be read.
 		 *
 		 * Returns true if any tags and/or moves were read.
 		 */
-		bool read(PgnStream& in, int maxMoves = INT_MAX - 1);
+		bool read(PgnStream& in, int maxMoves = INT_MAX - 1,
+				  bool addEco = true);
 		/*!
 		 * Writes the game to a text stream.
 		 *
@@ -196,7 +201,7 @@ class LIB_EXPORT PgnGame
 		void setGameEndTime(const QDateTime& dateTime);
 
 	private:
-		bool parseMove(PgnStream& in);
+		bool parseMove(PgnStream& in, bool addEco);
 		
 		Chess::Side m_startingSide;
 		const EcoNode* m_eco;


### PR DESCRIPTION
Fixes a bug in the library where PgnGame::read() automatically creates
the opening tags (ECO, Opening, and Variation) while reading a file that
already contains those tags.  This creates a bug in
EcoNode::initialize(PgnStream&) which uses PgnGame::read() to create the
EcoNode tree from a PGN file.