### PR TITLE
Giveaway Chess: remove castling rights if King is captured on base rank

### DIFF
--- a/projects/lib/src/board/giveawayboard.cpp
+++ b/projects/lib/src/board/giveawayboard.cpp
@@ -44,4 +44,12 @@ bool GiveawayBoard::hasCastling() const
 	return true;
 }
 
+void GiveawayBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	if (captureType(move) == King)
+		removeCastlingRights(sideToMove().opposite());
+
+	return WesternBoard::vMakeMove(move, transition);
+}
+
 } // namespace Chess

--- a/projects/lib/src/board/giveawayboard.h
+++ b/projects/lib/src/board/giveawayboard.h
@@ -53,6 +53,7 @@ class LIB_EXPORT GiveawayBoard : public AntiBoard
 		virtual Board* copy() const;
 		virtual QString variant() const;
 		virtual QString defaultFenString() const;
+		virtual void vMakeMove(const Move& move, BoardTransition* transition);
 
 	protected:
 		// Inherited from AntiBoard

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -825,6 +825,12 @@ void WesternBoard::removeCastlingRights(int square)
 		setCastlingSquare(side, KingSide, 0);
 }
 
+void WesternBoard::removeCastlingRights(Side side)
+{
+	setCastlingSquare(side, QueenSide, 0);
+	setCastlingSquare(side, KingSide, 0);
+}
+
 int WesternBoard::castlingFile(CastlingSide castlingSide) const
 {
 	Q_ASSERT(castlingSide != NoCastlingSide);

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -179,6 +179,10 @@ class LIB_EXPORT WesternBoard : public Board
 		 */
 		void removeCastlingRights(int square);
 		/*!
+		 * Removes all castling rights of \a side.
+		 */
+		void removeCastlingRights(Side side);
+		/*!
 		 * Defines the file a king may castle to on \a castlingSide.
 		 * Defaults: 2 (c-file) and width() - 2 (normally g-file)
 		 */


### PR DESCRIPTION
This patch removes castling rights for `GiveawayBoard` by invoking a new method in `WesternBoard`.

This change has been pending after corresponding code for Giveaway was removed from WesternBoard in #305. In contrast to the older (and reverted) solution this patch is not expected to influence other variants.