### PR TITLE
Scrolling of move list to follow the text cursor. Resolves #292.

### DIFF
--- a/projects/gui/src/movelist.cpp
+++ b/projects/gui/src/movelist.cpp
@@ -256,6 +256,7 @@ void MoveList::selectChosenMove()
 	m_moves[moveNum].move.mergeCharFormat(c, format);
 
 	c.endEditBlock();
+	m_moveList->setTextCursor(c);
 }
 
 bool MoveList::selectMove(int moveNum)


### PR DESCRIPTION
This patch prevents the text cursor from escaping the visible area.
