### PR TITLE
Support Grand Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -81,6 +81,8 @@ Fischer Random Chess / Chess 960
 Giveaway Chess (Losing Chess)
 .It gothic
 Gothic Chess
+.It grand
+Grand Chess
 .It grid
 Grid Chess
 .It gridolina

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -33,6 +33,7 @@ Options:
 			'fischerandom': Fischer Random Chess/Chess 960
 			'giveaway': Giveaway Chess (Losing Chess)
 			'gothic': Gothic Chess
+			'grand': Grand Chess
 			'grid': Grid Chess
 			'gridolina': Berolina Grid Chess
 			'gryphon': Gryphon Chess

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -353,7 +353,7 @@ QString Board::moveString(const Move& move, MoveNotation notation)
 Move Board::moveFromLanString(const QString& istr)
 {
 	QString str(istr);
-	str.remove(QRegExp("[x+#!?]"));
+	str.remove(QRegExp("[x=+#!?]"));
 	int len = str.length();
 	if (len < 4)
 		return Move();
@@ -373,22 +373,25 @@ Move Board::moveFromLanString(const QString& istr)
 		return Move(0, squareIndex(trg), promotion.type());
 	}
 
-	Square sourceSq(chessSquare(str.mid(0, 2)));
-	Square targetSq(chessSquare(str.mid(2, 2)));
-	if (!isValidSquare(sourceSq) || !isValidSquare(targetSq))
-		return Move();
-
 	if (len > 4)
+		promotion = pieceFromSymbol(str.mid(len - 1));
+
+	if (promotion.isValid())
+		len = len - 1;
+
+	for (int i = 2; i < len - 1; i++)
 	{
-		promotion = pieceFromSymbol(str.mid(len-1));
-		if (!promotion.isValid())
-			return Move();
+		Square sourceSq(chessSquare(str.mid(0, i)));
+		Square targetSq(chessSquare(str.mid(i, len - i)));
+		if (!isValidSquare(sourceSq) || !isValidSquare(targetSq))
+			continue;
+		int source = squareIndex(sourceSq);
+		int target = squareIndex(targetSq);
+
+		return Move(source, target, promotion.type());
 	}
+	return Move();
 
-	int source = squareIndex(sourceSq);
-	int target = squareIndex(targetSq);
-
-	return Move(source, target, promotion.type());
 }
 
 Move Board::moveFromString(const QString& str)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -35,6 +35,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/giveawayboard.cpp \
     $$PWD/suicideboard.cpp \
     $$PWD/gothicboard.cpp \
+    $$PWD/grandboard.cpp \
     $$PWD/crazyhouseboard.cpp \
     $$PWD/loopboard.cpp \
     $$PWD/chessgiboard.cpp \
@@ -84,6 +85,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/giveawayboard.h \
     $$PWD/suicideboard.h \
     $$PWD/gothicboard.h \
+    $$PWD/grandboard.h \
     $$PWD/crazyhouseboard.h \
     $$PWD/loopboard.h \
     $$PWD/chessgiboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -33,6 +33,7 @@
 #include "frcboard.h"
 #include "giveawayboard.h"
 #include "gothicboard.h"
+#include "grandboard.h"
 #include "gridboard.h"
 #include "gryphonboard.h"
 #include "hordeboard.h"
@@ -78,6 +79,7 @@ REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")
 REGISTER_BOARD(GiveawayBoard, "giveaway")
 REGISTER_BOARD(GothicBoard, "gothic")
+REGISTER_BOARD(GrandBoard, "grand")
 REGISTER_BOARD(GridBoard, "grid")
 REGISTER_BOARD(BerolinaGridBoard, "gridolina")
 REGISTER_BOARD(GryphonBoard, "gryphon")

