### PR TITLE
Fix problem with unknown symbols passing setFenString.

### DIFF
--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -588,12 +588,14 @@ bool Board::setFenString(const QString& fen)
 			{
 				setSquare(k++, piece);
 				i += l - 1;
+				pieceStr.clear();
+				square++;
 				break;
 			}
 		}
-
-		pieceStr.clear();
-		square++;
+		// left over: unknown symbols
+		if (!pieceStr.isEmpty())
+			return false;
 	}
 
 	// The board must have exactly 'boardSize' squares and each rank


### PR DESCRIPTION
I noticed that the GUI's FEN validator accepted a position with Makruk piece types for standard chess (forgot to select the variant).   

`Board::setFenString` should return false when finding unknown symbols. My older patch 2419a86 caused the problem. This PR fixes it.

Test examples for standard chess:
`8/4k3/3MM3/4K3/8/8/8/8 b - - 0 1` passed validation in GUI but should fail
 `8/4k3/3**3/4K3/8/8/8/8 b - - 0 1` dito