### PR TITLE
Add zh_CN localization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,36 @@ seconds:
 See `cutechess-cli -help` for descriptions of the supported options or manuals
 for full documentation.
 
+Translation
+-----------
+
+### Get involved
+
+To help with translations, add a line after the last line of `cutechess.pro`,
+in the following format:
+
+    TRANSLATIONS += translations/cutechess_[language_code].ts
+
+Then generate the translation file by running the command:
+
+    $ lupdate cutechess.pro
+
+There will be a new file pending for translation. Edit with Qt Linguist:
+
+    $ linguist translations/cutechess_[language_code].ts
+
+If new strings are added in source code, run `lupdate` to update corresponding
+`.ts` files.
+
+### Compiling translations
+
+After finishing translation, generate the binary file with the command:
+
+    $ lrelease translations/cutechess_[language_code].ts
+
+There will be the final `.qm` file for GUI application. Place the GUI
+executable under the same path of `translations` directory.
+
 License
 -------
 

--- a/cutechess.pro
+++ b/cutechess.pro
@@ -25,3 +25,6 @@ doc-txt.commands = \
 QMAKE_EXTRA_TARGETS += doc-txt
 QMAKE_DISTCLEAN += docs/cutechess-cli.6.txt
 QMAKE_DISTCLEAN += docs/engines.json.5.txt
+
+TRANSLATIONS += \
+    translations/cutechess_zh_CN.ts

--- a/dist/windows_setup.iss
+++ b/dist/windows_setup.iss
@@ -43,6 +43,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "{#CuteChessPath}\projects\gui\cutechess.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#CuteChessPath}\projects\cli\cutechess-cli.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#CuteChessPath}\translations\cutechess_zh_CN.qm"; DestDir: "{app}\translations"; Flags: ignoreversion
 #ifdef MinGW
   Source: "{#MinGWLibPath}\mingwm10.dll"; DestDir: "{app}"; Flags: ignoreversion
   Source: "{#MinGWLibPath}\libgcc_s_dw2-1.dll"; DestDir: "{app}"; Flags: ignoreversion