--- a/projects/lib/src/board/grandboard.cpp
+++ b/projects/lib/src/board/grandboard.cpp
@@ -1,0 +1,150 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "grandboard.h"
+
+namespace Chess {
+
+GrandBoard::GrandBoard()
+	: CapablancaBoard()
+{
+}
+
+Board* GrandBoard::copy() const
+{
+	return new GrandBoard(*this);
+}
+
+QString GrandBoard::variant() const
+{
+	return "grand";
+}
+
+int GrandBoard::height() const
+{
+	return 10;
+}
+
+QString GrandBoard::defaultFenString() const
+{
+	return "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R w - - 0 1";
+}
+
+bool GrandBoard::variantHasOptionalPromotions() const
+{
+	return true;
+}
+
+bool GrandBoard::hasCastling() const
+{
+	return false;
+}
+
+inline int GrandBoard::pawnMoveOffset(const PawnStep& ps, int sign) const
+{
+	return sign * ps.file - sign * (width() + 2) * 1;
+}
+
+void GrandBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+				       int pieceType,
+				       int square) const
+{
+	Chess::CapablancaBoard::generateMovesForPiece(moves, pieceType, square);
+	if (pieceType != Pawn)
+		return;
+
+	Side side = sideToMove();
+	Side opp = side.opposite();
+	int sign = (side == Side::White) ? 1 : -1;
+	int rank = chessSquare(square).rank();
+
+	// add missing pawn double steps from third rank
+	int rank3 = (side == Side::White) ? 2 : height() - 3;
+	if (rank == rank3)
+	{
+		for (const PawnStep& pStep: m_pawnSteps)
+		{
+			if (pStep.type != FreeStep)
+				continue;
+
+			int targetSquare = square + pawnMoveOffset(pStep, sign);
+			Piece capture = pieceAt(targetSquare);
+
+			if (capture.isEmpty())
+			{
+				targetSquare += pawnMoveOffset(pStep, sign);
+				capture = pieceAt(targetSquare);
+				if (capture.isEmpty())
+					moves.append(Move(square, targetSquare));
+			}
+		}
+	}
+
+	//add optional promotions on eighth and ninth ranks
+	int rank7 = (side == Side::White) ? height() - 4 : 3;
+	int rank8 = rank7 + sign;
+
+	if (rank != rank7 && rank != rank8)
+		return;
+
+	for (const PawnStep& pStep: m_pawnSteps)
+	{
+		int targetSquare = square + pawnMoveOffset(pStep, sign);
+		Piece capture = pieceAt(targetSquare);
+		bool isCapture = capture.side() == opp
+				||  targetSquare == enpassantSquare();
+
+		if ((capture.isEmpty() && pStep.type == FreeStep)
+		||  (isCapture && pStep.type == CaptureStep))
+			addPromotions(square, targetSquare, moves);
+	}
+}
+
+bool GrandBoard::vIsLegalMove(const Move& move)
+{
+	int promotion = move.promotion();
+
+	if (promotion == Piece::NoPiece)
+		return Chess::CapablancaBoard::vIsLegalMove(move);
+
+	// only allow promotion to already captured piece
+	Side side = sideToMove();
+	int count = 1;
+
+	for (int i = 0; i < arraySize(); i++)
+	{
+		Piece piece = pieceAt(i);
+		if (piece.side() == side && piece.type() == promotion)
+			count++;
+	}
+
+	if (promotion == Queen
+	||  promotion == Chancellor
+	||  promotion == Archbishop)
+		return count <= 1
+		&&     Chess::CapablancaBoard::vIsLegalMove(move);
+
+	if (promotion == Rook
+	||  promotion == Bishop
+	||  promotion == Knight)
+		return count <= 2
+		&&     Chess::CapablancaBoard::vIsLegalMove(move);
+
+	return false;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/grandboard.h
+++ b/projects/lib/src/board/grandboard.h
@@ -1,0 +1,78 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GRANDBOARD_H
+#define GRANDBOARD_H
+
+#include "capablancaboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Grand Chess
+ *
+ * Grand Chess is a variant of standard chess on a 10 x 10 board with
+ * Capablanca chess pieces. This game was introduced in 1984 by Christian
+ * Freeling, The Netherlands.
+ *
+ * Each side has one Cardinal (Archbishop, Bishop+Knight) and one Marshal
+ * (Chancellor, Rook+Knight) in addition to the standard pieces.
+ * GrandBoard uses the Capablanca names Archbishop and Chancellor.
+ *
+ * Initially each side has *ten* pawns on their third ranks. Most of the
+ * other pieces start on their second ranks. The rooks are placed at
+ * the corners. Castling is not allowed in Grand Chess.
+ *
+ * Pawns can make an initial double step and can be captured en passant.
+ * When reaching their eigth or ninth ranks pawns can optionally be
+ * promoted. Pawns can only promote to an own captured piece. On the tenth
+ * rank a pawn *must* be promoted. If promotion is impossible, then the
+ * pawn cannot advance to the tenth rank. It can give check to a king on
+ * the end rank nevertheless.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Grand_Chess
+ *
+ * \sa CapablancaBoard
+ * \sa EmbassyBoard
+ */
+class LIB_EXPORT GrandBoard : public CapablancaBoard
+{
+	public:
+		/*! Creates a new GrandBoard object. */
+		GrandBoard();
+
+		// Inherited from CapablancaBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual QString defaultFenString() const;
+		virtual bool variantHasOptionalPromotions() const;
+		virtual bool hasCastling() const;
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+		virtual bool vIsLegalMove(const Move& move);
+	private:
+		/*! Helper method for Pawn moves. Returns square offset for
+		 *  the given \a step with orientation \a sign. */
+		inline int pawnMoveOffset(const PawnStep& ps,
+					  int sign) const;
+
+};
+
+} // namespace Chess
+#endif // GRANDBOARD_H

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -267,6 +267,7 @@ class LIB_EXPORT WesternBoard : public Board
 		bool m_pawnHasDoubleStep;
 		bool m_hasEnPassantCaptures;
 		bool m_pawnAmbiguous;
