### PR TITLE
User Name Options

### DIFF
--- a/projects/gui/src/cutechessapp.cpp
+++ b/projects/gui/src/cutechessapp.cpp
@@ -39,6 +39,10 @@
 #include "importprogressdlg.h"
 #include "pgnimporter.h"
 #include "gamewall.h"
+#ifndef Q_OS_WIN32
+#	include <sys/types.h>
+#	include <pwd.h>
+#endif
 
 
 CuteChessApplication::CuteChessApplication(int& argc, char* argv[])
@@ -103,6 +107,12 @@ QString CuteChessApplication::userName()
 	#ifdef Q_OS_WIN32
 	return qgetenv("USERNAME");
 	#else
+	if (QSettings().value("ui/use_full_user_name", true).toBool())
+	{
+		auto pwd = getpwnam(qgetenv("USER"));
+		if (pwd != nullptr)
+			return QString(pwd->pw_gecos).split(',')[0];
+	}
 	return qgetenv("USER");
 	#endif
 }

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -552,7 +552,9 @@ void MainWindow::setCurrentGame(const TabData& gameData)
 			auto clock = m_gameViewer->chessClock(side);
 			clock->stop();
 			clock->setInfiniteTime(true);
-			clock->setPlayerName(gameData.m_pgn->playerName(side));
+			QString name = nameOnClock(gameData.m_pgn->playerName(side),
+						   side);
+			clock->setPlayerName(name);
 		}
 
 		updateWindowTitle();
@@ -581,7 +583,8 @@ void MainWindow::setCurrentGame(const TabData& gameData)
 		auto clock = m_gameViewer->chessClock(side);
 
 		clock->stop();
-		clock->setPlayerName(player->name());
+		QString name = nameOnClock(player->name(), side);
+		clock->setPlayerName(name);
 		connect(player, SIGNAL(nameChanged(QString)),
 			clock, SLOT(setPlayerName(QString)));
 
@@ -921,6 +924,16 @@ void MainWindow::updateMenus()
 	m_resignGameAct->setEnabled(gameOn && isHumanGame);
 }
 
+QString MainWindow::nameOnClock(const QString& name, Chess::Side side) const
+{
+	QString text = name;
+	bool displaySide = QSettings().value("ui/display_players_sides_on_clocks", false)
+				      .toBool();
+	if (displaySide)
+		text.append(QString(" (%1)").arg(side.toString()));
+	return text;
+}
+
 void MainWindow::editMoveComment(int ply, const QString& comment)
 {
 	bool ok;
@@ -953,7 +966,7 @@ void MainWindow::showAboutDialog()
 	html += "<h3>" + QString("Cute Chess %1")
 		.arg(CuteChessApplication::applicationVersion()) + "</h3>";
 	html += "<p>" + tr("Using Qt version %1").arg(qVersion()) + "</p>";
-	html += "<p>" + tr("Copyright 2008-2017 "
+	html += "<p>" + tr("Copyright 2008-2018 "
 			   "Ilari Pihlajisto and Arto Jonsson") + "</p>";
 	html += "<p>" + tr("This is free software; see the source for copying "
 			   "conditions. There is NO warranty; not even for "

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -107,6 +107,7 @@ class MainWindow : public QMainWindow
 		void readSettings();
 		void writeSettings();
 		QString genericTitle(const TabData& gameData) const;
+		QString nameOnClock(const QString& name, Chess::Side side) const;
 		void lockCurrentGame();
 		void unlockCurrentGame();
 		bool saveGame(const QString& fileName);

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -43,6 +43,18 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/close_unused_initial_tab", checked);
 	});
 
+	connect(ui->m_useFullUserNameCheck, &QCheckBox::toggled,
+		this, [=](bool checked)
+	{
+		QSettings().setValue("ui/use_full_user_name", checked);
+	});
+
+	connect(ui->m_playersSidesOnClocksCheck, &QCheckBox::toggled,
+		this, [=](bool checked)
+	{
+		QSettings().setValue("ui/display_players_sides_on_clocks", checked);
+	});
+
 	connect(ui->m_concurrencySpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
 		this, [=](int value)
 	{
@@ -173,6 +185,10 @@ void SettingsDialog::readSettings()
 		s.value("highlight_legal_moves", true).toBool());
 	ui->m_closeUnusedInitialTabCheck->setChecked(
 		s.value("close_unused_initial_tab", true).toBool());
+	ui->m_useFullUserNameCheck->setChecked(
+		s.value("use_full_user_name", true).toBool());
+	ui->m_playersSidesOnClocksCheck->setChecked(
+		s.value("display_players_sides_on_clocks", false).toBool());
 	ui->m_tbPathEdit->setText(s.value("tb_path").toString());
 	s.endGroup();
 

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -53,7 +53,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="m_siteLabel">
          <property name="text">
           <string>PGN Site:</string>
@@ -63,10 +63,10 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="4" column="1">
         <widget class="QLineEdit" name="m_siteEdit"/>
        </item>
-       <item row="3" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="m_tbPathLabel">
          <property name="text">
           <string>Syzygy tablebases path:</string>
@@ -76,7 +76,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="5" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLineEdit" name="m_tbPathEdit"/>
@@ -90,14 +90,14 @@
          </item>
         </layout>
        </item>
-       <item row="6" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="m_defaultPgnOutFileLabel">
          <property name="text">
           <string>PGN output for single games:</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="8" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QLineEdit" name="m_defaultPgnOutFileEdit">
@@ -117,6 +117,23 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="m_useFullUserNameCheck">
+         <property name="text">
+          <string>Use full name of human player</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="m_playersSidesOnClocksCheck">
+         <property name="text">
+          <string>Display players' sides on clocks </string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
This PR suggests adding choices for the name representation of human players to the GUI
- Add option to use full user name instead of login name
- Add option to display sides of players on chess clock
- Checkboxes to configure these options in General Settings

References: Issues #139 and #110 .
