### PR TITLE
Support Sittuyin (Myanmar Chess, Burmese Chess)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -123,6 +123,8 @@ S-Chess (Seirawan Chess)
 Shatranj
 .It simplifiedgryphon
 Simplified Gryphon Chess
+.It sittuyin
+Sittuyin (Myanmar Chess)
 .It slippedgrid
 Slipped Grid Chess
 .It suicide

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -55,6 +55,7 @@ Options:
 			'shatranj': Shatranj
 			'slippedgrid': Slipped Grid Chess
 			'simplifiedgryphon': Simplified Gryphon Chess
+			'sittuyin': Sittuyin (Myanmar Chess)
 			'suicide': Suicide Chess (Losing Chess)
 			'superandernach': Super-Andernach Chess
 			'threekings': Three Kings Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -47,6 +47,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/makrukboard.cpp \
     $$PWD/oukboard.cpp \
     $$PWD/aseanboard.cpp \
+    $$PWD/sittuyinboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -100,6 +101,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/makrukboard.h \
     $$PWD/oukboard.h \
     $$PWD/aseanboard.h \
+    $$PWD/sittuyinboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -51,6 +51,7 @@
 #include "racingkingsboard.h"
 #include "seirawanboard.h"
 #include "shatranjboard.h"
+#include "sittuyinboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
 #include "threekingsboard.h"
@@ -102,6 +103,7 @@ REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(SeirawanBoard, "seirawan")
 REGISTER_BOARD(ShatranjBoard, "shatranj")
 REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
+REGISTER_BOARD(SittuyinBoard, "sittuyin")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")
 REGISTER_BOARD(StandardBoard, "standard")
 REGISTER_BOARD(SuicideBoard, "suicide")

--- a/projects/lib/src/board/makrukboard.cpp
+++ b/projects/lib/src/board/makrukboard.cpp
@@ -160,6 +160,8 @@ void MakrukBoard::vMakeMove(const Move& move, BoardTransition* transition)
 	int capture = captureType(move);
 	Piece piece = pieceAt(move.sourceSquare());
 	int type = piece.type();
+	if (move.sourceSquare() == move.targetSquare())
+		capture = Piece::NoPiece;
 
 	ShatranjBoard::vMakeMove(move, transition);
 
@@ -183,7 +185,10 @@ void MakrukBoard::vMakeMove(const Move& move, BoardTransition* transition)
 	int promotion = move.promotion();
 	if (promotion != Piece::NoPiece)
 	{
-		md.pieceCount[type][side]--;
+		if (move.sourceSquare() == 0)
+			md.pieceCount[Piece::NoPiece][side]++; //drop
+		else
+			md.pieceCount[type][side]--;
 		md.pieceCount[promotion][side]++;
 	}
 