+		bool m_multiDigitNotation;
 		QVector<MoveData> m_history;
 		CastlingRights m_castlingRights;
 		int m_castleTarget[2][2];

--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -285,6 +285,31 @@ QString XboardEngine::moveString(const Chess::Move& move)
 	return board()->moveString(move, m_notation);
 }
 
+// compensation: xboard protocol shifts ranks one down if board height equals ten
+const QString XboardEngine::transformMove(const QString& str, int height, int shift) const
+{
+	if (height != 10)
+	      return str;
+
+	QString ret, num;
+	for (const auto c: str)
+	{
+		if (c.isDigit())
+			num.append(c);
+		else
+		{
+			if (!num.isEmpty())
+				ret.append(QString::number(shift + num.toInt()));
+			num.clear();
+			ret.append(c);
+		}
+	}
+	if (!num.isEmpty())
+		ret.append(QString::number(shift + num.toInt()));
+
+	return ret;
+}
+
 void XboardEngine::makeMove(const Chess::Move& move)
 {
 	Q_ASSERT(!move.isNull());
@@ -308,6 +333,8 @@ void XboardEngine::makeMove(const Chess::Move& move)
 		else if (move != m_nextMove)
 			setForceMode(true);
 	}
+
+	moveString = transformMove(moveString, board()->height(), -1);
 
 	if (m_ftUsermove)
 		write("usermove " + moveString);
@@ -675,12 +702,13 @@ void XboardEngine::parseLine(const QString& line)
 
 		// remove "..." of old format if necessary
 		int mark = (args.indexOf("..."));
-		const QString movestr = mark < 0 ? args : args.mid(4);
+		const QString& movestr = mark < 0 ? args : args.mid(4);
+		const QString& newMovestr = transformMove(movestr, board()->height(), +1);
 
-		Chess::Move move = board()->moveFromString(movestr);
+		Chess::Move move = board()->moveFromString(newMovestr);
 		if (move.isNull())
 		{
-			forfeit(Chess::Result::IllegalMove, movestr);
+			forfeit(Chess::Result::IllegalMove, newMovestr);
 			return;
 		}
 

--- a/projects/lib/src/xboardengine.h
+++ b/projects/lib/src/xboardengine.h
@@ -67,6 +67,7 @@ class LIB_EXPORT XboardEngine : public ChessEngine
 		void finishGame();
 		QString moveString(const Chess::Move& move);
 		int adaptScore(int score) const;
+		const QString transformMove(const QString& str, int height, int shift) const;
 		
 		bool m_forceMode;
 		bool m_drawOnNextMove;

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -368,6 +368,27 @@ void tst_Board::moveStrings_data() const
 		   "Qxd4 Bc3 Qh4+ g3 Qa4 Nf3 Qa6 Qxa6 bxa6 Ba5 h5 O-O"
 		<< "rnbqkknr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKKNR w KQkq - 0 1"
 		<< "r3kk1r/p2nppp1/p7/B6p/8/5NP1/PPP4P/R4RK1 b kq - 1 20";
