### PR TITLE
Adding option to copy notation of current game (main window) to clipboard

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -157,6 +157,8 @@ void MainWindow::createActions()
 	copyFenSequence->setShortcutContext(Qt::WidgetWithChildrenShortcut);
 	m_gameViewer->addAction(copyFenSequence);
 
+	m_copyPgnAct = new QAction(tr("Copy PG&N"), this);
+
 	m_flipBoardAct = new QAction(tr("&Flip Board"), this);
 
 	m_adjudicateDrawAct = new QAction(tr("Ad&judicate Draw"), this);
@@ -207,6 +209,7 @@ void MainWindow::createActions()
 	connect(m_newGameAct, SIGNAL(triggered()), this, SLOT(newGame()));
 	connect(m_copyFenAct, SIGNAL(triggered()), this, SLOT(copyFen()));
 	connect(copyFenSequence, SIGNAL(triggered()), this, SLOT(copyFen()));
+	connect(m_copyPgnAct, SIGNAL(triggered()), this, SLOT(copyPgn()));
 	connect(m_flipBoardAct, SIGNAL(triggered()),
 		m_gameViewer->boardScene(), SLOT(flip()));
 	connect(m_closeGameAct, &QAction::triggered, this, [=]()
@@ -274,6 +277,7 @@ void MainWindow::createMenus()
 	m_gameMenu->addAction(m_saveGameAct);
 	m_gameMenu->addAction(m_saveGameAsAct);
 	m_gameMenu->addAction(m_copyFenAct);
+	m_gameMenu->addAction(m_copyPgnAct);
 	m_gameMenu->addSeparator();
 	m_gameMenu->addAction(m_adjudicateDrawAct);
 	m_gameMenu->addAction(m_adjudicateWhiteWinAct);
@@ -1025,6 +1029,19 @@ bool MainWindow::saveGame(const QString& fileName)
 	setWindowModified(false);
 
 	return true;
+}
+
+void MainWindow::copyPgn()
+{
+	QString str("");
+	QTextStream s(&str);
+	PgnGame* pgn = m_tabs.at(m_tabBar->currentIndex()).m_pgn;
+	if (pgn == nullptr)
+		return;
+	s << *pgn;
+
+	QClipboard* cb = CuteChessApplication::clipboard();
+	cb->setText(s.readAll());
 }
 
 void MainWindow::onGameManagerFinished()

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -80,6 +80,7 @@ class MainWindow : public QMainWindow
 		void onGameFinished(ChessGame* game);
 		void editMoveComment(int ply, const QString& comment);
 		void copyFen();
+		void copyPgn();
 		void showAboutDialog();
 		void closeAllGames();
 		void adjudicateDraw();
@@ -142,6 +143,7 @@ class MainWindow : public QMainWindow
 		QAction* m_saveGameAct;
 		QAction* m_saveGameAsAct;
 		QAction* m_copyFenAct;
+		QAction* m_copyPgnAct;
 		QAction* m_flipBoardAct;
 		QAction* m_newTournamentAct;
 		QAction* m_stopTournamentAct;


### PR DESCRIPTION
This PR adds a menu item "Copy PGN" to the "Game" Menu of the GUI. The action copies the current Portable Game Notation of the game in the active tab to the clipboard.

This supports feature request #367.

