### PR TITLE
Add support for South-East Asian Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -45,10 +45,14 @@ Andernach Chess
 Anti-Andernach Chess
 .It antichess
 Antichess / Losing Chess
+.It asean
+ASEAN-Chess
 .It atomic
 Atomic Chess
 .It berolina
 Berolina Chess
+.It cambodian
+Ouk Chatrang (Cambodian Chess)
 .It capablanca
 Capablanca Chess
 .It caparandom
@@ -91,6 +95,8 @@ Gryphon Chess
 Horde Chess (v2)
 .It janus
 Janus Chess
+.It karouk
+Kar Ouk (One-check Ouk)
 .It kinglet
 Kinglet Chess
 .It kingofthehill
@@ -101,6 +107,8 @@ Knightmate
 Loop Chess (Drop Chess Variant)
 .It losers
 Loser's Chess
+.It makruk
+Makruk (Thai Chess)
 .It modern
 Modern Chess (9x9)
 .It pocketknight

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -15,8 +15,10 @@ Options:
 			'andernach': Andernach Chess
 			'antiandernach': Anti-Andernach Chess
 			'antichess': Antichess (Losing Chess)
+			'asean': ASEAN-Chess
 			'atomic': Atomic Chess
 			'berolina': Berolina Chess
+			'cambodian': Ouk Chatrang (Cambodian Chess)
 			'capablanca': Capablanca Chess
 			'caparandom': Capablanca Random Chess
 			'chancellor': Chancellor Chess (9x9)
@@ -38,11 +40,13 @@ Options:
 			'gryphon': Gryphon Chess
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
+			'karouk': Kar Ouk (One-check Ouk)
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess
 			'knightmate': Knightmate
 			'loop': Loop Chess (Drop Chess)
 			'losers': Loser's Chess
+			'makruk': Makruk (Thai Chess)
 			'modern': Modern Chess (9x9)
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess

--- a/projects/lib/src/board/aseanboard.cpp
+++ b/projects/lib/src/board/aseanboard.cpp
@@ -1,0 +1,120 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aseanboard.h"
+
+namespace Chess {
+
+AseanBoard::AseanBoard()
+	: MakrukBoard()
+{
+	// all pieces have standard chess names but move like Makruk pieces
+	setPieceType(Pawn, tr("pawn"), "P");
+	setPieceType(Knight, tr("knight"), "N", KnightMovement);
+	setPieceType(Bishop, tr("bishop"), "B", SilverGeneralMovement); //! Khon
+	setPieceType(Rook, tr("rook"), "R", RookMovement);
+	setPieceType(Queen, tr("queen"), "Q", FerzMovement); //! Ferz
+	setPieceType(King, tr("king"), "K");
+}
+
+Board* AseanBoard::copy() const
+{
+	return new AseanBoard(*this);
+}
+
+QString AseanBoard::variant() const
+{
+	return "asean";
+}
+
+QString AseanBoard::defaultFenString() const
+{
+	return "rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBQKBNR w - - 0 1";
+}
+
+QString AseanBoard::vFenString(Board::FenNotation notation) const
+{
+	return WesternBoard::vFenString(notation);
+}
+
+bool AseanBoard::vSetFenString(const QStringList& fen)
+{
+	if (!WesternBoard::vSetFenString(fen))
+		return false;
+
+	initHistory();
+	setAllPieceCounters();
+	return true;
+}
+
+int AseanBoard::promotionRank(int) const
+{
+	return 7; // eighth rank (base rank is 0)
+}
+
+void AseanBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+}
+
+MakrukBoard::CountingRules AseanBoard::countingRules() const
+{
+	return BareKing;
+}
+
+int AseanBoard::countingLimit() const
+{
+	// ASEAN-Chess Article 5.2e
+	Side side = sideToMove();
+	int rooks = pieceCount(side, Rook);
+	if (rooks > 0)
+		return 16;
+
+	int bishops = pieceCount(side, Bishop);
+	int queens = pieceCount(side,Queen);
+	if (bishops > 0 && queens > 0)
+		return 44;
+
+	int knights = pieceCount(side, Knight);
+	if (knights > 0 && queens > 0)
+		return 64;
+
+	return 1000; // intentional limit
+}
+
+Result AseanBoard::result()
+{
+	// Use standard chess result
+	Result gameResult = WesternBoard::result();
+	if (!gameResult.isNone())
+	{
+		// In ASEAN-Chess a three-fold repetition is not a draw
+		if (!gameResult.isDraw() || repeatCount() < 2)
+			return gameResult;
+	}
+	// Insufficent material: KvK, KQvK. KQQvK, KNvK
+	if (insufficientMaterial())
+	{
+		QString str = tr("Draw by insufficient mating material");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// apply counting rules
+	return resultFromCounting();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/aseanboard.h
+++ b/projects/lib/src/board/aseanboard.h
@@ -1,0 +1,84 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ASEANBOARD_H
+#define ASEANBOARD_H
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for ASEAN-Chess
+ *
+ * ASEAN-Chess is a standardised variant of chess defined by the ASEAN Chess
+ * Confederation. It is based both on standard chess and Makruk.
+ *
+ * ASEAN-Chess is played on a standard chess board. The pieces are named as in
+ * standard chess, but have the movements of Makruk. So the Queen has the
+ * movement of the Met (Ferz, 1 square diagonally), and the Bishop moves like
+ * the Khon in Makruk (or the Silver General in Shogi): 1 square diagonally or
+ * 1 square straight forward. There is no castling and pawns have no initial
+ * double steps.
+ *
+ * The starting position has the pawns on the third own rank, like in Makruk.
+ * However, the pieces on the base rank are placed in the starting order of
+ * standard chess. Pawns promote on the eighth rank to either Queen, Rook,
+ * Bishop, or Knight.
+ *
+ * Like in standard chess giving mate wins, stalemate is a draw, insufficient
+ * material is a draw, and after fifty consecutive moves without any pawn move
+ * and any capture a draw can be claimed. However, three-fold repetition of a
+ * move does not achieve a draw. A game is drawn when no side can be checkmated
+ * at all by any sequence of legal moves.
+ *
+ * When a King is left without any pieces the material on the board is evalua-
+ * ted at once. The stronger side must give mate within 16 moves if they have
+ * a Rook. If they have a Bishop and a Queen the limit is 44 moves. If they
+ * have a Knight and a Queen the limit is 64 moves.
+ *
+ * \note Rules: http://aseanchess.org/laws-of-asean-chess/
+ *
+ * \sa MakrukBoard
+ *
+ */
+class LIB_EXPORT AseanBoard : public MakrukBoard
+{
+	public:
+		/*! Creates a new AseanBoard object. */
+		AseanBoard();
+
+		// Inherited from MakrukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from MakrukBoard
+		virtual QString vFenString(FenNotation notation) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual int promotionRank(int file = 0) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
+		virtual int countingLimit() const;
+		virtual CountingRules countingRules() const;
+		virtual Result result();
+};
+
+} // namespace Chess
+#endif // ASEANBOARD_H

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -43,6 +43,9 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/modernboard.cpp \
     $$PWD/shatranjboard.cpp \
     $$PWD/courierboard.cpp \
+    $$PWD/makrukboard.cpp \
+    $$PWD/oukboard.cpp \
+    $$PWD/aseanboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -92,6 +95,9 @@ HEADERS += $$PWD/board.h \
     $$PWD/modernboard.h \
     $$PWD/shatranjboard.h \
     $$PWD/courierboard.h \
+    $$PWD/makrukboard.h \
+    $$PWD/oukboard.h \
+    $$PWD/aseanboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -18,6 +18,7 @@
 #include "boardfactory.h"
 #include "andernachboard.h"
 #include "antiboard.h"
+#include "aseanboard.h"
 #include "atomicboard.h"
 #include "berolinaboard.h"
 #include "capablancaboard.h"
@@ -42,7 +43,9 @@
 #include "loopboard.h"
 #include "losersboard.h"
 #include "ncheckboard.h"
+#include "makrukboard.h"
 #include "modernboard.h"
+#include "oukboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
 #include "seirawanboard.h"
@@ -59,8 +62,10 @@ REGISTER_BOARD(FiveCheckBoard, "5check")
 REGISTER_BOARD(AndernachBoard, "andernach")
 REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
 REGISTER_BOARD(AntiBoard, "antichess")
+REGISTER_BOARD(AseanBoard, "asean")
 REGISTER_BOARD(AtomicBoard, "atomic")
 REGISTER_BOARD(BerolinaBoard, "berolina")
+REGISTER_BOARD(OukBoard, "cambodian")
 REGISTER_BOARD(CapablancaBoard, "capablanca")
 REGISTER_BOARD(CaparandomBoard, "caparandom")
 REGISTER_BOARD(ChancellorBoard, "chancellor")
@@ -83,10 +88,12 @@ REGISTER_BOARD(BerolinaGridBoard, "gridolina")
 REGISTER_BOARD(GryphonBoard, "gryphon")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
+REGISTER_BOARD(KarOukBoard,"karouk")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosersBoard, "losers")
+REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")