--- a/translations/cutechess_zh_CN.ts
+++ b/translations/cutechess_zh_CN.ts
@@ -1,0 +1,2645 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>Board</name>
+    <message>
+        <location filename="../projects/lib/src/board/board.cpp" line="28"/>
+        <source>Zobrist key</source>
+        <translation>Zobrist 键值</translation>
+    </message>
+</context>
+<context>
+    <name>BookExportTask</name>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="144"/>
+        <source>Export Opening Book</source>
+        <translation>导出开局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="145"/>
+        <source>Parsing %1 PGN games</source>
+        <translation>正在分析 %1 场 PGN 对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="180"/>
+        <source>Writing opening book to disk</source>
+        <translation>正在将开局库写入磁盘</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::AntiBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/antiboard.cpp" line="112"/>
+        <source>%1 wins</source>
+        <translation>%1胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/antiboard.cpp" line="126"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/antiboard.cpp" line="133"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::AtomicBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/atomicboard.cpp" line="177"/>
+        <source>%1&apos;s king exploded</source>
+        <translation>%1的王爆炸了</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::CapablancaBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/capablancaboard.cpp" line="26"/>
+        <source>archbishop</source>
+        <translation>大主教</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/capablancaboard.cpp" line="27"/>
+        <source>chancellor</source>
+        <translation>首相</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::ChancellorBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/chancellorboard.cpp" line="27"/>
+        <source>chancellor</source>
+        <translation>首相</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::CourierBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/courierboard.cpp" line="27"/>
+        <source>bishop</source>
+        <translation>象</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/courierboard.cpp" line="28"/>
+        <source>queen</source>
+        <translation>后</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/courierboard.cpp" line="30"/>
+        <source>courier</source>
+        <translation>信使</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/courierboard.cpp" line="32"/>
+        <source>mann</source>
+        <translation>大臣</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/courierboard.cpp" line="34"/>
+        <source>schleich</source>
+        <translation>潜行者</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::CrazyhouseBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/crazyhouseboard.cpp" line="27"/>
+        <source>promoted knight</source>
+        <translation>升变的骑士</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/crazyhouseboard.cpp" line="28"/>
+        <source>promoted bishop</source>
+        <translation>升变的主教</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/crazyhouseboard.cpp" line="29"/>
+        <source>promoted rook</source>
+        <translation>升变的城堡</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/crazyhouseboard.cpp" line="30"/>
+        <source>promoted queen</source>
+        <translation>升变的皇后</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::ExtinctionBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/extinctionboard.cpp" line="99"/>
+        <source>Missing %1: %2 wins</source>
+        <translation>缺少%1：%2胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/extinctionboard.cpp" line="107"/>
+        <source>Draw by stalemate</source>
+        <translation>逼和作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/extinctionboard.cpp" line="114"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/extinctionboard.cpp" line="121"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::HordeBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/hordeboard.cpp" line="82"/>
+        <source>%1 wins</source>
+        <translation>%1胜</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::JanusBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/janusboard.cpp" line="26"/>
+        <source>janus</source>
+        <translation>双面神</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::KingOfTheHillBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/kingofthehillboard.cpp" line="42"/>
+        <source>White wins with king in the center</source>
+        <translation>白方王在中心胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/kingofthehillboard.cpp" line="45"/>
+        <source>Black wins with king in the center</source>
+        <translation>黑方王在中心胜</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::KnightMateBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/knightmateboard.cpp" line="26"/>
+        <source>king</source>
+        <translation>王</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/knightmateboard.cpp" line="27"/>
+        <source>mann</source>
+        <translation>大臣</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::LosersBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/losersboard.cpp" line="89"/>
+        <source>%1 gets mated</source>
+        <translation>%1 被将死</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/losersboard.cpp" line="104"/>
+        <source>%1 lost all pieces</source>
+        <translation>%1 失去了所有子力</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/losersboard.cpp" line="111"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/losersboard.cpp" line="118"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::ModernBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/modernboard.cpp" line="27"/>
+        <source>minister</source>
+        <translation>首相</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::NCheckBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/ncheckboard.cpp" line="85"/>
+        <source>%1 checks %2 times</source>
+        <translation>%1将军了 %2 次</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::RacingKingsBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="83"/>
+        <source>Drawn race</source>
+        <translation>竞速平手</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="89"/>
+        <source>Black wins the race</source>
+        <translation>黑方竞速获胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="100"/>
+        <source>White wins the race</source>
+        <translation>白方竞速获胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="107"/>
+        <source>Draw by stalemate</source>
+        <translation>逼和作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="114"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/racingkingsboard.cpp" line="121"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::SeirawanBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/seirawanboard.cpp" line="27"/>
+        <source>hawk</source>
+        <translation>鹰</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/seirawanboard.cpp" line="28"/>
+        <source>elephant</source>
+        <translation>大象</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/seirawanboard.cpp" line="31"/>
+        <source>auxhawk</source>
+        <translation>辅助鹰</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/seirawanboard.cpp" line="32"/>
+        <source>auxelephant</source>
+        <translation>辅助大象</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::ShatranjBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="26"/>
+        <source>ferz</source>
+        <translation>士</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="27"/>
+        <source>alfil</source>
+        <translation>象</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="130"/>
+        <source>%1 %2</source>
+        <translation>%1%2</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="132"/>
+        <source>mates</source>
+        <translation>将死胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="132"/>
+        <source>wins by stalemate</source>
+        <translation>困毙胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="141"/>
+        <source>Both kings bare</source>
+        <translation>双方孤王作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="147"/>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="154"/>
+        <source>Bare king</source>
+        <translation>孤死胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="161"/>
+        <source>Draw by seventy moves rule</source>
+        <translation>七十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/shatranjboard.cpp" line="168"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::SuicideBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/suicideboard.cpp" line="43"/>
+        <source>Draw</source>
+        <translation>和棋</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/suicideboard.cpp" line="46"/>
+        <source>%1 wins</source>
+        <translation>%1胜</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::ThreeKingsBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/threekingsboard.cpp" line="57"/>
+        <source>White wins</source>
+        <translation>白方胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/threekingsboard.cpp" line="60"/>
+        <source>Black wins</source>
+        <translation>黑方胜</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::TwoKingsEachBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/twokingseachboard.cpp" line="189"/>
+        <source>%1 mates</source>
+        <translation>%1将死胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/twokingseachboard.cpp" line="195"/>
+        <source>Draw by stalemate</source>
+        <translation>逼和作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/twokingseachboard.cpp" line="231"/>
+        <source>Draw by insufficient mating material</source>
+        <translation>死局作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/twokingseachboard.cpp" line="238"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/twokingseachboard.cpp" line="245"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>Chess::WesternBoard</name>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="40"/>
+        <source>pawn</source>
+        <translation>兵</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="41"/>
+        <source>knight</source>
+        <translation>马</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="42"/>
+        <source>bishop</source>
+        <translation>象</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="43"/>
+        <source>rook</source>
+        <translation>车</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="44"/>
+        <source>queen</source>
+        <translation>后</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="45"/>
+        <source>king</source>
+        <translation>王</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="1341"/>
+        <source>%1 mates</source>
+        <translation>%1将死胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="1347"/>
+        <source>Draw by stalemate</source>
+        <translation>逼和作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="1385"/>
+        <source>Draw by insufficient mating material</source>
+        <translation>死局作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="1392"/>
+        <source>Draw by fifty moves rule</source>
+        <translation>五十回合规则作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/westernboard.cpp" line="1399"/>
+        <source>Draw by 3-fold repetition</source>
+        <translation>三次重复局面作和</translation>
+    </message>
+</context>
+<context>
+    <name>CuteChessApplication</name>
+    <message>
+        <location filename="../projects/gui/src/cutechessapp.cpp" line="237"/>
+        <source>Active Games</source>
+        <translation>正在进行的对局</translation>
+    </message>
+</context>
+<context>
+    <name>EngineBuilder</name>
+    <message>
+        <location filename="../projects/lib/src/enginebuilder.cpp" line="46"/>
+        <source>Empty engine command</source>
+        <translation>引擎命令为空</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/enginebuilder.cpp" line="52"/>
+        <source>Unknown chess protocol: %1</source>
+        <translation>未知的国际象棋协议：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/enginebuilder.cpp" line="81"/>
+        <source>Cannot execute command: %1</source>
+        <translation>无法执行命令：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/enginebuilder.cpp" line="104"/>
+        <source>Cannot start engine %1:%2%3</source>
+        <translation>无法启动引擎 %1：%2%3</translation>
+    </message>
+</context>
+<context>
+    <name>EngineConfigurationDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="21"/>
+        <source>Basic</source>
+        <translation>基本</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="27"/>
+        <source>&amp;Name:</source>
+        <translation>名称(&amp;N)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="40"/>
+        <source>Co&amp;mmand:</source>
+        <translation>命令(&amp;M)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="55"/>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="82"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="64"/>
+        <source>Working &amp;Directory:</source>
+        <translation>工作目录(&amp;D)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="79"/>
+        <source>Browse working directory.</source>
+        <translation>浏览工作目录。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="91"/>
+        <source>&amp;Protocol:</source>
+        <translation>协议(&amp;P)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="104"/>
+        <source>&amp;Init Strings:</source>
+        <translation>初始化字符串(&amp;I)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="124"/>
+        <source>This option should be checked for Xboard/Winboard engines that report their scores from white&apos;s perspective.</source>
+        <translation>应该为以白方视角报告分数的 Xboard/Winboard 引擎勾选此项。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="127"/>
+        <source>Scores from &amp;white&apos;s perspective</source>
+        <translation>以白方视角显示分数(&amp;W)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="135"/>
+        <source>Advanced</source>
+        <translation>高级</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="169"/>
+        <source>Restore the default value for each option</source>
+        <translation>为每个选项恢复默认值</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="172"/>
+        <source>Restore defaults</source>
+        <translation>恢复默认</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="179"/>
+        <source>Detect the engine&apos;s options and supported features</source>
+        <translation>重新检测引擎的选项与支持特性</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineconfigdlg.ui" line="182"/>
+        <source>Detect</source>
+        <translation>重新检测</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="54"/>
+        <source>Add Engine</source>
+        <translation>增加引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="56"/>
+        <source>Configure Engine</source>
+        <translation>配置引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="177"/>
+        <source>Executables (*.exe *.bat *.cmd);;All Files (*.*)</source>
+        <translation>可执行文件 (*.exe *.bat *.cmd);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="179"/>
+        <source>All Files (*)</source>
+        <translation>所有文件 (*)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="203"/>
+        <source>Select Engine Executable</source>
+        <translation>选择引擎可执行文件</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="257"/>
+        <source>Select Engine Working Directory</source>
+        <translation>选择引擎工作目录</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="312"/>
+        <source>Engine Error</source>
+        <translation>引擎错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="376"/>
+        <source>Duplicate engine name</source>
+        <translation>重复的引擎名称</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationdlg.cpp" line="377"/>
+        <source>An engine with this name already exists</source>
+        <translation>已存在一个带有该名称的引擎</translation>
+    </message>
+</context>
+<context>
+    <name>EngineConfigurationModel</name>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationmodel.cpp" line="126"/>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationmodel.cpp" line="128"/>
+        <source>Command</source>
+        <translation>命令</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationmodel.cpp" line="130"/>
+        <source>Working Directory</source>
+        <translation>工作目录</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationmodel.cpp" line="132"/>
+        <source>Protocol</source>
+        <translation>协议</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineconfigurationmodel.cpp" line="134"/>
+        <source>Variants</source>
+        <translation>变体</translation>
+    </message>
+</context>
+<context>
+    <name>EngineManagementWidget</name>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>表单</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="22"/>
+        <source>Default location:</source>
+        <translation>默认位置：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="32"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="43"/>
+        <source>Configured chess engines:</source>
+        <translation>配置的引擎：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="63"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="83"/>
+        <source>Add a new engine</source>
+        <translation>增加一个新引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="86"/>
+        <source>Add</source>
+        <translation>增加</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="100"/>
+        <source>Remove selected engine(s)</source>
+        <translation>移除选定的引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="103"/>
+        <source>Remove</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="117"/>
+        <source>Configure selected engine(s)</source>
+        <translation>配置选定的引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/enginemanagementwidget.ui" line="120"/>
+        <source>Configure</source>
+        <translation>配置</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/enginemanagementwidget.cpp" line="115"/>
+        <source>Showing %1 of %2 engines</source>
+        <translation>显示 %2 个引擎中的 %1 个</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/enginemanagementwidget.cpp" line="190"/>
+        <source>Choose Directory</source>
+        <translation>选择目录</translation>
+    </message>
+</context>
+<context>
+    <name>EngineOptionModel</name>
+    <message>
+        <location filename="../projects/gui/src/engineoptionmodel.cpp" line="137"/>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineoptionmodel.cpp" line="139"/>
+        <source>Value</source>
+        <translation>值</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/engineoptionmodel.cpp" line="141"/>
+        <source>Alias</source>
+        <translation>别名</translation>
+    </message>
+</context>
+<context>
+    <name>EngineSelectionDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/engineselectiondlg.ui" line="14"/>
+        <source>Select Chess Engines</source>
+        <translation>选择国际象棋引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineselectiondlg.ui" line="22"/>
+        <source>&amp;Filter:</source>
+        <translation>筛选(&amp;F)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/engineselectiondlg.ui" line="53"/>
+        <source>Configured chess engines:</source>
+        <translation>配置的引擎：</translation>
+    </message>
+</context>
+<context>
+    <name>EvalHistory</name>
+    <message>
+        <location filename="../projects/gui/src/evalhistory.cpp" line="34"/>
+        <source>move</source>
+        <translation>回合</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalhistory.cpp" line="39"/>
+        <source>score</source>
+        <translation>分数</translation>
+    </message>
+</context>
+<context>
+    <name>EvalWidget</name>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="42"/>
+        <source>NPS</source>
+        <translation>NPS</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="42"/>
+        <source>Hash</source>
+        <translatorcomment>这个词的常见翻译过多，建议保留原文。</translatorcomment>
+        <translation>Hash</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="43"/>
+        <source>Pondermove</source>
+        <translation>后台思考着法</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="43"/>
+        <source>Ponderhit</source>
+        <translation>后台思考命中</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="43"/>
+        <source>TB</source>
+        <translation>残局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="54"/>
+        <source>Depth</source>
+        <translation>深度</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="54"/>
+        <source>Time</source>
+        <translation>时间</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="54"/>
+        <source>Nodes</source>
+        <translation>节点数</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="55"/>
+        <source>Score</source>
+        <translation>分数</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/evalwidget.cpp" line="55"/>
+        <source>PV</source>
+        <translation>主要变化</translation>
+    </message>
+</context>
+<context>
+    <name>GameDatabaseDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="14"/>
+        <source>Game Database</source>
+        <translation>对局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="22"/>
+        <source>&amp;Search:</source>
+        <translation>搜索(&amp;S)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="38"/>
+        <source>&amp;Clear</source>
+        <translation>清除(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="48"/>
+        <source>Advanced...</source>
+        <translation>高级...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="59"/>
+        <source>Import...</source>
+        <translation>导入...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="69"/>
+        <source>Export filtered games in PGN format</source>
+        <translation>以 PGN 格式导出筛选出的对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="72"/>
+        <source>Export...</source>
+        <translation>导出...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="82"/>
+        <source>Create opening book...</source>
+        <translation>创建开局库...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="182"/>
+        <source>Event:</source>
+        <translation>赛事：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="210"/>
+        <source>Site:</source>
+        <translation>地点：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="238"/>
+        <source>White:</source>
+        <translation>白方：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="266"/>
+        <source>Black:</source>
+        <translation>黑方：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasedlg.ui" line="294"/>
+        <source>Result:</source>
+        <translation>结果：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="286"/>
+        <source>Import Game</source>
+        <translation>导入对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="287"/>
+        <source>Portable Game Notation (*.pgn);;All Files (*.*)</source>
+        <translation>可移植棋局标记 (*.pgn);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="294"/>
+        <source>Export game collection</source>
+        <translation>导出对局集合</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="295"/>
+        <source>Portable Game Notation (*.pgn)</source>
+        <translation>可移植棋局标记 (*.pgn)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="386"/>
+        <source>Remove</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="390"/>
+        <source>PGN database does not exist.</source>
+        <translation>PGN 对局库不存在。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="391"/>
+        <source>Remove %1 from the list of databases?</source>
+        <translation>从对局库列表移除 %1 吗？</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="404"/>
+        <source>Import</source>
+        <translation>导入</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="410"/>
+        <source>PGN database has been modified since the last import.</source>
+        <translation>自上次导入以后 PGN 对局库被修改。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="411"/>
+        <source>The database must be imported again to read it.</source>
+        <translation>必须再次导入对局库以读取它。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="415"/>
+        <source>Error occured while trying to read the PGN database.</source>
+        <translation>试图读取 PGN 对局库时发生错误。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="416"/>
+        <source>Importing the database again may fix this problem.</source>
+        <translation>再次导入对局库可能修复此问题。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="458"/>
+        <source>[Advanced search]</source>
+        <translation>[高级搜索]</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="487"/>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="517"/>
+        <source>File Error</source>
+        <translation>文件错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="488"/>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="518"/>
+        <source>Error while saving file %1
+%2</source>
+        <translation>保存文件 %1 时发生错误
+%2</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="502"/>
+        <source>Opening depth</source>
+        <translation>开局深度</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="503"/>
+        <source>Maximum opening depth (plies):</source>
+        <translation>最大开局深度 (层数)：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="508"/>
+        <source>Create Opening Book</source>
+        <translation>创建开局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="509"/>
+        <source>Polyglot Book File (*.bin)</source>
+        <translation>Polyglot 对局库文件 (*.bin)</translation>
+    </message>
+</context>
+<context>
+    <name>GameDatabaseSearchDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="14"/>
+        <source>Advanced Search</source>
+        <translation>高级搜索</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="25"/>
+        <source>Event:</source>
+        <translation>赛事:</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="35"/>
+        <source>The name of the tournament or match event</source>
+        <translation>锦标赛或赛事的名称</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="42"/>
+        <source>Site:</source>
+        <translation>地点:</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="52"/>
+        <source>The location of the event</source>
+        <translation>赛事的地点</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="59"/>
+        <source>Date:</source>
+        <translation>日期:</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="77"/>
+        <source>Enable minimum date</source>
+        <translation>启用最小日期</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="90"/>
+        <source>Minimum starting date of the games</source>
+        <translation>对局的最小开始日期</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="100"/>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="142"/>
+        <source>M/d/yyyy</source>
+        <translation>yyyy/M/d</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="110"/>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="179"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="126"/>
+        <source>Enable maximum date</source>
+        <translation>启用最大日期</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="139"/>
+        <source>Maximum starting date of the games</source>
+        <translation>对局的最大开始日期</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="154"/>
+        <source>Round:</source>
+        <translation>场次：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="166"/>
+        <source>The minimum round ordinal of the games within the event</source>
+        <translation>赛事中对局的最小场次序号</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="169"/>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="192"/>
+        <source>null</source>
+        <translation>无</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="189"/>
+        <source>The maximum round ordinal of the games within the event</source>
+        <translation>赛事中对局的最大场次序号</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="207"/>
+        <source>Player:</source>
+        <translation>选手：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="219"/>
+        <source>The side the player plays on</source>
+        <translation>选手比赛的一方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="223"/>
+        <source>Any side</source>
+        <extracomment>This player may play either white or black pieces</extracomment>
+        <translatorcomment>这位选手可能执白棋或黑棋</translatorcomment>
+        <translation>任意一方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="228"/>
+        <source>White</source>
+        <extracomment>This player plays white pieces</extracomment>
+        <translatorcomment>这位选手执白棋</translatorcomment>
+        <translation>白方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="233"/>
+        <source>Black</source>
+        <extracomment>This player plays black pieces</extracomment>
+        <translatorcomment>这位选手执黑棋</translatorcomment>
+        <translation>黑方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="241"/>
+        <source>The first player&apos;s name, in &quot;lastname, firstname&quot; format</source>
+        <translation>第一位选手的名字，以“姓, 名”的格式</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="250"/>
+        <source>Opponent:</source>
+        <translation>对手：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="260"/>
+        <source>The second player&apos;s name, in &quot;lastname, firstname&quot; format</source>
+        <translation>第二位选手的名字，以“姓, 名”的格式</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="267"/>
+        <source>Result:</source>
+        <translation>结果：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="288"/>
+        <source>Search for the inverse of the chosen result</source>
+        <translation>搜索所选结果的相反结果</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="291"/>
+        <source>Not</source>
+        <translation>非</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="298"/>
+        <source>The result of the games</source>
+        <translation>对局的结果</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="302"/>
+        <source>Any result</source>
+        <extracomment>Any result</extracomment>
+        <translatorcomment>任意结果</translatorcomment>
+        <translation>任意结果</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="307"/>
+        <source>Any player wins</source>
+        <extracomment>Any player wins</extracomment>
+        <translatorcomment>任意选手胜</translatorcomment>
+        <translation>任意选手胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="312"/>
+        <source>White wins</source>
+        <extracomment>The player with white pieces wins</extracomment>
+        <translatorcomment>执白选手胜</translatorcomment>
+        <translation>白方胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="317"/>
+        <source>Black wins</source>
+        <extracomment>The player with black pieces wins</extracomment>
+        <translatorcomment>执黑选手胜</translatorcomment>
+        <translation>黑方胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="322"/>
+        <source>First player wins</source>
+        <extracomment>The first player wins</extracomment>
+        <translatorcomment>第一位选手胜</translatorcomment>
+        <translation>第一位选手胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="327"/>
+        <source>First player loses</source>
+        <extracomment>The first player loses</extracomment>
+        <translatorcomment>第一位选手败</translatorcomment>
+        <translation>第一位选手败</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="332"/>
+        <source>Draw</source>
+        <extracomment>The game is a draw</extracomment>
+        <translatorcomment>对局为和棋</translatorcomment>
+        <translation>和棋</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamedatabasesearchdlg.ui" line="337"/>
+        <source>Unfinished</source>
+        <extracomment>The game is in progress or the result is unknown</extracomment>
+        <translatorcomment>对局进行中或结果未知</translatorcomment>
+        <translation>未结束</translation>
+    </message>
+</context>
+<context>
+    <name>GameSettingsWidget</name>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>表单</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="37"/>
+        <source>Variant:</source>
+        <translation>变体：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="54"/>
+        <source>Time Control:</source>
+        <translation>时间控制：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="69"/>
+        <source>Opening suite</source>
+        <translation>开局组</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="78"/>
+        <source>PGN/EPD file:</source>
+        <translation>PGN/EPD 文件：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="93"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="222"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="102"/>
+        <source>Opening order:</source>
+        <translation>开局顺序：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="117"/>
+        <source>Sequential</source>
+        <translation>顺序</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="130"/>
+        <source>Random</source>
+        <translation>随机</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="152"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="231"/>
+        <source>Depth:</source>
+        <translation>深度：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="162"/>
+        <source> plies</source>
+        <translation> 层</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="175"/>
+        <source>FEN string:</source>
+        <translation>FEN 串：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="198"/>
+        <source>Opening book</source>
+        <translation>开局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="207"/>
+        <source>Polyglot file:</source>
+        <translation>Polyglot 文件：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="244"/>
+        <source> full moves</source>
+        <translation> 完整回合</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="254"/>
+        <source>Access mode:</source>
+        <translation>访问模式：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="269"/>
+        <source>The whole book is loaded in memory. This makes book access a bit faster but uses more memory.</source>
+        <translation>将整个开局库加载进内存。这使开局库访问得快一点，但使用更多内存。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="272"/>
+        <source>Ram</source>
+        <translation>内存</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="285"/>
+        <source>The book is accessed directly from disk. This is a good choice for very large books.</source>
+        <translation>开局库直接从磁盘访问。对于非常大的开局库来说是一个好的选择。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="288"/>
+        <source>Disk</source>
+        <translation>磁盘</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="318"/>
+        <source>Draw adjudication</source>
+        <translation>和棋判决</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="327"/>
+        <source>Move number:</source>
+        <translation>回合数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="337"/>
+        <source>The game can be adjudicated as a draw after this many full moves have been played. A value of 0 disables draw adjudication.</source>
+        <translation>该对局将在下了这么多完整回合后判和。0 值禁用和棋判决。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="340"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="433"/>
+        <source>Off</source>
+        <translation>关闭</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="356"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="420"/>
+        <source>Move count:</source>
+        <translation>累计回合：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="369"/>
+        <source>The scores of both players need to be within the chosen threshold for this many consecutive moves.</source>
+        <translation>两位选手的分数都需要在这么多连续回合间位于选定的阈值内。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="379"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="443"/>
+        <source>Score:</source>
+        <translation>分数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="392"/>
+        <source>Both players&apos; scores must be within this many centipawns from zero.</source>
+        <translation>两位选手的分数必须都在距离零这么多百分兵的范围内。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="395"/>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="462"/>
+        <source> cp</source>
+        <translation> 百分兵</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="411"/>
+        <source>Resign adjudication</source>
+        <translation>认输判决</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="430"/>
+        <source>Resign adjudication is used if an engine&apos;s score is below the threshold for at least this many consecutive moves.</source>
+        <translation>如果一个引擎的分数在至少这么多连续回合间低于阈值，认输判决将被采用。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="456"/>
+        <source>The score must be at least this many centipawns below zero.</source>
+        <translation>分数必须至少负这么多百分兵。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="480"/>
+        <source>Tablebase adjudication</source>
+        <translation>残局库判决</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/gamesettingswidget.ui" line="490"/>
+        <source>Thinking on opponent&apos;s time</source>
+        <translation>在对手的时间思考</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamesettingswidget.cpp" line="52"/>
+        <source>Select opening suite</source>
+        <translation>选择开局组</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamesettingswidget.cpp" line="53"/>
+        <source>PGN/EPD files (*.pgn *.epd)</source>
+        <translation>PGN/EPD 文件 (*.pgn *.epd)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamesettingswidget.cpp" line="62"/>
+        <source>Select opening book</source>
+        <translation>选择开局库</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamesettingswidget.cpp" line="63"/>
+        <source>Polyglot files (*.bin)</source>
+        <translation>Polyglot 文件 (*.bin)</translation>
+    </message>
+</context>
+<context>
+    <name>GameViewer</name>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="53"/>
+        <source>Skip to the beginning</source>
+        <translation>跳至开始</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="61"/>
+        <source>Previous move</source>
+        <translation>上一步</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="69"/>
+        <source>Next move</source>
+        <translation>下一步</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="77"/>
+        <source>Skip to the end</source>
+        <translation>跳至结束</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="184"/>
+        <source>Cannot show game</source>
+        <translation>无法显示对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gameviewer.cpp" line="185"/>
+        <source>This game is incompatible with Cute Chess and cannot be shown.</source>
+        <translation>该对局与 Cute Chess 不兼容，无法显示。</translation>
+    </message>
+</context>
+<context>
+    <name>ImportProgressDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/importprogressdlg.ui" line="20"/>
+        <source>Importing</source>
+        <translation>正在导入</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="38"/>
+        <source>Importing &quot;%1&quot;</source>
+        <translation>正在导入“%1”</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="76"/>
+        <source>%1 games/sec - %2</source>
+        <translation>%1 局/秒 - %2</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="89"/>
+        <source>Import failed</source>
+        <translation>导入失败</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="94"/>
+        <source>Import failed: file does not exist</source>
+        <translation>导入失败：文件不存在</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="98"/>
+        <source>Import failed: I/O error</source>
+        <translation>导入失败：输入/输出错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="102"/>
+        <source>Import failed: unknown error</source>
+        <translation>导入失败：未知错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="115"/>
+        <source>About 5 seconds</source>
+        <translation>大约 5 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="118"/>
+        <source>About 10 seconds</source>
+        <translation>大约 10 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="121"/>
+        <source>Less than a minute</source>
+        <translation>少于 1 分钟</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="124"/>
+        <source>About a minute</source>
+        <translation>大约 1 分钟</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/importprogressdlg.cpp" line="126"/>
+        <source>About %1 minutes</source>
+        <translation>大约 %1 分钟</translation>
+    </message>
+</context>
+<context>
+    <name>JsonParser</name>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="45"/>
+        <source>(empty string)</source>
+        <translation>(空字符串)</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="179"/>
+        <source>Unknown escape sequence: \%1</source>
+        <translation>未知转义序列：\%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="188"/>
+        <source>Invalid unicode digit: %1</source>
+        <translation>无效 Unicode 数字：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="199"/>
+        <source>Invalid unicode value: \u%1</source>
+        <translation>无效 Unicode 数值：\u%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="244"/>
+        <source>Unknown token: %1</source>
+        <translation>未知标记：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="256"/>
+        <source>Reached EOF unexpectedly</source>
+        <translation>意外到达 EOF</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="288"/>
+        <source>Invalid fraction: %1</source>
+        <translation>无效小数：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="303"/>
+        <source>Invalid integer: %1</source>
+        <translation>无效整数：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="311"/>
+        <source>Invalid value: %1</source>
+        <translation>无效值：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="331"/>
+        <source>Expected more key/value pairs</source>
+        <translation>期望更多键值/数值对</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="338"/>
+        <source>Invalid key: %1</source>
+        <translation>无效键值：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="347"/>
+        <source>Expected colon instead of: %1</source>
+        <translation>期望冒号而不是：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="363"/>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="401"/>
+        <source>Expected comma or closing bracket instead of: %1</source>
+        <translation>期望逗号或右括号而不是：%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonparser.cpp" line="389"/>
+        <source>Expected more array items</source>
+        <translation>期望更多数组项</translation>
+    </message>
+</context>
+<context>
+    <name>JsonSerializer</name>
+    <message>
+        <location filename="../projects/lib/components/json/src/jsonserializer.cpp" line="158"/>
+        <source>Invalid variant type: %1</source>
+        <translation>无效的变体类型：%1</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="138"/>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="176"/>
+        <source>&amp;New...</source>
+        <translation>新建(&amp;N)...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="141"/>
+        <source>&amp;Close</source>
+        <translation>关闭(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="148"/>
+        <source>&amp;Save</source>
+        <translation>保存(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="151"/>
+        <source>Save &amp;As...</source>
+        <translation>另存为(&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="168"/>
+        <source>&amp;Quit</source>
+        <translation>退出(&amp;Q)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="183"/>
+        <source>&amp;Game Database</source>
+        <translation>对局库(&amp;G)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="154"/>
+        <source>Copy F&amp;EN</source>
+        <translation>复制 FEN (&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="160"/>
+        <source>&amp;Flip Board</source>
+        <translation>翻转棋盘(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="162"/>
+        <source>Ad&amp;judicate Draw</source>
+        <translation>判决和棋(&amp;J)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="163"/>
+        <source>Adjudicate Win for White</source>
+        <translation>判决白方胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="164"/>
+        <source>Adjudicate Win for Black</source>
+        <translation>判决黑方胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="166"/>
+        <source>Resign</source>
+        <translation>认输</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="177"/>
+        <source>&amp;Stop</source>
+        <translation>停止(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="178"/>
+        <source>&amp;Results...</source>
+        <translation>结果(&amp;R)...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="180"/>
+        <source>&amp;Settings</source>
+        <translation>设置(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="185"/>
+        <source>&amp;Active Games</source>
+        <translation>正在进行的对局(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="187"/>
+        <source>&amp;Minimize</source>
+        <translation>最小化(&amp;M)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="190"/>
+        <source>Show &amp;Previous Tab</source>
+        <translation>显示上一个标签页(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="197"/>
+        <source>Show &amp;Next Tab</source>
+        <translation>显示下一个标签页(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="204"/>
+        <source>&amp;About Cute Chess...</source>
+        <translation>关于 Cute Chess (&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="270"/>
+        <source>&amp;Game</source>
+        <translation>对局(&amp;G)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="286"/>
+        <source>&amp;Tournament</source>
+        <translation>锦标赛(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="292"/>
+        <source>T&amp;ools</source>
+        <translation>工具(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="296"/>
+        <source>&amp;View</source>
+        <translation>视图(&amp;V)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="300"/>
+        <source>&amp;Window</source>
+        <translation>窗口(&amp;W)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="306"/>
+        <source>&amp;Help</source>
+        <translation>帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="327"/>
+        <source>Game Tabs</source>
+        <translation>对局标签</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="340"/>
+        <source>Engine Debug</source>
+        <translation>引擎调试</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="348"/>
+        <source>Evaluation history</source>
+        <translation>估值历史</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="354"/>
+        <source>White&apos;s evaluation</source>
+        <translation>白方评估</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="358"/>
+        <source>Black&apos;s evaluation</source>
+        <translation>黑方评估</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="364"/>
+        <source>Moves</source>
+        <translation>着法</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="372"/>
+        <source>Tags</source>
+        <translation>标签</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="653"/>
+        <source>End tournament game</source>
+        <translation>结束锦标赛对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="654"/>
+        <source>Do you really want to end the active tournament game?</source>
+        <translation>您真的要结束正在进行的锦标赛对局吗？</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="702"/>
+        <source>Could not initialize game</source>
+        <translation>无法初始化对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="703"/>
+        <source>The game could not be initialized due to an invalid opening.</source>
+        <translation>由于无效的开局，本局无法初始化。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="727"/>
+        <source>Game Error</source>
+        <translation>对局错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="789"/>
+        <source>Stop tournament</source>
+        <translation>停止锦标赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="790"/>
+        <source>Do you really want to stop the ongoing tournament?</source>
+        <translation>您真的要停止正在进行的锦标赛吗？</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="829"/>
+        <source>Tournament error</source>
+        <translation>锦标赛错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="830"/>
+        <source>Tournament &quot;%1&quot; finished with an error.
+
+%2</source>
+        <translation>锦标赛“%1”以一个错误结束。
+
+%2</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="956"/>
+        <source>Copyright 2008-2017 Ilari Pihlajisto and Arto Jonsson</source>
+        <translation>版权所有 2008-2017 Ilari Pihlajisto 与 Arto Jonsson</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="964"/>
+        <source>About Cute Chess</source>
+        <translation>关于 Cute Chess</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="1095"/>
+        <source>user decision</source>
+        <translation>用户决定</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="905"/>
+        <source>%1 vs %2</source>
+        <translation>%1 vs %2</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="907"/>
+        <source>%1 vs %2 (%3)</source>
+        <translation>%1 vs %2 (%3)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="927"/>
+        <source>Edit move comment</source>
+        <translation>编辑着法评论</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="928"/>
+        <source>Comment:</source>
+        <translation>评论：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="955"/>
+        <source>Using Qt version %1</source>
+        <translation>使用 Qt 版本 %1</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="958"/>
+        <source>This is free software; see the source for copying conditions. There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</source>
+        <translation>本软件是自由软件；复制条件参阅源代码。「不作」任何担保；亦不为「可销售性」或「特定用途的适用性」作担保。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="991"/>
+        <source>Save Game</source>
+        <translation>保存对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="993"/>
+        <source>Portable Game Notation (*.pgn);;All Files (*.*)</source>
+        <translation>可移植棋局标记 (*.pgn);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/mainwindow.cpp" line="1062"/>
+        <source>The game was modified.
+Do you want to save your changes?</source>
+        <translation>该对局已被修改。
+您要保存更改吗？</translation>
+    </message>
+</context>
+<context>
+    <name>NewGameDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="14"/>
+        <source>New Game</source>
+        <translation>新建对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="25"/>
+        <source>White</source>
+        <translation>白方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="31"/>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="119"/>
+        <source>Human</source>
+        <translation>人类</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="44"/>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="132"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="94"/>
+        <source>Configure white engine</source>
+        <translation>配置白方引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="113"/>
+        <source>Black</source>
+        <translation>黑方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newgamedlg.ui" line="182"/>
+        <source>Configure black engine</source>
+        <translation>配置黑方引擎</translation>
+    </message>
+</context>
+<context>
+    <name>NewTournamentDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="14"/>
+        <source>New Tournament</source>
+        <translation>新建锦标赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="27"/>
+        <source>General information</source>
+        <translation>基本信息</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="33"/>
+        <source>Event:</source>
+        <translation>赛事：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="43"/>
+        <source>My Tournament</source>
+        <translation>我的锦标赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="70"/>
+        <source>PGN output:</source>
+        <translation>PGN 输出：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="101"/>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="125"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="110"/>
+        <source>EPD output:</source>
+        <translation>EPD 输出：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="172"/>
+        <source>Players</source>
+        <translation>选手</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="53"/>
+        <source>Site:</source>
+        <translation>地点：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="155"/>
+        <source>Games</source>
+        <translation>对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="271"/>
+        <source>Add</source>
+        <translation>增加</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="285"/>
+        <source>Remove</source>
+        <translation>移除</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/newtournamentdlg.ui" line="302"/>
+        <source>Configure...</source>
+        <translation>配置...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/newtournamentdialog.cpp" line="87"/>
+        <source>Select PGN output file</source>
+        <translation>选择 PGN 输出文件</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/newtournamentdialog.cpp" line="88"/>
+        <source>Portable Game Notation (*.pgn)</source>
+        <translation>可移植棋局标记 (*.pgn)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/newtournamentdialog.cpp" line="96"/>
+        <source>Select EPD output file</source>
+        <translation>选择 EPD 输出文件</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/newtournamentdialog.cpp" line="97"/>
+        <source>Extended Position Description (*.epd)</source>
+        <translation>扩展局面描述 (*.epd)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/newtournamentdialog.cpp" line="213"/>
+        <source>Resolve Duplicates!</source>
+        <translation>解决重复！</translation>
+    </message>
+</context>
+<context>
+    <name>PgnDatabaseModel</name>
+    <message>
+        <location filename="../projects/gui/src/pgndatabasemodel.cpp" line="118"/>
+        <source>Database</source>
+        <translation>对局库</translation>
+    </message>
+</context>
+<context>
+    <name>PgnExportTask</name>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="210"/>
+        <source>Export Games</source>
+        <translation>导出对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/gamedatabasedlg.cpp" line="211"/>
+        <source>Writing %1 games to file</source>
+        <translation>正在将 %1 场对局写入文件</translation>
+    </message>
+</context>
+<context>
+    <name>PgnGameEntryModel</name>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="166"/>
+        <source>Event</source>
+        <translation>赛事</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="168"/>
+        <source>Site</source>
+        <translation>地点</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="170"/>
+        <source>Date</source>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="172"/>
+        <source>Round</source>
+        <translation>场次</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="174"/>
+        <source>White</source>
+        <translation>白方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="176"/>
+        <source>Black</source>
+        <translation>黑方</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgngameentrymodel.cpp" line="178"/>
+        <source>Result</source>
+        <translation>结果</translation>
+    </message>
+</context>
+<context>
+    <name>PgnTagsModel</name>
+    <message>
+        <location filename="../projects/gui/src/pgntagsmodel.cpp" line="93"/>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/pgntagsmodel.cpp" line="95"/>
+        <source>Value</source>
+        <translation>值</translation>
+    </message>
+</context>
+<context>
+    <name>PlainTextLog</name>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="44"/>
+        <source>Clear Log</source>
+        <translation>清除日志</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="47"/>
+        <source>Save Log to File...</source>
+        <translation>将日志保存到文件...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="50"/>
+        <source>Save Log</source>
+        <translation>保存日志</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="51"/>
+        <source>Text Files (*.txt);;All Files (*.*)</source>
+        <translation>文本文档 (*.txt);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="80"/>
+        <source>The file &quot;%1&quot; could not be saved because of insufficient privileges.</source>
+        <translation>无法保存文件“%1”因为权限不够。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="85"/>
+        <source>Try selecting a location where you have the permissions to create files.</source>
+        <translation>请尝试选择一个您有创建文件许可的位置。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="91"/>
+        <source>The file &quot;%1&quot; could not be saved because the operation timed out.</source>
+        <translation>无法保存文件“%1”因为操作超时。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="96"/>
+        <source>Try saving the file to a local or another network disk.</source>
+        <translation>请尝试将文件保存到本地或另一个网络磁盘。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/plaintextlog.cpp" line="101"/>
+        <source>The file &quot;%1&quot; could not be saved.</source>
+        <translation>无法保存文件“%1”。</translation>
+    </message>
+</context>
+<context>
+    <name>Result</name>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="104"/>
+        <source>%1 resigns</source>
+        <translation>%1认输</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="108"/>
+        <source>Draw by timeout</source>
+        <translation>超时作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="110"/>
+        <source>%1 loses on time</source>
+        <translation>%1超时作负</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="115"/>
+        <source>Draw by adjudication</source>
+        <translation>判决作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="117"/>
+        <source>%1 wins by adjudication</source>
+        <translation>%1判决获胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="120"/>
+        <source>%1 makes an illegal move</source>
+        <translation>%1采取了非法着法</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="124"/>
+        <source>Draw by disconnection</source>
+        <translation>断开连接作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="126"/>
+        <source>%1 disconnects</source>
+        <translation>%1断开连接</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="131"/>
+        <source>Draw by stalled connection</source>
+        <translation>停滞连接作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="133"/>
+        <source>%1&apos;s connection stalls</source>
+        <translation>%1的连接停滞</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="138"/>
+        <source>Draw by agreement</source>
+        <translation>协议作和</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="140"/>
+        <source>%1 wins by agreement</source>
+        <translation>%1协议获胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="143"/>
+        <source>No result</source>
+        <translation>无结果</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="145"/>
+        <source>Result error</source>
+        <translation>结果错误</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="150"/>
+        <source>%1 wins</source>
+        <translation>%1胜</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/result.cpp" line="152"/>
+        <source>Drawn game</source>
+        <translation>和局</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="20"/>
+        <source>Settings</source>
+        <translation>设置</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="30"/>
+        <source>General</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="39"/>
+        <source>Highlight legal moves</source>
+        <translation>高亮合法着法</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="49"/>
+        <source>Close initial game tab if unused</source>
+        <translation>如果未使用，关闭初始对局标签页</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="59"/>
+        <source>PGN Site:</source>
+        <translation>PGN 地点：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="72"/>
+        <source>Syzygy tablebases path:</source>
+        <translation>Syzygy 残局库路径：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="198"/>
+        <source>Maximum number of concurrent games:</source>
+        <translation>同时进行的最大对局数量：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="241"/>
+        <source>PGN output:</source>
+        <translation>PGN 输出：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="248"/>
+        <source>tournaments.pgn</source>
+        <translation>tournaments.pgn</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="266"/>
+        <source>EPD output:</source>
+        <translation>EPD 输出：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="273"/>
+        <source>tournaments.epd</source>
+        <translation>tournaments.epd</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="87"/>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="112"/>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="255"/>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="280"/>
+        <source>Browse...</source>
+        <translation>浏览...</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="96"/>
+        <source>PGN output for single games:</source>
+        <translation>单场对局的 PGN 输出：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="105"/>
+        <source>games.pgn</source>
+        <translation>games.pgn</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="125"/>
+        <source>Engines</source>
+        <translation>引擎</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="147"/>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="190"/>
+        <source>Games</source>
+        <translation>对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/settingsdlg.ui" line="172"/>
+        <source>Tournaments</source>
+        <translation>锦标赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="107"/>
+        <source>Choose Directory</source>
+        <translation>选择目录</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="125"/>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="140"/>
+        <source>Select PGN output file</source>
+        <translation>选择 PGN 输出文件</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="127"/>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="142"/>
+        <source>Portable Game Notation (*.pgn)</source>
+        <translation>可移植棋局标记 (*.pgn)</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="155"/>
+        <source>Select EPD output file</source>
+        <translation>选择 EPD 输出文件</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/settingsdlg.cpp" line="157"/>
+        <source>Extended Position Description (*.epd)</source>
+        <translation>扩展局面描述 (*.epd)</translation>
+    </message>
+</context>
+<context>
+    <name>Side</name>
+    <message>
+        <location filename="../projects/lib/src/board/side.cpp" line="45"/>
+        <source>white</source>
+        <translation>白方</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/board/side.cpp" line="47"/>
+        <source>black</source>
+        <translation>黑方</translation>
+    </message>
+</context>
+<context>
+    <name>ThreadedTask</name>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="31"/>
+        <source>%1 - Undefined time remaining</source>
+        <translation>%1 - 未定义的剩余时间</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="32"/>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="90"/>
+        <source>About 5 seconds</source>
+        <translation>大约 5 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="93"/>
+        <source>About 10 seconds</source>
+        <translation>大约 10 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="96"/>
+        <source>Less than a minute</source>
+        <translation>少于 1 分钟</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="99"/>
+        <source>About a minute</source>
+        <translation>大约 1 分钟</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/threadedtask.cpp" line="101"/>
+        <source>About %1 minutes</source>
+        <translation>大约 %1 分钟</translation>
+    </message>
+</context>
+<context>
+    <name>TimeControl</name>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="27"/>
+        <source>%1 sec</source>
+        <translation>%1秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="29"/>
+        <source>%1 min</source>
+        <translation>%1分钟</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="30"/>
+        <source>%1 h</source>
+        <translation>%1小时</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="38"/>
+        <source>%1 k</source>
+        <translation>%1千</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="39"/>
+        <source>%1 M</source>
+        <translation>%1百万</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="172"/>
+        <source>infinite time</source>
+        <translation>无限时间</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="174"/>
+        <source>%1 per move</source>
+        <translation>每着%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="177"/>
+        <source>%1 moves in %2</source>
+        <translation>%2内%1着</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="184"/>
+        <source>, %1 increment</source>
+        <translation>，每着加%1</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="187"/>
+        <source>, %1 nodes</source>
+        <translation>，%1节点</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="190"/>
+        <source>, %1 plies</source>
+        <translation>，%1层</translation>
+    </message>
+    <message>
+        <location filename="../projects/lib/src/timecontrol.cpp" line="192"/>
+        <source>, %1 msec margin</source>
+        <translation>，宽限%1毫秒</translation>
+    </message>
+</context>
+<context>
+    <name>TimeControlDialog</name>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="14"/>
+        <source>Time Controls</source>
+        <translation>时间控制</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="26"/>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="38"/>
+        <source>Tournament time control</source>
+        <translation>锦标赛时间控制</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="41"/>
+        <source>Tournament</source>
+        <translation>锦标赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="51"/>
+        <source>Fixed time limit for each move</source>
+        <translation>每着固定的时限</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="54"/>
+        <source>Time per move</source>
+        <translation>每着时间</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="61"/>
+        <source>Infinite thinking time</source>
+        <translation>无限思考时间</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="64"/>
+        <source>Infinite</source>
+        <translation>无限</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="79"/>
+        <source>Moves:</source>
+        <translation>步数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="89"/>
+        <source>The number of moves in a time control</source>
+        <translation>时间控制中的步数</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="92"/>
+        <source>Whole game</source>
+        <translation>整场对局</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="105"/>
+        <source>Time:</source>
+        <translation>时间：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="117"/>
+        <source>Time limit for the chosen time control</source>
+        <translation>选定时间控制的时限</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="136"/>
+        <source>Time unit for the time limit</source>
+        <translation>时限的时间单位</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="143"/>
+        <source>Seconds</source>
+        <translation>秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="148"/>
+        <source>Minutes</source>
+        <translation>分</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="153"/>
+        <source>Hours</source>
+        <translation>小时</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="163"/>
+        <source>Increment:</source>
+        <translation>增量：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="173"/>
+        <source>Time increment per move in seconds</source>
+        <translation>以秒为单位的每步时间增量</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="176"/>
+        <source> sec</source>
+        <translation> 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="183"/>
+        <source>Maximum search depth in plies (engines only)</source>
+        <translation>以层数为单位的最大搜索深度（仅引擎）</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="193"/>
+        <source>Plies:</source>
+        <translation>层数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="203"/>
+        <source>Maximum number of nodes to search (engines only)</source>
+        <translation>最大搜索节点数（仅引擎）</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="213"/>
+        <source>Nodes:</source>
+        <translation>节点数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="223"/>
+        <source>The time limit can be exceeded by this many milliseconds</source>
+        <translation>可以超过时限这么多毫秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="226"/>
+        <source> ms</source>
+        <translation> 毫秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/timecontroldlg.ui" line="236"/>
+        <source>Margin:</source>
+        <translation>宽限：</translation>
+    </message>
+</context>
+<context>
+    <name>TournamentResultsDialog</name>
+    <message>
+        <location filename="../projects/gui/src/tournamentresultsdlg.cpp" line="31"/>
+        <source>Tournament Results</source>
+        <translation>锦标赛结果</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/tournamentresultsdlg.cpp" line="74"/>
+        <source>Score of %1 vs %2: %3 - %4 - %5 [%6]
+</source>
+        <translation>%1 vs %2 的分数：%3 - %4 - %5 [%6]
+</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/src/tournamentresultsdlg.cpp" line="84"/>
+        <source>
+
+%1 of %2 games finished.</source>
+        <translation>
+
+已结束 %1/%2 场对局。</translation>
+    </message>
+</context>
+<context>
+    <name>TournamentSettingsWidget</name>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="14"/>
+        <source>Form</source>
+        <translation>表单</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="32"/>
+        <source>Tournament type</source>
+        <translation>锦标赛类型</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="40"/>
+        <source>Round Robin</source>
+        <translation>循环赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="50"/>
+        <source>Gauntlet</source>
+        <translation>车轮赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="57"/>
+        <source>Knockout</source>
+        <translation>淘汰赛</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="87"/>
+        <source>At most this many players from the top of the players list will be seeded in the tournament.</source>
+        <translation>选手列表顶端最多这么多选手将在锦标赛中成为种子。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="94"/>
+        <source>Seeds:</source>
+        <translation>种子数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="109"/>
+        <source>Rounds</source>
+        <translation>场次</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="118"/>
+        <source>Games per encounter:</source>
+        <translation>对手间每次相遇的对局数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="138"/>
+        <source>Rounds:</source>
+        <translation>循环轮数：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="158"/>
+        <source>Play each opening twice</source>
+        <translation>每种开局比两次</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="165"/>
+        <source>Wait between games:</source>
+        <translation>对局之间等待时间：</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="175"/>
+        <source> s</source>
+        <translation> 秒</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="182"/>
+        <source>If enabled, crashed engines are restarted and the tournament is not stopped.</source>
+        <translation>如果启用，崩溃的引擎将被重启，锦标赛不会停止。</translation>
+    </message>
+    <message>
+        <location filename="../projects/gui/ui/tournamentsettingswidget.ui" line="185"/>
+        <source>Recover crashed engines</source>
+        <translation>恢复崩溃的引擎</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Here comes a translation file for zh_CN localization. It works when the executable is placed like this:
```
├ translations/
│  ├ cutechess_[language_code_1].qm
│  └ cutechess_[language_code_2].qm
└ cutechess-gui
```
To maintainers: please compile with `lrelease` and include the `.qm` file with the `translations` directory in release packages, excluding the `.ts` file.