+	QTest::newRow("grand lan1")
+		<< "grand"
+		<< "d10d9 f5f6 g8g6 f6g7"
+		<< "3r6/1nb1kcabn1/ppprpppppp/3q6/3p6/5P4/5C4/PPPPPRPPPP/1NBQKRABN1/10 b - - 0 1"
+		<< "10/1nbrkcabn1/ppprpp1ppp/3q2P3/3p6/10/5C4/PPPPPRPPPP/1NBQKRABN1/10 b - - 0 3";
+	QTest::newRow("grand san1")
+		<< "grand"
+		<< "R10d9 f6 g6 fxg7"
+		<< "3r6/1nb1kcabn1/ppprpppppp/3q6/3p6/5P4/5C4/PPPPPRPPPP/1NBQKRABN1/10 b - - 0 1"
+		<< "10/1nbrkcabn1/ppprpp1ppp/3q2P3/3p6/10/5C4/PPPPPRPPPP/1NBQKRABN1/10 b - - 0 3";
+	QTest::newRow("grand san2")
+		<< "grand"
+		<< "Rc6 c3=C+ Rxc3 Rxc3"
+		<< "10/10/p9/10/1p5R2/1P1k6/P1p7/n4r4/K9/10 w - - 0 1"
+		<< "10/10/p9/10/1p8/1P1k6/P9/n1r7/K9/10 w - - 0 3";
+	QTest::newRow("grand san3")
+		<< "grand"
+		<< "R10a9 R10b9 Ra10 Rg9 R1a7 Rbb9 R7a8+ Kc9 Ke4 Ra9 R10xa9+ "
+		   "Kd10 Ra10+ Kd9 Rj8 Re9+ Kd5 Kc9 Rjj10 Rd9+ Kc6 Kc8 Rjc10+"
+		<< "Rr8/10/1r1k6/10/10/10/10/5K4/10/R9 w - - 0 1"
+		<< "R1R7/3r6/2k7/10/2K7/10/10/10/10/10 b - - 12 12";
 	QTest::newRow("seirawan san1")
 		<< "seirawan"
 		<< "e4 e5 Nf3 Nf6/H Bc4 Hh6 O-O/Eh1 Bd6 Nc3/H O-O/Ee8"
@@ -1165,12 +1186,25 @@ void tst_Board::perft_data() const
 		<< 5
 		<< Q_UINT64_C(4629764);
 
+	variant = "grand";
+	QTest::newRow("grand startpos")
+		<< variant
+		<< "r8r/1nbqkcabn1/pppppppppp/10/10/10/10/PPPPPPPPPP/1NBQKCABN1/R8R w - - 0 1"
+		<< 3 // 3plies: 259514, 4 plies: 15921643, 5 plies: 959883584
+		<< Q_UINT64_C(259514);
+	QTest::newRow("grand endgame1")
+		<< variant
+		<< "10/4k5/6P3/10/10/10/10/10/1p2K5/10 w - - 0 1"
+		<< 3 // 1 ply: 15, 2 plies: 165, 3 plies: 2446
+		<< Q_UINT64_C(2446);
+
 	variant = "seirawan";
 	QTest::newRow("seirawan startpos")
 		<< variant
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w BCDFGbcdfgKQkq - 0 1"
 		<< 4 // 4 plies: 782599, 5 plies: 27639803, 6 plies: 967587141 (sjaakii: 967584909)
 		<< Q_UINT64_C(782599);
+
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
- Add support for multi-digit notations
- Add extension to support CECP quirk for games with 10 ranks

This patch supports _Grand Chess_, a 1984 chess variant by Christian Freeling on a 10x10 board. This variant uses piece types known from _Capablanca Chess_. The starting position resembles the position of Embassy Chess. However, both sides have 10 pawns on their _third_ rank, the rooks are at the corners of the board, and the rest of the pieces on their second rank.

![grand1](https://user-images.githubusercontent.com/6425738/39387240-d233495e-4a78-11e8-9696-83459fc983ec.png)

This variant has initial double step option for pawns and en passant captures. Pawns can only be promoted to an own captured piece. Pawn promotion is optional when reaching rank eight or nine but mandatory when reaching the last rank. If promotion is impossible, then the pawn will not be able to advance to the tenth rank. It will be able to give check to a king on the end rank nevertheless.

The implementation uses `GrandBoard`, a subclass of `CapablancaBoard`. The base classes have been adapted to support notation with multiple digits, currently for board sizes up to at least 26x99 (one character, two digits). `Board::moveFromLanString`, `WesternBoard::sanMoveString` and `WesternBoard::moveFromSanString` have been modified aiming at low loss of execution speed for standard chess. 

A peculiarity of the Xboard engine protocol (CECP) is the shift of rank notation from 1-10 to 0-9 for boards with exactly 10 ranks. The method` XboardEngine::transformMove` takes care of that.
`
The implementation has been tested with both UCI and CECP engines Sjaak II 1.4.1 (both protocols) and NebiyuAlien (CECP).

I hope this is useful.