--- a/projects/lib/src/board/makrukboard.cpp
+++ b/projects/lib/src/board/makrukboard.cpp
@@ -1,0 +1,458 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+MakrukBoard::MakrukBoard()
+	: ShatranjBoard(),
+	  m_promotionRank(5),
+	  m_rules(Makruk),
+	  m_useWesternCounting(false),
+	  m_history()
+{
+	// King, Ferz, Rook, Knight and Pawn as in chaturanga and shatranj
+	setPieceType(Bia, tr("bia"), "P");                    //! Cowry Shell, Chip
+	setPieceType(Ma, tr("ma"), "N", KnightMovement);      //! Horse
+	//! Khon (Base) replaces Alfil (Bishop): moves as Shogi's Silver General
+	setPieceType(Khon, tr("khon"), "S", SilverGeneralMovement, "E");
+	setPieceType(Rua, tr("rua"), "R", RookMovement);      //! Boat
+	setPieceType(Met, tr("met"), "M", FerzMovement, "F"); //! Grain: Advisor
+	setPieceType(Khun, tr("khun"), "K");                  //! Leader, Lord
+}
+
+Board* MakrukBoard::copy() const
+{
+	return new MakrukBoard(*this);
+}
+
+QString MakrukBoard::variant() const
+{
+	return "makruk";
+}
+
+QString MakrukBoard::defaultFenString() const
+{
+	return "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1";
+}
+
+int MakrukBoard::promotionRank(int) const
+{
+	return 5; // counting from zero
+}
+
+MakrukBoard::CountingRules MakrukBoard::countingRules() const
+{
+	return Makruk;
+}
+
+inline void rotateAndStoreOffsets(QVarLengthArray<int> a[2])
+{
+	a[Side::Black].resize(a[Side::White].size());
+	for (int i = 0; i < a[Side::White].count(); i++)
+		a[Side::Black][i] = -a[Side::White][i];
+}
+
+void MakrukBoard::initHistory()
+{
+	MoveData md {false, 0, 0, 0, {}};
+	m_history.clear();
+	m_history.append(md);
+}
+
+void MakrukBoard::vInitialize()
+{
+	ShatranjBoard::vInitialize();
+
+	m_promotionRank = promotionRank();
+	m_rules = countingRules();
+	initHistory();
+
+	/*
+	 * The Silver General does not have dyad (C_2, 180 degrees) rotation
+	 * symmetric movement, so offsets are different for White and Black
+	 */
+	int arwidth = width() + 2;
+	m_silverGeneralOffsets[Side::White].resize(5);
+	m_silverGeneralOffsets[Side::White][0] = -arwidth - 1;
+	m_silverGeneralOffsets[Side::White][1] = -arwidth + 1;
+	m_silverGeneralOffsets[Side::White][2] = arwidth - 1;
+	m_silverGeneralOffsets[Side::White][3] = arwidth + 1;
+	m_silverGeneralOffsets[Side::White][4] = -arwidth;
+
+	rotateAndStoreOffsets(m_silverGeneralOffsets);
+}
+
+void MakrukBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	if (pieceHasMovement(pieceType, SilverGeneralMovement))
+		generateHoppingMoves(square, m_silverGeneralOffsets[sideToMove()], moves);
+
+	if (pieceType != Bia)
+		return ShatranjBoard::generateMovesForPiece(moves, pieceType, square);
+
+	generatePawnMoves(square, moves);
+}
+
+void MakrukBoard::generatePawnMoves(int square,
+				    QVarLengthArray< Move >& moves) const
+{
+	// Generate moves for pawn (bia)
+	QVarLengthArray< Move > moves1;
+	ShatranjBoard::generateMovesForPiece(moves1, Bia, square);
+
+	Side side = sideToMove();
+	int arwidth = width() + 2;
+
+	// Add moves, promote pawn (bia) to ferz (met) when reaching the
+	// promotion rank
+	for (const Move m: moves1)
+	{
+		int rank = height() + 1 - m.targetSquare() / arwidth;
+		int rrank = (side == Side::White) ? rank : height() - 1 - rank;
+
+		if (rrank < m_promotionRank)
+			moves.append(m);
+		else if (m.promotion() != 0)
+			moves.append(m);
+		else
+			addPromotions(square, m.targetSquare(), moves);
+	}
+}
+
+bool MakrukBoard::inCheck(Side side, int square) const
+{
+	Piece piece;
+	Side opSide = side.opposite();
+	if (square == 0)
+		square = kingSquare(side);
+
+	// Silver General Attacks attacks (by Khon)
+	for (int i = 0; i < m_silverGeneralOffsets[side].size(); i++)
+	{
+		piece = pieceAt(square + m_silverGeneralOffsets[side][i]);
+		if (piece.side() == opSide
+		&&  pieceHasMovement(piece.type(), SilverGeneralMovement))
+			return true;
+	}
+	return ShatranjBoard::inCheck(side, square);
+}
+
+void MakrukBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	int capture = captureType(move);
+	Piece piece = pieceAt(move.sourceSquare());
+	int type = piece.type();
+
+	ShatranjBoard::vMakeMove(move, transition);
+
+	m_history.append(m_history.last());
+	MoveData& md = m_history.last();
+
+	md.totalPlies++;
+	if (md.countingLimit > 0)
+		md.plyCount++;
+
+	Side side = sideToMove();
+	Side opp = side.opposite();
+
+	// update piece counters
+	if (capture != Piece::NoPiece)
+	{
+		md.pieceCount[capture][opp]--;
+		md.pieceCount[Piece::NoPiece][opp]--;
+	}
+
+	int promotion = move.promotion();
+	if (promotion != Piece::NoPiece)
+	{
+		md.pieceCount[type][side]--;
+		md.pieceCount[promotion][side]++;
+	}
+
+	// Makruk: Allow counting only if there are no Pawns (Chip, Bia)
+	bool noPawns = (0 == pieceCount(Side::NoSide, Bia));
+
+	// Bare King: Start Pieces' Honour Counting
+	if (!md.piecesHonour
+	&&  (pieceCount(opp) < 2 || pieceCount(side) < 2)
+	&&  (m_rules == BareKing || noPawns))
+	{
+		md.piecesHonour = true;
+		md.plyCount = 2 * pieceCount();
+		md.countingLimit = noPawns ? 2 * countingLimit() : 2 * 64;
+	}
+
+	// No Pawns: Start Board's Honour Counting for Makruk
+	if (!md.piecesHonour
+	&&  noPawns && m_rules == Makruk && md.countingLimit <= 0)
+	{
+		md.plyCount = 0;
+		md.countingLimit = 2 * 64;
+	}
+}
+
+void MakrukBoard::vUndoMove(const Move& move)
+{
+	ShatranjBoard::vUndoMove(move);
+	m_history.pop_back();
+}
+
+/*!
+ * When using Makruk counting rules (no Western counting)
+ *
+ * - This method sets the castling rights field to "-" for Makruk.
+ * - The ep field is replaced by the counting limit (in plies).
+ * - Makruk ply counting replaces the reversible move count.
+ * - This method uses an own total ply counter to keep track of the
+ *   full move count.
+ *
+ *   Examples:
+ *   Default FEN: rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1
+ *   KSSMvK black mates: 8/8/2m5/s7/8/1k6/1s6/1K6 w - 44 38 182
+ */
+QString MakrukBoard::vFenString(Board::FenNotation notation) const
+{
+	if (m_useWesternCounting)
+		return WesternBoard::vFenString(notation);
+
+	const MoveData md = m_history.last();
+	QString fen = "- " + QString::number(md.countingLimit);
+	fen.append(' ').append(QString::number(md.plyCount));
+	fen.append(' ').append(QString::number(1 + md.totalPlies / 2));
+	return fen;
+}
+
+/*!
+ * This method reads FEN with full Makruk/Ouk counting support (A),
+ * standard FEN (B), and short FEN-like notation without castling
+ * rights and en passant fields (C).
+ * The latter two use Western counting and ignore Makruk counting.
+ *
+ * A: rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1
+ *
+ * B: rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - - 0 1
+ * C: rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w 0 1
+ *
+ * FEN with Ouk initial move rights instead of castling rights are
+ * supported by OukBoard. Format C does not carry this information.
+ * Also see \a OukBoard.
+ *
+ */
+bool MakrukBoard::vSetFenString(const QStringList& inputFen)
+{
+	m_useWesternCounting = false;
+
+	if (!WesternBoard::vSetFenString(inputFen))
+		return false;
+
+	// Remove empty parts from QStringList
+	const QStringList fen = inputFen.filter(QRegExp("^\\S+"));
+	int fensize = fen.size();
+
+	// Does not match any expected format
+	if (fensize <= 1 || fensize == 3)
+		return false;
+
+	// Count all pieces
+	initHistory();
+	setAllPieceCounters();
+
+	// Short FEN format or normal ep field "-" turn off Makruk counting
+	bool ok = true;
+	int tmp = (fen.count() > 1) ? fen.at(1).toInt(&ok) : 0;
+	if (!ok || fensize == 2)
+	{
+		m_useWesternCounting = true;
+		return true;
+	}
+
+	// Makruk counting limit (in plies) instead of en passant field
+	MoveData &md = m_history.last();
+	md.countingLimit = tmp;
+
+	// Makruk counting plies instead of irreversible half move count
+	tmp = (fen.count() > 2) ? fen.at(2).toInt(&ok) : 0;
+	if (!ok)
+		return false;
+	md.plyCount = tmp;
+
+	// This implementation uses a total ply counter of its own
+	tmp = (fen.count() > 3) ? fen.at(3).toInt(&ok) : 1;
+	if (!ok)
+		return false;
+
+	md.totalPlies = 2 * (tmp - 1);
+	if (sideToMove() == Side::Black)
+		md.totalPlies++;
+
+	// Reconstruction of md.piecesHonour, see vMakeMove
+	bool noPawns = (0 == pieceCount(Side::NoSide, Bia));
+	if ((pieceCount(Side::White) < 2 || pieceCount(Side::Black) < 2)
+	&&  (m_rules == BareKing || noPawns))
+	{
+		md.piecesHonour = true;
+	}
+
+	return true;
+}
+
+void MakrukBoard::setAllPieceCounters()
+{
+	MoveData& md = m_history.last();
+	int maxindex = arraySize();
+	for (int i = 0;  i < maxindex; ++i)
+	{
+		Piece piece = pieceAt(i);
+		if (!piece.isValid())
+			continue;
+
+		Side side = piece.side();
+		md.pieceCount[piece.type()][side]++;
+		md.pieceCount[Piece::NoPiece][side]++;
+	}
+}
+
+int MakrukBoard::material() const
+{
+	// Insufficient mating material?
+	int material = 0;
+	bool mets[] = { false, false };
+	for (int i = 0; i < arraySize(); i++)
+	{
+		const Piece& piece = pieceAt(i);
+		if (!piece.isValid())
+			continue;
+
+		switch (piece.type())
+		{
+		case Met:  // Advisor (Ferz), Queen
+		{
+			material+= 1;
+			auto color = chessSquare(i).color();
+			if (color != Square::NoColor && !mets[color])
+			{
+				material += 2;
+				mets[color] = true;
+			}
+			break;
+		}
+		case Ma:  // Horse, Knight
+			material += 4;
+			break;
+		default:
+			material += 9;
+			break;
+		}
+	}
+	return material;
+}
+
+bool MakrukBoard::insufficientMaterial() const
+{
+	return material() < 25;
+}
+
+int MakrukBoard::pieceCount(Side side, int pieceType) const
+{
+	const MoveData & md = m_history.last();
+	if (side == Side::NoSide)
+		return md.pieceCount[pieceType][Side::White]
+		     + md.pieceCount[pieceType][Side::Black];
+	else
+		return md.pieceCount[pieceType][side];
+}
+
+int MakrukBoard::countingLimit() const
+{
+	Side side = sideToMove();
+	int rooks = pieceCount(side, Rua);
+	if (rooks > 1)
+		return 8;
+	if (rooks == 1)
+		return 16;
+	int khons = pieceCount(side, Khon);
+	if (khons > 1)
+		return 22;
+	if (pieceCount(side, Ma) > 1)
+		return 32;
+	if (khons == 1)
+		return 44;
+
+	return 64;
+}
+
+Result MakrukBoard::resultFromCounting() const
+{
+	const MoveData md = m_history.last();
+
+	if (md.countingLimit > 0
+	&&  md.plyCount >= md.countingLimit)
+	{
+		QString str = md.piecesHonour ? tr("Draw by counting rules.")
+					      : tr("Draw by sixty-four move rule.");
+		return Result(Result::Draw, Side::NoSide, str );
+	}
+	return Result();
+}
+
+Result MakrukBoard::result()
+{
+	QString str;
+	Side side = sideToMove();
+	Side opp = side.opposite();
+
+	// Checkmate/Stalemate
+	if (!canMove())
+	{
+		if (inCheck(side))
+		{
+			str = tr("%1 mates").arg(opp.toString());
+			return Result(Result::Win, opp, str);
+		}
+		else
+		{
+			str = tr("Draw by stalemate");
+			return Result(Result::Draw, Side::NoSide, str);
+		}
+	}
+
+	// Insufficent material: KvK, KMvK. KMMvK, KNvK
+	if (insufficientMaterial())
+	{
+		str = tr("Draw by insufficient mating material");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// Main path: result from Makruk counting
+	if (!m_useWesternCounting)
+		return resultFromCounting();
+
+	// Fallback: Western counting - 50 move rule
+	if (reversibleMoveCount() >= 100)
+	{
+		str = tr("Draw by fifty move rule");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/makrukboard.h
+++ b/projects/lib/src/board/makrukboard.h
@@ -1,0 +1,191 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MAKRUKBOARD_H
+#define MAKRUKBOARD_H
+
+#include "shatranjboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Makruk (Thai Chess)
+ *
+ * Makruk Chess is a variant of chess popular and with a long tradition
+ * in Thailand. It is very similar to Ouk Cha Trang (Cambodian Chess).
+ *
+ * The Pawn, Knight, Rook, Ferz, and King are all traditional pieces with
+ * movements known from Chaturanga and Shatranj. In Makruk these pieces
+ * are named differently (with other meanings).
+ *
+ * The Elephant (Gaja, Alfil) was replaced by the Khon (Base) which moves
+ * like Shogi's Silver General: 1 square diagonally or 1 square forward.
+ * Met is the Thai name of the Ferz which only moves 1 square diagonally.
+ *
+ * Makruk has no Pawn double step option and no castling. When reaching the
+ * own sixth rank a Pawn (Bia, shell) is promoted to Ferz (Met, grain).
+ *
+ * Like in standard chess giving mate wins, stalemate is a draw, and two bare
+ * kings is a draw. If there is (obviously) not enough material to force a win,
+ * the game will be drawn.
+ *
+ * There is no fifty-move rule. When the last Pawn on the board is captured
+ * or promoted the game must be won within 64 moves else the game is drawn.
+ *
+ * A new counting overrides when there are no Pawns on the board and a side
+ * is left with no pieces besides their "bare" King. The starting count equals
+ * 1 plus the number of pieces.
+ *
+ * The counting limit depends on the stronger side:
+ * If they have 2 Rooks (with or without other pieces) it is 8 moves,
+ * 1 Rook: 16 moves, 2 Khons: 22 moves, 2 Knights: 32 moves, 1 Khon: 44 moves,
+ * else 64 moves. When the count *exceeds* the limit the game is drawn.
+ * There is no counting as long as there are any unpromoted pawns on the board.
+ *
+ * Example: For KRRNP vs K the weaker side will count their moves 7 (= 1 + 6)
+ * and 8 (the limit defined by 2 Rooks), and if they have a legal move at
+ * count 9 the game will end in a draw.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Makruk_chess
+ *
+ * \sa ShatranjBoard
+ * \sa OukBoard
+ *
+ * \note This implementation can read and write positions in FEN standard
+ * notation and per default an adapted FEN notation where the fields have
+ * Makruk/Ouk specific meanings to support the counting rules:
+ * The castling field is present but unused in Makruk - it is used for initial
+ * move status in Ouk. The en passant field "-" is replaced by the active
+ * Makruk counting limit in plies. The half move count gives a ply count
+ * according to endgame counting rules instead of the reversible ply count
+ * of standard chess.
+ */
+class LIB_EXPORT MakrukBoard : public ShatranjBoard
+{
+	public:
+		/*! Creates a new MakrukBoard object. */
+		MakrukBoard();
+
+		// Inherited from ShatranjBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		/*! Piece types for Makruk */
+		enum MakrukPieceType
+		{
+			Bia    = Pawn,	  //!< Shell, Chip
+			Ma     = Knight,  //!< Horse
+			Khon   = Bishop,  //!< Base, replaces Alfil
+			Rua    = Rook,	  //!< Boat
+			Met    = Queen,	  //!< Grain: Mantri, Ferz, Advisor
+			Khun   = King	  //!< Leader, Chief
+		};
+
+		/*! Khon moves like Silver General. */
+		static const unsigned SilverGeneralMovement = 256;
+		/*!
+		 * Returns the relative rank of pawn promotions counting from
+		 * 0 for the first rank. The default returns 5 for promotions
+		 * on the sixth rank. The formal \a file parameter is unused.
+		 * Override this method if the promotion rank is not uniform.
+		 *
+		 * \sa SittuyinBoard
+		 */
+		virtual int promotionRank(int file = 0) const;
+		/*!
+		 * Returns the number of pieces of \a side and of \a pieceType.
+		 * NoPiece as \a pieceType counts all pieces of \a side.
+		 * This is the default. If \a side is set to NoSide then the
+		 * count of all pieces of \a pieceType is given.
+		 * A call without arguments returns the total piece count.
+		 */
+		int pieceCount(Side side = Side::NoSide,
+			       int pieceType = Piece::NoPiece) const;
+		/*!
+		 * Returns maximum count of plies allowed to finish the game:
+		 * Limit for Board's Honour or Pieces' Honour counting.
+		 */
+		virtual int countingLimit() const;
+		/*!
+		 * Rule sets of Thai and Cambodian Chess
+		 */
+		enum CountingRules {Makruk, BareKing};
+		/*!
+		 * Returns type of counting rules to apply. Default: Makruk.
+		 * \sa OukBoard
+		 */
+		virtual CountingRules countingRules() const;
+		/*!
+		 * Initialize counter history
+		 */
+		void initHistory();
+		/*!
+		 * Counts all pieces on the board and updates all counters
+		 * of last MoveData entry in move history.
+		 */
+		void setAllPieceCounters();
+		/*!
+		 * Returns game result based on specific counting rules
+		 */
+		Result resultFromCounting() const;
+		/*!
+		 * Appends generated pseudo-legal pawn moves to \a moves
+		 */
+		virtual void generatePawnMoves(int sourceSquare,
+				       QVarLengthArray<Move>& moves) const;
+		/*!
+		 * Returns true if material on board is known to be not
+		 * sufficient to enforce mate, else false.
+		 */
+		bool insufficientMaterial() const;
+
+		// Inherited from ShatranjBoard
+		virtual void vInitialize();
+		virtual QString vFenString(FenNotation notation) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+
+	private:
+		QVarLengthArray<int> m_silverGeneralOffsets[2];
+		int m_promotionRank;
+		enum CountingRules m_rules;
+		bool m_useWesternCounting;
+		// Data for reversing/unmaking a move
+		struct MoveData
+		{
+			bool piecesHonour;
+			int countingLimit;
+			int plyCount;
+			int totalPlies;
+			int pieceCount[King + 1][2];
+		};
+		QVarLengthArray<MoveData> m_history;
+
+		int material() const;
+};
+
+} // namespace Chess
+#endif // MAKRUKBOARD_H

--- a/projects/lib/src/board/oukboard.cpp
+++ b/projects/lib/src/board/oukboard.cpp
@@ -1,0 +1,254 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "oukboard.h"
+
+namespace Chess {
+
+OukBoard::OukBoard()
+	: MakrukBoard(),
+	  m_initialSquare{{{King, 94},{Maiden, 95}},{{King, 25},{Maiden, 24}}},
+	  m_initialOffsets{{King, 8}, {King, 12}, {Maiden, 20}},
+	  m_moveCount{}
+{
+	// Movements as in chaturanga and shatranj, except Alfil -> Koul (Base, Pillar)
+	setPieceType(Fish, tr("trey"), "P");                       //! Pawn
+	setPieceType(Horse, tr("ses"), "N", KnightMovement);       //! Knight
+	setPieceType(Pillar, tr("kol"), "S", SilverGeneralMovement, "E"); //! replaces Alfil
+	setPieceType(Boat, tr("tuuk"), "R", RookMovement);         //! Rook
+	setPieceType(Maiden, tr("neang"), "M", FerzMovement, "F"); //! Queen, Counselor, Mantri, Met
+	setPieceType(King, tr("sdaach"), "K");                     //! King
+}
+
+Board* OukBoard::copy() const
+{
+	return new OukBoard(*this);
+}
+
+QString OukBoard::variant() const
+{
+	return "cambodian";
+}
+
+QString OukBoard::defaultFenString() const
+{
+	return "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w DEde 0 0 1";
+}
+
+MakrukBoard::CountingRules OukBoard::countingRules() const
+{
+	return BareKing;
+}
+
+/*!
+ * Ouk Chatrang has special initial moves for King (Ang) and Maiden (Neang).
+ * The initial files of unmoved Kings and Maidens are listed in the castling
+ * field of the FEN. So it is status "DEde" for the starting position.
+ */
+QString OukBoard::vFenString(Board::FenNotation notation) const
+{
+	const QString vfs = MakrukBoard::vFenString(notation);
+
+	// Set castling rights string
+	QString castlingStr;
+	if (m_moveCount[Side::White][King] == 0)
+		  castlingStr.append('D');
+	if (m_moveCount[Side::White][Maiden] == 0)
+		  castlingStr.append('E');
+	if (m_moveCount[Side::Black][Maiden] == 0)
+		  castlingStr.append('d');
+	if (m_moveCount[Side::Black][King] == 0)
+		  castlingStr.append('e');
+
+	QStringList vfen = vfs.split(' ', QString::SkipEmptyParts);
+
+	// Append the rest of the FEN string
+	QString s = (!castlingStr.isEmpty() ? castlingStr : "-");
+	for (int i = 1; i < vfen.count(); i++)
+		s.append(" ").append(vfen.at(i));
+
+	return s;
+}
+
+bool OukBoard::parseCastlingRights(QChar c)
+{
+	if (c == '-')
+		return true;
+
+	const QString tokens("DEde");
+	if (tokens.indexOf(c) < 0)
+		return false;
+
+	// Enable initial moves by clearing matching move count
+	if (c == 'D')
+		m_moveCount[Side::White][King] = 0;
+	else if (c == 'E')
+		m_moveCount[Side::White][Maiden] = 0;
+	else if (c == 'd')
+		m_moveCount[Side::Black][Maiden] = 0;
+	else if (c == 'e')
+		m_moveCount[Side::Black][King] = 0;
+
+	return true;
+}
+
+bool OukBoard::vSetFenString(const QStringList& fen)
+{
+	// At first assume that King and Maiden pieces have moved
+	m_moveCount[Side::White][King] = 1;
+	m_moveCount[Side::Black][King] = 1;
+	m_moveCount[Side::White][Maiden] = 1;
+	m_moveCount[Side::Black][Maiden] = 1;
+
+	// parseCastlingRights is called via vSetFenString of base class
+	if (!MakrukBoard::vSetFenString(fen))
+		return false;
+
+	// Expect pieces on their initial squares if move counter is zero
+	const OukPieceType types[2]{King, Maiden};
+	for (int side = Side::White; side <= Side::Black; side++)
+	{
+		for (auto type: types)
+		{
+			int index = m_initialSquare[side][type];
+			if ( m_moveCount[side][type] == 0
+			&&   pieceAt(index) != Piece(Side::Type(side), type))
+				return false;
+		}
+	}
+	return true;
+}
+
+void OukBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	MakrukBoard::generateMovesForPiece(moves, pieceType, square);
+
+	Side side = sideToMove();
+
+	// Only consider King and Neang on their initial squares
+	if ((pieceType != King || square != m_initialSquare[side][King])
+	&&  (pieceType != Maiden || square != m_initialSquare[side][Maiden]))
+		return;
+	// Return if the piece has moved already
+	if (m_moveCount[side].value((OukPieceType)pieceType, -1) != 0)
+		return;
+	// No special moves for King in check
+	if (pieceType == King && inCheck(side))
+		return;
+
+	// Generate initial move option for King (leap of Horse)
+	// and for Neang (forward two squares)
+	int sign = (side == Side::White) ? 1 : -1;
+
+	for (const auto& i: m_initialOffsets)
+	{
+		if (pieceType != i.type)
+			continue;
+
+		int target = square - i.offset * sign;
+		const Piece& piece = pieceAt(target);
+
+		if  (piece.isEmpty())
+			moves.append(Move(square, target));
+	}
+}
+
+bool OukBoard::inCheck(Side side, int square) const
+{
+	int sign = (side == Side::White) ? 1 : -1;
+	Side opSide = side.opposite();
+	if (square == 0)
+		square = kingSquare(side);
+
+	// Attack by Advisor (Maiden, Neang), initial move
+	if (!m_moveCount[opSide][Maiden]
+	&&  m_initialSquare[opSide][Maiden] == square - 2 * sign * (width() + 2))
+		return true;
+
+	// Attack by King, initial move
+	int ksq = kingSquare(opSide);
+	bool attacked = (ksq == square - 8 * sign || ksq == square - 12 * sign);
+
+	if (!m_moveCount[opSide][King] && attacked)
+	{
+		if (square == kingSquare(side)
+		|| !inCheck(opSide))
+			return true;
+	}
+	return MakrukBoard::inCheck(side, square);
+}
+
+void OukBoard::updateCounter(Move m, int increment)
+{
+	Side side = sideToMove();
+	int source = m.sourceSquare();
+	int target= m.targetSquare();
+
+	if (source == m_initialSquare[side][King]
+	||  target == m_initialSquare[side][King])
+		m_moveCount[side][King] += increment;
+
+	if (source == m_initialSquare[side][Maiden]
+	||  target == m_initialSquare[side][Maiden])
+		m_moveCount[side][Maiden] += increment;
+}
+
+void OukBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	MakrukBoard::vMakeMove(move, transition);
+	updateCounter(move, +1);
+}
+
+void OukBoard::vUndoMove(const Move& move)
+{
+	updateCounter(move, -1);
+	MakrukBoard::vUndoMove(move);
+}
+
+
+
+KarOukBoard::KarOukBoard(): OukBoard(){}
+
+Board* KarOukBoard::copy() const
+{
+	return new KarOukBoard(*this);
+}
+
+QString KarOukBoard::variant() const
+{
+	return "karouk";
+}
+
+QString KarOukBoard::defaultFenString() const
+{
+	return "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w DEde 0 0 1";
+}
+
+Result KarOukBoard::result()
+{
+	Side side = sideToMove();
+	if (!inCheck(side))
+		return OukBoard::result();
+
+	Side opp = side.opposite();
+	QString str = tr("%1 wins by giving check").arg(opp.toString());
+	return Result(Result::Win, opp, str);
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/oukboard.h
+++ b/projects/lib/src/board/oukboard.h
@@ -1,0 +1,119 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OUKBOARD_H
+#define OUKBOARD_H
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Ouk Chatrang (Ouk Khmer, Cambodian Chess)
+ *
+ * Ouk Chatrang is a variant of chess popular and with a long tradition
+ * in Cambodia. It is closely related to Chaturanga and Makruk.
+ *
+ * Cambodian Chess (Ouk) and Thai Chess (Makruk) are essentially the same game,
+ * but the pieces are named differently.
+ *
+ * Ouk has additional moves, which have been abandoned in Makruk:
+ *
+ * The King has the option to make an initial leap sideways like a Horse
+ * (Knight), but only if not in check. The Advisor (Maiden, Neang) may leap
+ * straight forward two squares on its initial move. These moves cannot capture.
+ *
+ * \note Rules: http://history.chess.free.fr/cambodian/Cambodian%20Chess%20Games.htm
+ *              http://www.khmerinstitute.com/culture/ok.html
+ *
+ * \sa MakrukBoard
+ * \sa ShatranjBoard
+ *
+ */
+class LIB_EXPORT OukBoard : public MakrukBoard
+{
+	public:
+		/*! Creates a new OukBoard object. */
+		OukBoard();
+
+		// Inherited from MakrukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Piece types for ouk variants. */
+		enum OukPieceType
+		{
+			Fish = Pawn,	//!< Trey, Trei
+			Horse = Knight,	//!< Ses, Se
+			Pillar = Bishop,//!< Kol, Koul
+			Boat = Rook,	//!< Tuuk
+			Maiden = Queen,	//!< Neang (Met)
+			King		//!< Sdaach, Ang
+		};
+
+		// Inherited from MakrukBoard
+		virtual CountingRules countingRules() const;
+		virtual bool parseCastlingRights(QChar c);
+		virtual QString vFenString(FenNotation notation) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+
+	private:
+		void updateCounter(Move m, int increment);
+		const QMap<OukPieceType, int>m_initialSquare[2];
+		const struct
+		{
+			OukPieceType type;
+			int offset;
+		} m_initialOffsets[3];
+		QMap<OukPieceType, int> m_moveCount[2];
+};
+
+
+/*!
+ * \brief A board for Kar Ouk
+ *
+ * Kar Ouk is a variant of Ouk Chatrang. It has been popular in Cambodia.
+ * In this variant the side that gives check to their opponent wins.
+ *
+ * \sa OukBoard
+ *
+ */
+
+class LIB_EXPORT KarOukBoard : public OukBoard
+{
+	public:
+		/*! Creates a new KarOukBoard object. */
+		KarOukBoard();
+
+		// Inherited from OukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+};
+
+} // namespace Chess
+#endif // OUKBOARD_H

--- a/projects/lib/src/board/shatranjboard.h
+++ b/projects/lib/src/board/shatranjboard.h
@@ -99,7 +99,6 @@ class LIB_EXPORT ShatranjBoard : public WesternBoard
 		int m_arwidth;
 		QVarLengthArray<int> m_ferzOffsets;
 		QVarLengthArray<int> m_alfilOffsets;
-		int pieceCount(Side side) const;
 		bool bareKing(Side side, int count = 0) const;
 };
 

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -443,7 +443,56 @@ void tst_Board::moveStrings_data() const
 		<< "e1c1 e8g8"
 		<< "r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R[EHeh] w KQkq - 0 1"
 		<< "r4rk1/pppppppp/8/8/8/8/PPPPPPPP/2KR3R[EHeh] w aH - 2 2";
-
+	QTest::newRow("makruk lan1a")
+		<< "makruk"
+		<< "e3e4 b8d7 b3b4 a6a5 c1b2 h6h5 f1g2 h5h4 g3h4 h8h4 g2g3 h4h7"
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1"
+		<< "r1smksn1/3n3r/1pppppp1/p7/1P2P3/P1PP1PSP/1S6/RN1KM1NR w - 0 0 7";
+	QTest::newRow("makruk san1a")
+		<< "makruk"
+		<< "e4 Nd7 b4 a5 Sb2 h5 Sg2 h4 gxh4 Rxh4 Sg3 Rh7"
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1"
+		<< "r1smksn1/3n3r/1pppppp1/p7/1P2P3/P1PP1PSP/1S6/RN1KM1NR w - 0 0 7";
+	QTest::newRow("makruk san1b")
+		<< "makruk"
+		<< "e4 Nd7 b4 a5 Sb2 h5 Sg2 h4 gxh4 Rxh4 Sg3 Rh7"
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - - 0 1"
+		<< "r1smksn1/3n3r/1pppppp1/p7/1P2P3/P1PP1PSP/1S6/RN1KM1NR w - - 2 7";
+	QTest::newRow("makruk pawn promotion, board's honour counting")
+		<< "makruk"
+		<< "h3=M"
+		<< "6r1/3M2k1/1M1K4/3N1M1R/7p/6m1/8/8 b - 0 0 93"
+		<< "6r1/3M2k1/1M1K4/3N1M1R/8/6mm/8/8 w - 128 0 94";
+	QTest::newRow("makruk board's to pieces' honour counting")
+		<< "makruk"
+		<< "Rxd6+ Nxd6"
+		<< "8/5M2/2rM1K1k/5M2/4N1R1/8/8/8 b - 128 33 110"
+		<< "8/5M2/3N1K1k/5M2/6R1/8/8/8 b - 32 12 111";
+	QTest::newRow("cambodian san1")
+		<< "cambodian"
+		<< "e4 d5 Me3 Md6 Kb2 Kg7"
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w DEde 0 0 1"
+		<< "rns2snr/6k1/pppmpppp/3p4/4P3/PPPPMPPP/1K6/RNS2SNR w - 0 0 4";
+	QTest::newRow("asean san1b")
+		<< "asean"
+		<< "e4 Nd7 b4 a5 Bb2 h5 Bg2 h4 gxh4 Rxh4 Bg3 Rh7"
+		<< "rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBKQBNR w - - 0 1"
+		<< "r1bqkbn1/3n3r/1pppppp1/p7/1P2P3/P1PP1PBP/1B6/RN1KQ1NR w - - 2 7";
+	QTest::newRow("asean san2 promotion")
+		<< "asean"
+		<< "h8=R Kc3"
+		<< "8/7P/6K1/5R2/1k6/8/4b3/8 w - - 0 1"
+		<< "7R/8/6K1/5R2/8/2k5/4b3/8 w - - 1 2";
+	QTest::newRow("asean san3 pawn move")
+		<< "asean"
+		<< "h3 Nf1"
+		<< "6k1/8/6p1/N5b1/5b1p/8/3NK3/8 b - - 0 1"
+		<< "6k1/8/6p1/N5b1/5b2/7p/4K3/5N2 b - - 1 2";
+	QTest::newRow("asean san4 no threefold rep adjudicated")
+		<< "asean"
+		<< "Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3"
+		<< "8/8/8/4K3/8/1kq5/8/8 w - - 0 1"
+		<< "8/8/8/4K3/8/1kq5/8/8 w - - 16 9";
 }
 
 void tst_Board::moveStrings()