--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -1,0 +1,315 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "sittuyinboard.h"
+
+namespace Chess {
+
+SittuyinBoard::SittuyinBoard()
+	: MakrukBoard(),
+	  m_inSetUp(true)
+{
+	// Movements as in makruk, the Elephant has Silver General Movement
+	setPieceType(Pawn, tr("pawn"), "P");                      //!< Ne: Feudal Lord P
+	setPieceType(Knight, tr("knight"), "N", KnightMovement);  //!< Myin: Horse N
+	setPieceType(Elephant, tr("elephant"), "S", SilverGeneralMovement, "E"); //! Sin: Elephant E
+	setPieceType(Rook, tr("rook"), "R", RookMovement);        //! Yahhta: Chariot R
+	setPieceType(General, tr("general"), "F", FerzMovement);  //! Sit-ke: General G
+	setPieceType(King, tr("king"), "K");                      //! Min-gyi: King K
+}
+
+Board* SittuyinBoard::copy() const
+{
+	return new SittuyinBoard(*this);
+}
+
+QString SittuyinBoard::variant() const
+{
+	return "sittuyin";
+}
+
+QString SittuyinBoard::defaultFenString() const
+{
+	return "8/8/4pppp/pppp4/4PPPP/PPPP4/8/8[KFRRSSNNkfrrssnn] w - 0 0 1";
+	//Federation notation, ref. Maung Maung Lwin
+	//return "8/8/4pppp/pppp4/4PPPP/PPPP4/8/8[KGRREENNkgrreenn] w - 0 0 1";
+}
+
+bool SittuyinBoard::variantHasDrops() const
+{
+	return true;
+}
+
+bool SittuyinBoard::variantHasOptionalPromotions() const
+{
+	return true;
+}
+
+QList< Piece > SittuyinBoard::reservePieceTypes() const
+{
+	QList< Piece > types;
+	for (Side side: { Side::White, Side::Black} )
+	{
+		for (int type = Knight; type <= King; type++)
+			types << Piece(side, type);
+	}
+	return types;
+}
+
+MakrukBoard::CountingRules SittuyinBoard::countingRules() const
+{
+	return BareKing;
+}
+
+bool SittuyinBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	Piece whiteKing(Side::White, King);
+	Piece blackKing(Side::Black, King);
+	return whiteKings + reserveCount(whiteKing) == 1 && blackKings + reserveCount(blackKing) == 1;
+}
+
+int SittuyinBoard::promotionRank(int file) const
+{
+	return std::max(file , height() - 1 - file);
+}
+
+void SittuyinBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	moves.append(Move(sourceSquare, targetSquare, General));
+}
+
+void SittuyinBoard::generatePawnMoves(int square,
+				     QVarLengthArray<Move>& moves) const
+{
+	// Generate moves for Pawn (Feudal Lord)
+	QVarLengthArray< Move > moves1;
+	ShatranjBoard::generateMovesForPiece(moves1, Pawn, square);
+
+	// Add normal moves and demote shatranj promotions
+	for (const Move& m: moves1)
+		moves.append(Move(m.sourceSquare(), m.targetSquare()));
+
+	// No promotions if General still on board
+	Side side = sideToMove();
+	if (pieceCount(side, General) > 0)
+		return;
+
+	Square sq = chessSquare(square);
+	int file = sq.file();
+	int rank = sq.rank();
+	int rrank = (side == Side::White) ? rank : height() - 1 - rank;
+
+	// Must promote from promotion rank (except the last pawn)
+	if (rrank != promotionRank(file)
+	&&  pieceCount(sideToMove(), Pawn) != 1)
+		return;
+
+	// Generate promotion to General when on promotion square
+	addPromotions(square, square, moves);
+
+	// Generate General's moves, must not capture by promotion
+	QVarLengthArray< Move > moves2;
+	generateMovesForPiece(moves2, General, square);
+	for (const Move& move: moves2)
+	{
+		if (captureType(move) == Piece::NoPiece)
+			addPromotions(square, move.targetSquare(), moves);
+	}
+}
+
+void SittuyinBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	// Normal game moves
+	if (!m_inSetUp)
+	{
+		// No drops after set up
+		if (square == 0)
+			return;
+		// Pawn moves, special promotions, see above
+		if (pieceType == Pawn)
+			return generatePawnMoves(square, moves);
+
+		return MakrukBoard::generateMovesForPiece(moves, pieceType, square);
+	}
+
+	// Set-up: generate drops onto own half
+	if (square != 0)
+		return;
+
+	Side side = sideToMove();
+	const int size = arraySize();
+	const int len = (size - (width() + 2)) / 2;
+	const bool isBlack = (side == Side::Black);
+	const int start = 2 * (width() + 2) + 1;
+
+	// loop index i will have Black side perspective
+	for (int i = start; i < len; i++)
+	{
+		int index = isBlack ? i : size - 1 - i;
+		Piece tmp = pieceAt(index);
+		if (!tmp.isEmpty())
+			continue;
+
+		// Rooks must be placed on the base rank
+		if (pieceType == Rook
+		&&  chessSquare(i).rank() != height() - 1)
+			continue;
+
+		moves.append(Move(0, index, pieceType));
+	}
+}
+
+bool SittuyinBoard::inSetup() const
+{
+	// Set-up phase (sit-tee) ends when no pieces are left in reserve
+	for (Piece piece: reservePieceTypes())
+	{
+		if (reserveCount(piece) > 0)
+			return true;
+	}
+	return false;
+}
+
+bool SittuyinBoard::vSetFenString(const QStringList& fen)
+{
+	int ret = MakrukBoard::vSetFenString(fen);
+	m_inSetUp = inSetup();
+	return ret;
+}
+
+
+void SittuyinBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	MakrukBoard::vMakeMove(move, transition);
+
+	if (move.sourceSquare() == 0)
+		removeFromReserve(Piece(sideToMove(), move.promotion()));
+
+	m_inSetUp = inSetup();
+}
+
+void SittuyinBoard::vUndoMove(const Move& move)
+{
+	MakrukBoard::vUndoMove(move);
+
+	if (move.sourceSquare() == 0)
+		addToReserve(Piece(sideToMove(), move.promotion()));
+
+	m_inSetUp = inSetup();
+}
+
+bool SittuyinBoard::vIsLegalMove(const Move& move)
+{
+	int promotion = move.promotion();
+	Side side = sideToMove();
+	Side opp = side.opposite();
+	int oppKingSquare = kingSquare(opp);
+
+	// Pawn promotion: must not give check
+	if (!m_inSetUp && promotion == General)
+	{
+		QVarLengthArray<Move> moves;
+		generateMovesForPiece(moves, General, move.targetSquare());
+		for (const Move& m: moves)
+		{
+			if (m.targetSquare() == oppKingSquare)
+				return false;
+		}
+	}
+	return MakrukBoard::vIsLegalMove(move);
+}
+
+bool SittuyinBoard::isLegalPosition()
+{
+	Side side = sideToMove();
+	Side opp = side.opposite();
+
+	if (kingSquare(opp) != 0 && inCheck(opp))
+		return false;
+
+	if (m_inSetUp)
+		return true;
+
+	// A side may have one General at most
+	if (pieceCount(opp, General) > 1
+	||  pieceCount(side, General) > 1)
+		return false;
+
+	return true;
+}
+
+int SittuyinBoard::countingLimit() const
+{
+	// analoguous to ASEAN-Chess Article 5.2e
+	Side side = sideToMove();
+	int rooks = pieceCount(side, Rook);
+	if (rooks > 0)
+		return 16;
+
+	int elephants = pieceCount(side, Elephant);
+	int generals = pieceCount(side,Queen);
+	if (elephants > 0 && generals > 0)
+		return 44;
+
+	int knights = pieceCount(side, Knight);
+	if (knights > 0 && generals > 0)
+		return 64;
+
+	return 1000; // intentional limit
+}
+
+Result SittuyinBoard::result()
+{
+	QString str;
+	Side side = sideToMove();
+	Side opp = side.opposite();
+
+	// Checkmate/Stalemate
+	if (!canMove())
+	{
+		if (inCheck(side))
+		{
+			str = tr("%1 mates").arg(opp.toString());
+			return Result(Result::Win, opp, str);
+		}
+		else
+		{
+			str = tr("%1 forfeits by stalemating").arg(opp.toString());
+			return Result(Result::Adjudication, side, str);
+		}
+	}
+
+	// 50 move rule
+	if(reversibleMoveCount() >= 100)
+	{
+		str = tr("Draw by fifty moves rule");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// Insufficent material: KvK, KGvK, KNvK
+	if (insufficientMaterial())
+	{
+		str = tr("Draw by insufficient mating material");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+	// apply counting rules
+	return resultFromCounting();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/sittuyinboard.h
+++ b/projects/lib/src/board/sittuyinboard.h
@@ -1,0 +1,125 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SITTUYINBOARD_H
+#define SITTUYINBOARD_H
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Sit-tu-yin (Myanmar Traditional Chess, Burmese Chess)
+ *
+ * Sittuyin is the traditional variant of chess in Myanmar.
+ * It is an old game (9th century) closely related to Makruk and Chaturanga.
+ * There has been a wide variety of local or temporary rules.
+ *
+ * Each side begins with four Pawns on the left side on their third rank and
+ * four Pawns on the right side on their fourth rank.
+ *
+ * In the initial phase of the game the red side places their pieces behind
+ * their Pawns. After that the black side places their pieces. Rooks must be
+ * placed on the back rank. After all pieces have been placed the red side
+ * makes their first move.
+ *
+ * Sittuyin pieces move like Makruk (Thai Chess) pieces: The movements of
+ * King, Rook, Knight, and Pawn are the same as in Makruk, Shatranj, and
+ * chess. There are no "modern" moves: no pawn double steps, and no castling.
+ * The General moves one square diagonally. The Elephant has the same move-
+ * ment but can also make a step straight forward.
+ *
+ * If a side has no General then a Pawn can be promoted to General. This
+ * can only be done by a side's last Pawn or within the opponent's half from
+ * a square that is part of a main diagonal. Promotion counts as a move of
+ * its own. When promoting the Pawn either remains on its current square or
+ * makes a General's move. The promotion move must not give check or capture
+ * an opponent piece. Pawn promotion is optional, not oligatory: The Pawn can
+ * also make a normal move or capture.
+ *
+ * Checkmating the opponent King wins. Stalemating is not allowed. A draw can
+ * be claimed if no pawns have been moved and no captures have been made for
+ * fifty consecutive moves. A game will be drawn if it is impossible for
+ * the remaining pieces to give mate. There is no 3-fold repetition rule.
+ *
+ * Endgames with King and Rook, or King, Elephant and General, or King,
+ * Knight and General against a lone King must be won within a defined number
+ * of moves, else the game is drawn.
+ *
+ * \note Rules: The Official Rules by the Myanmar Chess Federation
+ * (as described by Maung Maung Lwin).
+ * \note: Set-up phase with alternating red and black piece drops.
+ * \note: Board will adjudicate against side giving stalemate.
+ *
+ * \sa MakrukBoard
+ * \sa ShatranjBoard
+ *
+ */
+class LIB_EXPORT SittuyinBoard : public MakrukBoard
+{
+	public:
+		/*! Creates a new SittuyinBoard object. */
+		SittuyinBoard();
+
+		// Inherited from MakrukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual bool variantHasDrops() const;
+		virtual bool variantHasOptionalPromotions() const;
+
+	protected:
+		/*! Piece types for sittuyin variants. */
+		enum SittuyinPieceType
+		{
+			Pawn = 1,          //!< Ne: Feudal Lord
+			Knight,            //!< Myin: Horse
+			Elephant = Bishop, //!< Sin: Elephant
+			Rook,              //!< Yahhta: Chariot
+			General = Queen,   //!< Sit-ke: General
+			King               //!< Min-gyi: King
+		};
+
+		// Inherited from MakrukBoard
+		virtual QList< Piece > reservePieceTypes() const;
+		virtual bool kingsCountAssertion(int whiteKings, int blackKings) const;
+		virtual void generatePawnMoves(int sourceSquare,
+					       QVarLengthArray<Move>& moves) const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual int promotionRank(int file = 0) const;
+		virtual bool vIsLegalMove(const Move& move);
+		virtual bool isLegalPosition();
+		virtual int countingLimit() const;
+		virtual CountingRules countingRules() const;
+		virtual Result result();
+
+	private:
+		bool m_inSetUp;
+		bool inSetup() const;
+};
+
+} // namespace Chess
+#endif // SITTUYINBOARD_H

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -186,6 +186,9 @@ QString WesternBoard::sanMoveString(const Move& move)
 	Piece capture = pieceAt(target);
 	Square square = chessSquare(source);
 
+	if (source == target)
+		capture = Piece::NoPiece;
+
 	char checkOrMate = 0;
 	makeMove(move);
 	if (inCheck(sideToMove()))
@@ -892,6 +895,9 @@ void WesternBoard::vMakeMove(const Move& move, BoardTransition* transition)
 		isReversible = false;
 		epSq = 0;
 	}
+
+	if (source == target)
+		clearSource = 0;
 
 	setEnpassantSquare(0);
 

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -513,6 +513,27 @@ void tst_Board::moveStrings_data() const
 		<< "Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3"
 		<< "8/8/8/4K3/8/1kq5/8/8 w - - 0 1"
 		<< "8/8/8/4K3/8/1kq5/8/8 w - - 16 9";
+	QTest::newRow("sittuyin lan1 promotion staying on square")
+		<< "sittuyin"
+		<< "g3g3f"
+		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
+		<< "8/8/6R1/s3r3/P5R1/1KP3f1/1F2kr2/8[-] w - 0 0 73";
+	QTest::newRow("sittuyin san1 promotion staying on square")
+		<< "sittuyin"
+		<< "g3=F"
+		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
+		<< "8/8/6R1/s3r3/P5R1/1KP3f1/1F2kr2/8[-] w - 0 0 73";
+	QTest::newRow("sittuyin san2 promotion by move")
+		<< "sittuyin"
+		<< "f2=F"
+		<< "5R2/8/8/8/5n2/5k2/3K4/4p3[-] b - 0 0 81"
+		<< "5R2/8/8/8/5n2/5k2/3K1f2/8[-] w - 0 0 82";
+	QTest::newRow("sittuyin san3 no threefold rep adjudicated")
+		<< "sittuyin"
+		<< "Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3"
+		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 0 1"
+		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 16 9";
+
 }
 
 void tst_Board::moveStrings()
