### PR TITLE
Bump Travis QT versions and add 5.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - QT_BASE=57
     - QT_BASE=58
     - QT_BASE=59
+    - QT_BASE=510
   global:
     # Coverity Scan access token
     - secure: "a0D9/23/IV+404/STxfr9o0eVEp8Qx1J1KZPyKepSwdky9LpmeDTt6KWtfaL4mBiGNFpIHG239LHKbjIHLouFwP9SeLottIYUe/1xO12Y2eL5uUES0SbCGwyr248s5WvT15tvkF3xHy2FLMw0lDgsLDaOiOU7STteNYlFIHEkjUTQzx5UaG5utVDwsrjPdkkyij+Z2Ztl8tXCbEeyrct5ixzJX+lhAofwE7zpKlvhD1Snf/bHh0GopYQg8nL0Cdb15uhCjwTDQuaLTT2ICr8KsllLUie1ex5zWpCu4f9vsFFWZsBfFZ3+rReHfcNzWIoJ/0YNqdNBDio+akgewW31A/yUhnIxb5RuCirDnbny++yC/ZyMJUtY0LcRWZIfqa3BCRAp/jUY0VdIbteoGQWhZergXcEQEccpJKXoALlm4KEKHnVOGLf/Ceb/exG5vv0xiCUU6RwthFpuRLVFrqkMQH/mJ7kD1N44AoGlE1ElxxiguAze8v0oCWNMEDF5LGjvifWX2i4zhsvaqmwb7atMedyTtU5Hw8s3638C+PEQ1n1anb8cYYpGlZb6G1w3mi1j186ZrL+qCdHnu6Is3zGOBK7jVMcuGE4jPKmDCA6LPl0gig72JKL5yfIkDfkAuufJXSBmNVCUbiCEA2RWAzbCWFEsymMdV14m8TQ2JtEKes="
@@ -27,6 +28,7 @@ before_install:
   - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - if [ "$QT_BASE" = "58" ]; then sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y; fi
   - if [ "$QT_BASE" = "59" ]; then sudo add-apt-repository ppa:beineri/opt-qt594-trusty -y; fi
+  - if [ "$QT_BASE" = "510" ]; then sudo add-apt-repository ppa:beineri/opt-qt-5.10.1-trusty -y; fi
   - sudo apt-get update -qq
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_install:
   # run Coverity scans only once
   - if [ "${TRAVIS_BRANCH}" == "coverity_scan" ] && [ ${TRAVIS_JOB_NUMBER##*.} -gt 1 ]; then exit 0; fi
   - if [ "$QT_BASE" = "55" ]; then sudo add-apt-repository ppa:beineri/opt-qt551-trusty -y; fi
-  - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
+  - if [ "$QT_BASE" = "56" ]; then sudo add-apt-repository ppa:beineri/opt-qt563-trusty -y; fi
   - if [ "$QT_BASE" = "57" ]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - if [ "$QT_BASE" = "58" ]; then sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y; fi
-  - if [ "$QT_BASE" = "59" ]; then sudo add-apt-repository ppa:beineri/opt-qt591-trusty -y; fi
+  - if [ "$QT_BASE" = "59" ]; then sudo add-apt-repository ppa:beineri/opt-qt594-trusty -y; fi
   - sudo apt-get update -qq
 
 install:


### PR DESCRIPTION
Bump Travis QT versions to the latest available (5.6.3 and 5.9.4) and add a build with QT 5.10.1. QT 5.10.1 builds fine on my machine (Arch Linux) but I guess we'll have to see what Travis thinks about it...