@@ -740,6 +789,77 @@ void tst_Board::results_data() const
 		<< variant
 		<< "12/4k7/5W6/12/4K7/11E/12/12 b - - 0 1"
 		<< "1-0";
+
+	variant = "makruk";
+
+	QTest::newRow("makruk white win /w pawns: no counting")
+		<< variant
+		<< "7R/6Mk/5S2/7P/Pp6/8/2mnr3/K7 b - 0 0 129"
+		<< "1-0";
+
+	QTest::newRow("makruk black win KNMvsK")
+		<< variant
+		<< "8/8/8/8/8/5nk1/6m1/6K1 w - 128 56 213"
+		<< "0-1";
+
+	QTest::newRow("makruk full count black win KRvKM")
+		<< variant
+		<< "8/8/8/8/8/6k1/8/M1r3K1 w - 128 128 115"
+		<< "0-1";
+
+	QTest::newRow("makruk board's honour draw KRvKM")
+		<< variant
+		<< "2r5/8/8/8/8/1k6/6K1/M7 b - 128 128 125"
+		<< "1/2-1/2";
+
+	QTest::newRow("makruk board's honour draw KSMvKS")
+		<< variant
+		<< "8/8/8/4S3/2k1K3/1s6/7M/8 b - 128 128 236"
+		<< "1/2-1/2";
+
+	QTest::newRow("makruk KNvK insufficient material")
+		<< variant
+		<< "8/8/1k6/3K4/8/3N4/8/8 b - 128 6 105"
+		<< "1/2-1/2";
+
+	QTest::newRow("makruk KMMvK insufficient material")
+		<< variant
+		<< "8/8/6MM/8/8/2K5/k7/8 b - 128 8 99"
+		<< "1/2-1/2";
+
+	QTest::newRow("makruk KMMvK win overrides insufficient material")
+		<< variant
+		<< "8/5KMk/6M1/8/8/8/8/8 b - 128 8 75"
+		<< "1-0";
+
+	QTest::newRow("makruk KSMvK pieces' honour white win")
+		<< variant
+		<< "8/5KMk/7S/8/8/8/8/8 b - 88 52 174"
+		<< "1-0";
+
+	QTest::newRow("makruk KRRvK pieces' honour white win")
+		<< variant
+		<< "8/8/8/2K1k3/8/4RR2/8/8 b - 16 14 128"
+		<< "1-0";
+
+	QTest::newRow("makruk KRRvK pieces' honour ongoing")
+		<< variant
+		<< "8/8/8/2K1k3/8/3R1R2/8/8 w - 16 13 128"
+		<< "*";
+
+	variant = "karouk";
+
+	QTest::newRow("karouk KRRvKM black wins by check")
+		<< variant
+		<< "8/8/8/2K1k3/3m4/3R1R2/8/8 w - 128 13 128"
+		<< "0-1";
+
+	variant = "asean";
+
+	QTest::newRow("asean KQvK insufficient material")
+		<< variant
+		<< "8/8/8/5K2/1q6/8/8/k7 w - - 0 71"
+		<< "1/2-1/2";
 }
 
 void tst_Board::results()