@@ -1307,6 +1328,18 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/8/pppppppp/8/8/PPPPPPPP/8/RNBQKBNR w - - 0 1"
 		<< 5 // 4 plies: 273026, 5 plies: 6223994, 6 plies: 142078057
 		<< Q_UINT64_C(6223994);
+
+	variant = "sittuyin";
+	QTest::newRow("sittuyin startpos")
+		<< variant
+		<< "8/8/4pppp/pppp4/4PPPP/PPPP4/8/8[KFRRSSNNkfrrssnn] w - 0 0 1"
+		<< 3 // 1 ply: 88, 2 plies: 7744, 3 plies: 580096, 4 plies: 43454464
+		<< Q_UINT64_C(580096);
+	QTest::newRow("sittuyin midgame")
+		<< variant
+		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
+		<< 4 // 1 ply: 35, 2 plies: 825, 3 plies: 26791, 4 plies: 657824
+		<< Q_UINT64_C(657824);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
This PR adds support for Sittuyin, the traditional chess of Myanmar. The code is based on the Makruk implementation of PR #348.

Sittuyin is the traditional variant of chess in Myanmar. It is an old game (9th century) closely related to Makruk and Chaturanga. There has been a wide variety of local or temporary rules.

Each side begins with four Pawns on the left side on their third rank and four Pawns on the right side on their fourth rank.

