### PR TITLE
Add GUI configuration: human player can/cannot play after timeout

### DIFF
--- a/projects/gui/src/newgamedlg.cpp
+++ b/projects/gui/src/newgamedlg.cpp
@@ -154,7 +154,9 @@ PlayerBuilder* NewGameDialog::createPlayerBuilder(Chess::Side side) const
 
 		return new EngineBuilder(config);
 	}
-	return new HumanBuilder(CuteChessApplication::userName());
+	bool ignoreFlag = QSettings().value("games/human_can_play_after_timeout",
+					   true).toBool();
+	return new HumanBuilder(CuteChessApplication::userName(), ignoreFlag);
 }
 
 void NewGameDialog::setPlayerType(Chess::Side side, PlayerType type)

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -55,6 +55,15 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/display_players_sides_on_clocks", checked);
 	});
 
+
+	connect(ui->m_humanCanPlayAfterTimeoutCheck, &QCheckBox::toggled,
+		[=](bool checked)
+	{
+		QSettings().setValue("games/human_can_play_after_timeout",
+				      checked);
+	});
+
+
 	connect(ui->m_concurrencySpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
 		this, [=](int value)
 	{
@@ -197,6 +206,8 @@ void SettingsDialog::readSettings()
 	s.endGroup();
 
 	s.beginGroup("games");
+	ui->m_humanCanPlayAfterTimeoutCheck
+		->setChecked(s.value("human_can_play_after_timeout", true).toBool());
 	ui->m_defaultPgnOutFileEdit
 		->setText(s.value("default_pgn_output_file").toString());
 	s.endGroup();

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -53,7 +53,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="m_siteLabel">
          <property name="text">
           <string>PGN Site:</string>
@@ -63,10 +63,10 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QLineEdit" name="m_siteEdit"/>
        </item>
-       <item row="5" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="m_tbPathLabel">
          <property name="text">
           <string>Syzygy tablebases path:</string>
@@ -76,7 +76,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLineEdit" name="m_tbPathEdit"/>
@@ -90,14 +90,14 @@
          </item>
         </layout>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="m_defaultPgnOutFileLabel">
          <property name="text">
           <string>PGN output for single games:</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
           <widget class="QLineEdit" name="m_defaultPgnOutFileEdit">
@@ -132,6 +132,16 @@
         <widget class="QCheckBox" name="m_playersSidesOnClocksCheck">
          <property name="text">
           <string>Display players' sides on clocks </string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QCheckBox" name="m_humanCanPlayAfterTimeoutCheck">
+         <property name="text">
+          <string>Human player can play after timeout</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/projects/lib/src/chessplayer.cpp
+++ b/projects/lib/src/chessplayer.cpp
@@ -26,6 +26,7 @@ ChessPlayer::ChessPlayer(QObject* parent)
 	  m_timer(new QTimer(this)),
 	  m_claimedResult(false),
 	  m_validateClaims(true),
+	  m_canPlayAfterTimeout(false),
 	  m_board(nullptr),
 	  m_opponent(nullptr)
 {
@@ -195,7 +196,12 @@ void ChessPlayer::setName(const QString& name)
 
 bool ChessPlayer::canPlayAfterTimeout() const
 {
-	return false;
+	return m_canPlayAfterTimeout;
+}
+
+void ChessPlayer::setCanPlayAfterTimeout(bool enable)
+{
+        m_canPlayAfterTimeout = enable;
 }
 
 void ChessPlayer::startPondering()

--- a/projects/lib/src/chessplayer.h
+++ b/projects/lib/src/chessplayer.h
@@ -144,6 +144,13 @@ class LIB_EXPORT ChessPlayer : public QObject
 		/*! Sets result claim validation mode to \a validate. */
 		void setClaimsValidated(bool validate);
 
+		/*!
+		 * If \a enable is true the player will be allowed to continue
+		 * the game after time is out, else the player will forfeit.
+		 */
+		void setCanPlayAfterTimeout(bool enable);
+
+
 	public slots:
 		/*!
 		 * Waits (without blocking) until the player is ready,
@@ -243,10 +250,8 @@ class LIB_EXPORT ChessPlayer : public QObject
 		virtual void startThinking() = 0;
 
 		/*!
-		 * Returns true if this player can keep player after running
+		 * Returns true if this player can keep playing after running
 		 * out of time; otherwise returns false.
-		 *
-		 * By default this method always returns false.
 		 */
 		virtual bool canPlayAfterTimeout() const;
 
@@ -290,6 +295,7 @@ class LIB_EXPORT ChessPlayer : public QObject
 		QTimer* m_timer;
 		bool m_claimedResult;
 		bool m_validateClaims;
+		bool m_canPlayAfterTimeout;
 		Chess::Side m_side;
 		Chess::Board* m_board;
 		ChessPlayer* m_opponent;

--- a/projects/lib/src/humanbuilder.cpp
+++ b/projects/lib/src/humanbuilder.cpp
@@ -18,8 +18,9 @@
 #include "humanbuilder.h"
 #include "humanplayer.h"
 
-HumanBuilder::HumanBuilder(const QString& name)
-	: PlayerBuilder(name)
+HumanBuilder::HumanBuilder(const QString& name, bool playAfterTimeout)
+	: PlayerBuilder(name),
+	  m_playAfterTimeout(playAfterTimeout)
 {
 }
 
@@ -37,8 +38,10 @@ ChessPlayer* HumanBuilder::create(QObject *receiver,
 
 	ChessPlayer* player = new HumanPlayer(parent);
 	if (!name().isEmpty())
+	{
 		player->setName(name());
-
+		player->setCanPlayAfterTimeout(m_playAfterTimeout);
+	}
 	if (receiver != nullptr && method != nullptr)
 		QObject::connect(player, SIGNAL(debugMessage(QString)),
 				 receiver, method);

--- a/projects/lib/src/humanbuilder.h
+++ b/projects/lib/src/humanbuilder.h
@@ -30,9 +30,11 @@ class LIB_EXPORT HumanBuilder : public PlayerBuilder
 		 * Creates a new HumanBuilder.
 		 *
 		 * Any created players will have the name \a playerName,
-		 * unless it's an empty string.
+		 * unless it's an empty string. They cannot forfeit on
+		 * time if \a playAfterTimeout is true.
 		 */
-		HumanBuilder(const QString& playerName = QString());
+		HumanBuilder(const QString& playerName = QString(),
+			     bool playAfterTimeout = true);
 
 		// Inherited from PlayerBuilder
 		virtual bool isHuman() const;
@@ -40,6 +42,8 @@ class LIB_EXPORT HumanBuilder : public PlayerBuilder
 					    const char* method,
 					    QObject* parent,
 					    QString* error) const;
+	private:
+		bool m_playAfterTimeout;
 };
 
 #endif // HUMANBUILDER_H

--- a/projects/lib/src/humanplayer.cpp
+++ b/projects/lib/src/humanplayer.cpp
@@ -18,17 +18,11 @@
 #include "humanplayer.h"
 #include "board/board.h"
 
-
 HumanPlayer::HumanPlayer(QObject* parent)
 	: ChessPlayer(parent)
 {
 	setState(Idle);
 	setName("Human");
-}
-
-bool HumanPlayer::canPlayAfterTimeout() const
-{
-	return true;
 }
 
 void HumanPlayer::startGame()

--- a/projects/lib/src/humanplayer.h
+++ b/projects/lib/src/humanplayer.h
@@ -72,7 +72,6 @@ class LIB_EXPORT HumanPlayer : public ChessPlayer
 		
 	protected:
 		// Inherited from ChessPlayer
-		virtual bool canPlayAfterTimeout() const;
 		virtual void startGame();
 		virtual void startThinking();
 


### PR DESCRIPTION
This adds a checkbox to the General Settings of the GUI. The user may configure whether a human player can play after timeout or forfeit games on time. The configuration is saved and comes into action _for new games only_ (remark: behaviour of updated version changed) immediately when changing the status of the checkbox.
I refrained from using a per-game configuration. Nevertheless, I hope this is useful.