@@ -1141,6 +1261,32 @@ void tst_Board::perft_data() const
 		<< "rnebmk1wbenr/1ppppp1pppp1/6f5/p5p4p/P5P4P/6F5/1PPPPP1PPPP1/RNEBMK1WBENR w - - 0 1"
 		<< 4 // 4 plies: 500337, 5 plies: 14144849, 6 plies: 400324148
 		<< Q_UINT64_C(500337);
+
+	variant = "makruk";
+	QTest::newRow("makruk startpos")
+		<< variant
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1"
+		<< 5 // 4 plies: 273026, 5 plies: 6223994, 6 plies: 142078049
+		<< Q_UINT64_C(6223994);
+
+	variant = "cambodian";
+	QTest::newRow("cambodian startpos")
+		<< variant
+		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w DEde 0 0 1"
+		<< 4 // 4 plies: 361793, 5 plies: 8601434, 6 plies: 204755574
+		<< Q_UINT64_C(361793);
+	QTest::newRow("cambodian check1")
+		<< variant
+		<< "r1s1ks1r/3nm3/pppNpppp/3n4/5P2/PPPPPNPP/8/R1SKMS1R b DEe 0 0 5"
+		<< 2 // 1 ply: 2, 2 plies: 72 (sjaakii-1.4.1 dito)
+		<< Q_UINT64_C(72);
+
+	variant = "asean";
+	QTest::newRow("asean startpos")
+		<< variant
+		<< "rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBQKBNR w - - 0 1"
+		<< 5 // 4 plies: 273026, 5 plies: 6223994, 6 plies: 142078057
+		<< Q_UINT64_C(6223994);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
This PR adds support for South-East Asian chess:

