### PR TITLE
Add support for length-based draw adjudication to the library

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -145,6 +145,12 @@ Adjudicate the game as a loss if an engine's score is at least
 centipawns below zero for at least
 .Ar count
 consecutive moves.
+.It Fl maxmoves Ar n
+Adjudicate the game as a draw if at least
+.Ar n
+full moves have been played without result. Ignored if
+.Ar n
+equals zero (default).
 .It Fl tb Ar paths
 Adjudicate games using Syzygy tablebases.
 .Ar Paths

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -66,6 +66,9 @@ Options:
 			Adjudicate the game as a loss if an engine's score is
 			at least SCORE centipawns below zero for at least COUNT
 			consecutive moves.
+  -maxmoves N		Adjudicate the game as a draw if the game is still
+			ongoing after N or more full moves have been played.
+			This limit is not in action if set to zero.
   -tb PATHS		Adjudicate games using Syzygy tablebases. PATHS should
 			be semicolon-delimited list of paths to the compressed
 			tablebase files. Only the DTZ tablebase files are

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -244,6 +244,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-concurrency", QVariant::Int, 1, 1);
 	parser.addOption("-draw", QVariant::StringList);
 	parser.addOption("-resign", QVariant::StringList);
+	parser.addOption("-maxmoves", QVariant::Int, 1, 1);
 	parser.addOption("-tb", QVariant::String, 1, 1);
 	parser.addOption("-tbpieces", QVariant::Int, 1, 1);
 	parser.addOption("-tbignore50", QVariant::Bool, 0, 0);
@@ -345,6 +346,13 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 			ok = (countOk && scoreOk);
 			if (ok)
 				adjudicator.setResignThreshold(moveCount, -score);
+		}
+		// Maximum game length before draw adjudication
+		else if (name == "-maxmoves")
+		{
+			ok = value.toInt() >= 0;
+			if (ok)
+				adjudicator.setMaximumGameLength(value.toInt());
 		}
 		// Syzygy tablebase adjudication
 		else if (name == "-tb")

--- a/projects/gui/src/gamesettingswidget.cpp
+++ b/projects/gui/src/gamesettingswidget.cpp
@@ -138,6 +138,7 @@ GameAdjudicator GameSettingsWidget::adjudicator() const
 			     ui->m_drawScoreSpin->value());
 	ret.setResignThreshold(ui->m_resignMoveCountSpin->value(),
 			       -ui->m_resignScoreSpin->value());
+	ret.setMaximumGameLength(ui->m_maxGameLengthSpin->value());
 	ret.setTablebaseAdjudication(ui->m_tbCheck->isChecked());
 
 	return ret;
@@ -252,6 +253,10 @@ void GameSettingsWidget::readSettings()
 	ui->m_resignScoreSpin->setValue(s.value("score").toInt());
 	s.endGroup();
 
+	s.beginGroup("game_length");
+	ui->m_maxGameLengthSpin->setValue(s.value("max_moves", 0).toInt());
+	s.endGroup();
+
 	ui->m_tbCheck->setChecked(tbOk && s.value("use_tb").toBool());
 	ui->m_ponderingCheck->setChecked(s.value("pondering").toBool());
 
@@ -340,6 +345,12 @@ void GameSettingsWidget::enableSettingsUpdates()
 		QSettings().setValue("games/resign_adjudication/score", score);
 	});
 