In the initial phase of the game the red side places their pieces behind their Pawns. After that the black side places their pieces. Rooks must be placed on the back rank ~~and must not start on the opponent king's file if only Pawns are in between~~. After all pieces have been placed the red side makes their first move.

Sittuyin pieces move like Makruk (Thai Chess) pieces: The movements of King, Rook, Knight, and Pawn are the same as in Makruk, Shatranj, and chess. There are no "modern" moves: no pawn double steps, and no castling. The General moves one square diagonally. The Elephant has the same movement but can also make a step straight forward.

If a side has no General then a Pawn can be promoted to General. This can only be done by a side's last Pawn or within the opponent's half from a square that is part of a main diagonal. Promotion counts as a move of its own. When promoting the Pawn either remains on its current square or makes a General's move. The promotion move must not give check or capture an opponent piece. Pawn promotion is optional, not oligatory: The Pawn can also make a normal move or capture.

Checkmating the opponent King wins. Stalemating is not allowed. A draw can be claimed if no pawns have been moved and no captures have been made for fifty consecutive moves. A game will be drawn if it is impossible for the remaining pieces to give mate. There is no 3-fold repetition rule.

Endgames with King and Rook, or King, Elephant and General, or King, Knight and General against a lone King must be won within a defined number of moves, else the game is drawn.


**Rules:** The Official Rules by the Myanmar Chess Federation (as described by Maung Maung Lwin).
**Deviations:**
- `SittuyinBoard` uses a set-up phase with _alternating_ red and black piece drops.
- `SittuyinBoard` will adjudicate against the side giving stalemate!

COMPLEMENT (not subject of this PR):
also allow the piece symbol set KGRENP used in Maung Maung Lwin's reference description.