- Makruk  (Thai Chess),
- Ouk Chatrang (Cambodian Chess)
- Kar Ouk variant
 - ASEAN-Chess

I hope this is useful.

_Ouk Chatrang_ (Cambodian Chess, Ouk Khmer) and _Makruk_ (Thai Chess) are hugely popular in their home countries. These game styles have emerged from the origins of chess many centuries ago.

The implementation of `MakrukBoard` is based on `ShatranjBoard`, because all pieces basically move like their counterparts in Chaturanga and Shatranj. One Exception is the Khon piece, which replaces the Alfil (Elephant, medieval Bishop). It can move one square diagonally or one square straight ahead. The pawns start on the third rank and promote to Met (Ferz, Advisor, medieval Queen) like in Shatranj, however the promotion already takes place on the sixth rank. 

When no unpromoted pawns are left on the board, the game will end within 64 moves.
Giving mate to the opponent King wins, stalemate draws, insufficient material leads to a draw. When a side has no pieces left besides their King, this does not cause the end of the game as in Chaturanga or Shatranj. The lone King can be chased by the opponent for a number of moves, which are counted out. The maximum move count and the starting count depend on the material present at that position. 

 Cutechess does the counting on behalf of the players (even with hindsight, as both sides are assumed to be in disadvantage when applying "Board's Honour" 64-move counting).