+	connect(ui->m_maxGameLengthSpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+		[=](int moveCount)
+	{
+		QSettings().setValue("games/game_length/max_moves", moveCount);
+	});
+
 	connect(ui->m_tbCheck, &QCheckBox::toggled, [=](bool checked)
 	{
 		QSettings().setValue("games/use_tb", checked);
@@ -355,6 +366,7 @@ void GameSettingsWidget::onHumanCountChanged(int count)
 {
 	ui->m_drawAdjudicationGroup->setEnabled(count == 0);
 	ui->m_resignAdjudicationGroup->setEnabled(count < 2);
+	ui->m_gameLengthGroup->setEnabled(count < 2);
 	ui->m_ponderingCheck->setEnabled(count < 2);
 	ui->m_openingBookGroup->setEnabled(count < 2);
 }

--- a/projects/gui/ui/gamesettingswidget.ui
+++ b/projects/gui/ui/gamesettingswidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>562</height>
+    <width>426</width>
+    <height>637</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -308,8 +308,11 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QFormLayout" name="formLayout_6">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <item row="1" column="0">
       <widget class="QGroupBox" name="m_drawAdjudicationGroup">
        <property name="enabled">
         <bool>false</bool>
@@ -402,7 +405,7 @@
        </layout>
       </widget>
      </item>
-     <item>
+     <item row="1" column="1">
       <widget class="QGroupBox" name="m_resignAdjudicationGroup">
        <property name="enabled">
         <bool>false</bool>
@@ -463,6 +466,53 @@
           </property>
           <property name="maximum">
            <number>9999</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QGroupBox" name="m_gameLengthGroup">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="title">
+        <string>Game Length</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="m_maxGameLengthLabel">
+          <property name="text">
+           <string>Limit:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="m_maxGameLengthSpin">
+          <property name="toolTip">
+           <string>The game will be adjucated as drawn when move limit is reached</string>
+          </property>
+          <property name="toolTipDuration">
+           <number>-1</number>
+          </property>
+          <property name="wrapping">
+           <bool>true</bool>
+          </property>
+          <property name="specialValueText">
+           <string>Off</string>
+          </property>
+          <property name="suffix">
+           <string> moves</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>5000</number>
+          </property>
+          <property name="value">
+           <number>0</number>
           </property>
          </widget>
         </item>

--- a/projects/lib/src/gameadjudicator.cpp
+++ b/projects/lib/src/gameadjudicator.cpp
@@ -26,6 +26,7 @@ GameAdjudicator::GameAdjudicator()
 	  m_drawScoreCount(0),
 	  m_resignMoveCount(0),
 	  m_resignScore(0),
+	  m_maxGameLength(0),
 	  m_tbEnabled(false)
 {
 	m_resignScoreCount[0] = 0;
@@ -51,6 +52,12 @@ void GameAdjudicator::setResignThreshold(int moveCount, int score)
 	m_resignScore = score;
 	m_resignScoreCount[0] = 0;
 	m_resignScoreCount[1] = 0;
+}
+
+void GameAdjudicator::setMaximumGameLength(int moveCount)
+{
+	Q_ASSERT(moveCount >= 0);
+	m_maxGameLength = moveCount;
 }
 
 void GameAdjudicator::setTablebaseAdjudication(bool enable)
@@ -85,6 +92,7 @@ void GameAdjudicator::addEval(const Chess::Board* board, const MoveEvaluation& e
 			m_drawScoreCount++;
 		else
 			m_drawScoreCount = 0;
+
 		if (board->plyCount() / 2 >= m_drawMoveNum
 		&&  m_drawScoreCount >= m_drawMoveCount * 2)
 		{
@@ -105,6 +113,14 @@ void GameAdjudicator::addEval(const Chess::Board* board, const MoveEvaluation& e
 		if (count >= m_resignMoveCount)
 			m_result = Chess::Result(Chess::Result::Adjudication,
 						 side.opposite());
+	}
+
+	// Limit game length
+	if (m_maxGameLength > 0
+	&&  board->plyCount() >= 2 * m_maxGameLength)
+	{
+		m_result = Chess::Result(Chess::Result::Adjudication, Chess::Side::NoSide);
+		return;
 	}
 }
 

--- a/projects/lib/src/gameadjudicator.h
+++ b/projects/lib/src/gameadjudicator.h
@@ -57,6 +57,14 @@ class LIB_EXPORT GameAdjudicator
 		 */
 		void setResignThreshold(int moveCount, int score);
 		/*!
+		 * Limits the number of moves playable in a game.
+		 *
+		 * A game will be adjudicated as a draw when the number of
+		 * moves played exceeds the limit given by \a moveCount.
+		 * The limit is not in action if set to zero.
+		 */
+		void setMaximumGameLength(int moveCount);
+		/*!
 		 * Sets tablebase adjudication to \a enable.
 		 *
 		 * If \a enable is true then games are adjudicated if the
@@ -92,6 +100,7 @@ class LIB_EXPORT GameAdjudicator
 		int m_resignMoveCount;
 		int m_resignScore;
 		int m_resignScoreCount[2];
+		int m_maxGameLength;
 		bool m_tbEnabled;
 		Chess::Result m_result;
 };


### PR DESCRIPTION
This PR adds support of length-based draw adjudication to the library, the CLI and the GUI.
This feature has been requested in #325.

It adds a new option `-maxmoves n` to CLI in order to limit the number of moves in a game:
longer games are adjudicated as drawn.
A corresponding spin box supports the game configuration of the GUI.
