### PR TITLE
Add function to resign a game via GUI menu item

### DIFF
--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -67,6 +67,7 @@ class MainWindow : public QMainWindow
 		void onWindowMenuAboutToShow();
 		void showGameWindow();
 		void updateWindowTitle();
+		void updateMenus();
 		bool save();
 		bool saveAs();
 		void onTabChanged(int index);
@@ -84,6 +85,7 @@ class MainWindow : public QMainWindow
 		void adjudicateDraw();
 		void adjudicateWhiteWin();
 		void adjudicateBlackWin();
+		void resignGame();
 
 	private:
 		struct TabData
@@ -134,6 +136,7 @@ class MainWindow : public QMainWindow
 		QAction* m_adjudicateBlackWinAct;
 		QAction* m_adjudicateWhiteWinAct;
 		QAction* m_adjudicateDrawAct;
+		QAction* m_resignGameAct;
 		QAction* m_closeGameAct;
 		QAction* m_saveGameAct;
 		QAction* m_saveGameAsAct;

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -317,7 +317,17 @@ void ChessGame::startTurn()
 
 void ChessGame::onAdjudication(const Chess::Result& result)
 {
-	if (result.type() != Chess::Result::Adjudication || m_finished)
+	if (m_finished || result.type() != Chess::Result::Adjudication)
+		return;
+
+	m_result = result;
+
+	stop();
+}
+
+void ChessGame::onResignation(const Chess::Result& result)
+{
+	if (m_finished || result.type() != Chess::Result::Resignation)
 		return;
 
 	m_result = result;

--- a/projects/lib/src/chessgame.h
+++ b/projects/lib/src/chessgame.h
@@ -86,6 +86,7 @@ class LIB_EXPORT ChessGame : public QObject
 		void emitStartFailed();
 		void onMoveMade(const Chess::Move& move);
 		void onAdjudication(const Chess::Result& result);
+		void onResignation(const Chess::Result& result);
 
 	signals:
 		void humanEnabled(bool);


### PR DESCRIPTION
This adds a menu item to the "Game" menu of the GUI with the functionality to resign a game for a human player. When the new item "Resign" is selected, the side to move resigns the game. However, if the side to move is not a human (local) player then the side to wait resigns the game. If both sides are played by engines, no resignation will be triggered - and the menu item will be rendered inactive anyway.

In addition, the menu items for game adjudication are disabled if the game shown in the active tab is finished.