These Makruk counting rules are used by default. Positions are given by an adapted FEN like
`rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - 0 0 1`. The FEN comprises of the board situation, the side to move, the counting limit (in plies), the count (in plies), and the full move count.

If a standard FEN like `rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w - - 0 1` or a shortened notation like `rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w 0 1` is given then _chess counting_ will come into operation. This supports older engines without Makruk counting. Note: the fifty-move rule is in action, the three-fold repetition rule is not.

_Ouk Chatrang_ has the same rules as Makruk, but there are additional initial moves for King (Ang)  and Maiden (Neang / Advisor / Queen). This is probably the older of the two variants.

The variant _Kar Ouk_ is the same but giving check to the opponent King wins.

The modern variant _ASEAN-Chess_ tries to bridge the gap between Standard Chess and Makruk. The starting positions of the pawns and the piece movements of Makruk are used. However the piece names, promotion rules, and most other rules comply with Standard Chess. ASEAN-Chess has its own counting rules that differ from Makruk and Ouk. ASEAN-Chess has no draw rule for three-fold repetiton of positions.

The implementation of `MakrukBoard` has been tested manually and with chess engines Sjaak II, Bilis v 2.1, Fairymax 5.0b, Nebiyu Alien, SamChess MK, PyChess and the new Makruk-Stockfish, `OukBoard` has been tested with Sjaak II and Fairy-Max 5.0b, `AseanBoard` also with Sjaak II and Fairy-Max 5.0b. Sjaak II and Fairy-Max claim draws after three-fold repetition, thus forfeiting the game, because in ASEAN-Chess this rule is not in action.


Update:
- fixed signature of AseanBoard::promotionRank method
- clarified counting rules for Makruk
- prevented Kings and Neangs from capturing with initial leap in Ouk
- improved code for counting, making and undoing moves
- now it is possible to limit the total number of moves by using the game configuration (GUI) or the _-maxmoves_ option (CLI), so no need for an extra rule in `MakrukBoard`.
- implemented counting rules for Ouk Chatrang (see questions, contradicting sources)
- implemented restrictions of initial moves for Ouk Chatrang (see questions, contradicting and incomplete sources)
- implemented new FEN notation for Makruk and Ouk: supports counting rules and initial movement rights (Ouk Chatrang)
- fall back to chess counting if FEN without Makruk counters is provided
- speed up (3x) by counting all pieces only once per game
- corrected insufficient material evaluation for ASEAN-chess
- added test cases for Makruk, Ouk, ASEAN-chess and KarOuk


![mak1](https://user-images.githubusercontent.com/6425738/35295870-af8a2988-007a-11e8-8a66-98c97939ae1c.png)
_Initial position of Makruk with the standard (CBurnett) piece set_

Makruk

Counting Rules:
-Pawns present, no bare King: no counting
-**Pawns absent**, no bare King: _"Board's Honour"_ counting, 64 moves
-Pawn present,  bare King: no counting (update: probably clarified)
-**Pawns absent**, bare King: _"Pieces' Honour"_ counting based on material present when triggered, takes precedence over _"Board's Honour"_ counting, only starts once, no restart after a capture

#
Ouk Chatrang (Some sources contradict each other or are not definite):

References:
[Khmer Institute](http://www.khmerinstitute.com/culture/ok.html)
[Sourceforge Ouk - Khmer Chess](http://ouk.sourceforge.net/movement.php)
[Cambodian Chess Games](http://history.chess.free.fr/cambodian/Cambodian%20Chess%20Games.htm)
[Chhiv Bora teaching Ouk](https://www.youtube.com/watch?v=KjzKrzYbJag)

Counting Rules: **either** like Makruk rules **or rather**
-Pawns present, no bare King: like Makruk, no counting
-Pawns absent, no bare King: **no counting** in contrast to Makruk
-Pawn present,  bare King: **64 minus number of all pieces**
-Pawns absent, bare King: like Makruk

Initial Moves:

King allowed to leap two ranks forward: NO
King, Neang allowed to leap when in check: NO
King, Neang allowed to leap after a capture has been made: YES
King allowed to capture with initial leap: YES?/NO/YES?/**NO**
Neang allowed to capture with initial leap: NO/YES/YES/**NO** 


ASEAN:
http://aseanchess.org/laws-of-asean-chess/
Are the material counts for the stronger side in rule 5.2e **exact or minimal**?

#
SUPPLEMENTS (later. not subjects of this PR):
- Import of notation format KQRBNP for Makruk/Ouk (used e.g. by playok.com)
- possibly Sittuyin (Burmese Chess): This is a related game, but has different promotion rules, and has a setup phase: First the white (or rather, red) side sets their pieces and then the black (or green) side sets their pieces. 
- Makruk/Ouk graphics piece set (I used a set derived from PyChess, this needs some additional work: autoscaling problems)

![mak2](https://user-images.githubusercontent.com/6425738/35545551-ddde8154-056f-11e8-9043-077007596208.png)
_Initial position of Makruk with the Makruk piece set by @cajone - taken from PyChess and arranged for Cutechess: needs some work, and confirmation of permission (although this is GPL'ed work, I would not like to annoy the artist and the project)_
