### PR TITLE
Makruk Pieces by Peter Thomson

### DIFF
--- a/projects/gui/res/chessboard/chessboard.qrc
+++ b/projects/gui/res/chessboard/chessboard.qrc
@@ -2,6 +2,7 @@
 <qresource>
 	<file>default.svg</file>
 	<file>merida.svg</file>
+	<file>makruk.svg</file>
 	<file>MaurizioMonge/celtic.svg</file>
 	<file>MaurizioMonge/eyes.svg</file>
 	<file>MaurizioMonge/fantasy.svg</file>

--- a/projects/gui/res/chessboard/makruk.svg
+++ b/projects/gui/res/chessboard/makruk.svg
@@ -1,0 +1,5906 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="744.09448"
+   height="1052.3622"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="makruk.svg">
+  <title
+     id="title2993">Makruk Pieces</title>
+  <defs
+     id="defs4">
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721"
+       xlink:href="#linearGradient3693"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299" />
+    <inkscape:perspective
+       id="perspective10"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635">
+      <stop
+         id="stop3637"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643" />
+      <stop
+         id="stop3639"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645">
+      <stop
+         id="stop3649"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693"
+       inkscape:collect="always">
+      <stop
+         id="stop3695"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6777"
+       inkscape:collect="always">
+      <stop
+         id="stop6779"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop6781"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-12.45355,-3.2772499)"
+       gradientUnits="userSpaceOnUse"
+       y2="193.2683"
+       x2="297.82674"
+       y1="193.2683"
+       x1="82.221229"
+       id="linearGradient6084"
+       xlink:href="#linearGradient6078"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-6"
+       xlink:href="#linearGradient3693-2"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-2" />
+    <inkscape:perspective
+       id="perspective10-6"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-9">
+      <stop
+         id="stop3637-3"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-6" />
+      <stop
+         id="stop3639-0"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-2">
+      <stop
+         id="stop3649-7"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-2"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-9"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-1"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6078"
+       inkscape:collect="always">
+      <stop
+         id="stop6080"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop6082"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.82506606,0,0,0.96191487,42.21019,12.145526)"
+       gradientUnits="userSpaceOnUse"
+       y2="161.85785"
+       x2="275.24833"
+       y1="161.85785"
+       x1="60.182661"
+       id="linearGradient4511"
+       xlink:href="#linearGradient4505"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-7"
+       xlink:href="#linearGradient3693-4"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-6" />
+    <inkscape:perspective
+       id="perspective10-7"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-1">
+      <stop
+         id="stop3637-5"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-9" />
+      <stop
+         id="stop3639-7"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-1">
+      <stop
+         id="stop3649-77"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-4"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-90"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-9"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4505"
+       inkscape:collect="always">
+      <stop
+         id="stop4507"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop4509"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-14.4199,3.9327)"
+       gradientUnits="userSpaceOnUse"
+       y2="223.52318"
+       x2="320.85376"
+       y1="223.52318"
+       x1="67.828083"
+       id="linearGradient12663"
+       xlink:href="#linearGradient12657"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-8"
+       xlink:href="#linearGradient3693-21"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-5" />
+    <inkscape:perspective
+       id="perspective10-2"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-5">
+      <stop
+         id="stop3637-0"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-64" />
+      <stop
+         id="stop3639-6"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-11">
+      <stop
+         id="stop3649-0"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-8" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-21"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-0"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-5"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient10333">
+      <stop
+         id="stop10335"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop10337"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12657"
+       inkscape:collect="always">
+      <stop
+         id="stop12659"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop12661"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="186.58282"
+       x2="301.90114"
+       y1="186.58282"
+       x1="51.08697"
+       id="linearGradient8078"
+       xlink:href="#linearGradient8072"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-5"
+       xlink:href="#linearGradient3693-3"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-0" />
+    <inkscape:perspective
+       id="perspective10-8"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-6">
+      <stop
+         id="stop3637-9"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-3" />
+      <stop
+         id="stop3639-3"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-3">
+      <stop
+         id="stop3649-9"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-19" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-3"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-4"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-0"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9155">
+      <stop
+         id="stop9157"
+         offset="0"
+         style="stop-color:#f5ea8e;stop-opacity:1;" />
+      <stop
+         id="stop9159"
+         offset="1"
+         style="stop-color:#d3bc5f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9174">
+      <stop
+         id="stop9176"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.50877196;" />
+      <stop
+         id="stop9178"
+         offset="1"
+         style="stop-color:#e9ddaf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient9202">
+      <stop
+         id="stop9204"
+         offset="0"
+         style="stop-color:#9f9011;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8072"
+       inkscape:collect="always">
+      <stop
+         id="stop8074"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop8076"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-4"
+       xlink:href="#linearGradient3693-9"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-29" />
+    <inkscape:perspective
+       id="perspective10-0"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-99">
+      <stop
+         id="stop3637-36"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-0" />
+      <stop
+         id="stop3639-5"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-25">
+      <stop
+         id="stop3649-4"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-9"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-1"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-96"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9155-0">
+      <stop
+         id="stop9157-4"
+         offset="0"
+         style="stop-color:#f5ea8e;stop-opacity:1;" />
+      <stop
+         id="stop9159-0"
+         offset="1"
+         style="stop-color:#d3bc5f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9174-8">
+      <stop
+         id="stop9176-3"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.50877196;" />
+      <stop
+         id="stop9178-8"
+         offset="1"
+         style="stop-color:#e9ddaf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient9202-0">
+      <stop
+         id="stop9204-2"
+         offset="0"
+         style="stop-color:#9f9011;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0.92694625,9.5011949)"
+       gradientUnits="userSpaceOnUse"
+       y2="170.09067"
+       x2="288.78738"
+       y1="170.09067"
+       x1="76.433698"
+       id="linearGradient8347"
+       xlink:href="#linearGradient8341"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-74"
+       xlink:href="#linearGradient3693-39"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-25" />
+    <inkscape:perspective
+       id="perspective10-9"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-8">
+      <stop
+         id="stop3637-91"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-5" />
+      <stop
+         id="stop3639-4"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-30">
+      <stop
+         id="stop3649-1"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-39"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-2"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-8"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8341"
+       inkscape:collect="always">
+      <stop
+         id="stop8343"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop8345"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-9.8317497,-5.2435999)"
+       gradientUnits="userSpaceOnUse"
+       y2="193.2683"
+       x2="297.82674"
+       y1="193.2683"
+       x1="82.221229"
+       id="linearGradient5223"
+       xlink:href="#linearGradient5217"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-2"
+       xlink:href="#linearGradient3693-99"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-1" />
+    <inkscape:perspective
+       id="perspective10-62"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-0">
+      <stop
+         id="stop3637-2"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-01" />
+      <stop
+         id="stop3639-9"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-5">
+      <stop
+         id="stop3649-3"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-49" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-99"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-7"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-82"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5217"
+       inkscape:collect="always">
+      <stop
+         id="stop5219"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop5221"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-12.45355,-1.9663499)"
+       gradientUnits="userSpaceOnUse"
+       y2="159.89824"
+       x2="298.75533"
+       y1="159.89824"
+       x1="83.146518"
+       id="linearGradient6783-1"
+       xlink:href="#linearGradient6777-2"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-49"
+       xlink:href="#linearGradient3693-6"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-7" />
+    <inkscape:perspective
+       id="perspective10-79"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-97">
+      <stop
+         id="stop3637-56"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-4" />
+      <stop
+         id="stop3639-63"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-10">
+      <stop
+         id="stop3649-2"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-6"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-48"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-08"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6777-2"
+       inkscape:collect="always">
+      <stop
+         id="stop6779-1"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop6781-9"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="167.82665"
+       x2="269.34068"
+       y1="167.82665"
+       x1="91.82772"
+       id="linearGradient4425"
+       xlink:href="#linearGradient4419"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-69"
+       xlink:href="#linearGradient3693-60"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-71" />
+    <inkscape:perspective
+       id="perspective10-75"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-4">
+      <stop
+         id="stop3637-22"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-45" />
+      <stop
+         id="stop3639-1"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-23">
+      <stop
+         id="stop3649-18"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-60"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-8"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-92"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4419"
+       inkscape:collect="always">
+      <stop
+         id="stop4421"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop4423"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-12.050301,5.5616777)"
+       gradientUnits="userSpaceOnUse"
+       y2="223.52318"
+       x2="320.85376"
+       y1="223.52318"
+       x1="67.828083"
+       id="linearGradient12663-5"
+       xlink:href="#linearGradient12657-9"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-1"
+       xlink:href="#linearGradient3693-98"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-27" />
+    <inkscape:perspective
+       id="perspective10-76"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-2">
+      <stop
+         id="stop3637-1"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-7" />
+      <stop
+         id="stop3639-79"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-7">
+      <stop
+         id="stop3649-06"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-98"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-80"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-3"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient10333-9">
+      <stop
+         id="stop10335-0"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop10337-8"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12657-9"
+       inkscape:collect="always">
+      <stop
+         id="stop12659-1"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop12661-1"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="186.58282"
+       x2="301.75901"
+       y1="186.58282"
+       x1="50.944847"
+       id="linearGradient12655"
+       xlink:href="#linearGradient12649"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-81"
+       xlink:href="#linearGradient3693-20"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-9" />
+    <inkscape:perspective
+       id="perspective10-77"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-14">
+      <stop
+         id="stop3637-03"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-1" />
+      <stop
+         id="stop3639-2"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-4">
+      <stop
+         id="stop3649-35"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-20"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-22"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-97"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9155-2">
+      <stop
+         id="stop9157-1"
+         offset="0"
+         style="stop-color:#f5ea8e;stop-opacity:1;" />
+      <stop
+         id="stop9159-6"
+         offset="1"
+         style="stop-color:#d3bc5f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient9174-4">
+      <stop
+         id="stop9176-1"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.50877196;" />
+      <stop
+         id="stop9178-2"
+         offset="1"
+         style="stop-color:#e9ddaf;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient9202-5">
+      <stop
+         id="stop9204-7"
+         offset="0"
+         style="stop-color:#9f9011;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient12649"
+       inkscape:collect="always">
+      <stop
+         id="stop12651"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop12653"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-3.707785,9.5011949)"
+       gradientUnits="userSpaceOnUse"
+       y2="170.09067"
+       x2="288.78738"
+       y1="170.09067"
+       x1="76.433698"
+       id="linearGradient8347-2"
+       xlink:href="#linearGradient8341-0"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="79.565208"
+       x2="145.8732"
+       y1="114.92841"
+       x1="212.1792"
+       id="linearGradient3721-17"
+       xlink:href="#linearGradient3693-5"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       id="perspective3299-56" />
+    <inkscape:perspective
+       id="perspective10-1"
+       inkscape:persp3d-origin="372.04724 : 350.78739 : 1"
+       inkscape:vp_z="744.09448 : 526.18109 : 1"
+       inkscape:vp_y="6.1230318e-14 : 1000 : 0"
+       inkscape:vp_x="0 : 526.18109 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3635-16">
+      <stop
+         id="stop3637-39"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0.49803922;"
+         offset="0.5"
+         id="stop3643-33" />
+      <stop
+         id="stop3639-46"
+         offset="1"
+         style="stop-color:#ffff23;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3645-9">
+      <stop
+         id="stop3649-99"
+         offset="0"
+         style="stop-color:#ffff23;stop-opacity:0.49803922;" />
+      <stop
+         style="stop-color:#ffff23;stop-opacity:0;"
+         offset="1"
+         id="stop3651-498" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3693-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3695-42"
+         offset="0"
+         style="stop-color:#ffff82;stop-opacity:1;" />
+      <stop
+         id="stop3697-4"
+         offset="1"
+         style="stop-color:#ffff82;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8341-0"
+       inkscape:collect="always">
+      <stop
+         id="stop8343-0"
+         offset="0"
+         style="stop-color:#daa520;stop-opacity:1;" />
+      <stop
+         id="stop8345-4"
+         offset="1"
+         style="stop-color:#daa520;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6777"
+       id="linearGradient4387"
+       gradientUnits="userSpaceOnUse"
+       x1="83.146518"
+       y1="159.89824"
+       x2="298.75533"
+       y2="159.89824" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6777-2"
+       id="linearGradient4883"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.45355,-1.9663499)"
+       x1="83.146518"
+       y1="159.89824"
+       x2="298.75533"
+       y2="159.89824" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6777-2"
+       id="linearGradient4889"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.45355,-1.9663499)"
+       x1="83.146518"
+       y1="159.89824"
+       x2="298.75533"
+       y2="159.89824" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="319.08317"
+     inkscape:cy="757.86288"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-grids="true"
+     inkscape:snap-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3841" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Makruk Pieces</dc:title>
+        <cc:license
+           rdf:resource="https://gnu.org/copyleft/gpl.html   GNU General Public License V3" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Peter Thomson, alwey</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Peter Thomson (2015)</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2018-04-28</dc:date>
+        <dc:description>Makruk piece set by Peter Thomson (cajone) for the PyChess project. Adapted piece sizes by alwey for the CuteChess project.</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,2.6171874e-6)">
+    <g
+       id="K">
+      <desc
+         id="desc4879">White King (Khun, Lord)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer4"
+         transform="translate(30.42105,81.3616)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6751"
+           d="m 190.95093,-2.7808296 36.1509,87.1329476 -20.39282,12.050302 11.12336,11.58683 28.73533,10.19641 26.88144,16.22156 19.92935,23.63713 4.63473,23.17365 -6.02515,25.02755 -9.73294,19.46587 -25.95449,31.97965 -40.32216,34.29701 74.1557,0.92695 1.39042,29.77197 -206.245545,0 0,-29.77197 82.961685,-0.46348 -36.1509,-27.80839 -20.85629,-21.78323 -16.221559,-23.63713 -9.269463,-24.1006 -2.317365,-23.17366 7.41557,-20.39282 16.685037,-18.53892 22.24671,-13.9042 28.27186,-11.12335 7.87904,-2.78084 7.41557,-9.732937 -20.85629,-8.805989 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Gradient"
+         id="layer5"
+         transform="translate(30.42105,81.521496)">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6751-6"
+           d="m 191.18115,-2.4432683 36.1509,87.1329483 -20.39282,12.050303 11.12336,11.586827 28.73533,10.19641 26.88144,16.22156 19.92935,23.63713 4.63473,23.17365 -6.02515,25.02755 -9.73294,19.46587 -25.95449,31.97965 -40.32216,34.29701 74.1557,0.92695 1.39042,29.77197 -206.245537,0 0,-29.77197 82.961677,-0.46348 -36.1509,-27.80839 -20.85629,-21.78323 -16.221557,-23.63713 -9.26946,-24.1006 -2.31737,-23.17366 7.41557,-20.39282 16.685037,-18.53892 22.24671,-13.9042 28.27186,-11.12335 7.87904,-2.78084 7.41557,-9.732935 -20.85629,-8.805989 z"
+           style="fill:url(#linearGradient4387);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-3"
+         inkscape:label="Layer 1"
+         transform="translate(30.42105,83.361601)">
+        <rect
+           y="27.344906"
+           x="162.67908"
+           height="15.294614"
+           width="53.299412"
+           id="rect7395"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="7.4354506"
+           y="31.567141"
+           x="174.58932"
+           height="15.38369"
+           width="98.536415"
+           id="rect7397"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:15.75340939;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="7.4354501"
+           y="101.5006"
+           x="135.79764"
+           height="43.103004"
+           width="95.011993"
+           id="rect7399"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7867"
+           d="M 203.46471,99.646719 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892"
+           d="m 215.65358,106.42396 c 64.74226,20.21891 84.49536,49.0161 81.69422,77.26596 -3.38984,34.18666 -29.89134,72.02054 -82.53438,108.94"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6"
+           d="m 224.97026,289.83951 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.48880172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path7942"
+           d="M 152.18955,86.900744 191.03144,-5.19406 228.44137,86.714215"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946"
+           d="m 229.42325,84.283265 -22.44034,12.127007 9.30481,9.557458 0,0"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7969"
+           d="M 57.298382,253.67222 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8"
+           d="m 164.64125,106.11552 c -64.742256,20.21891 -83.336668,48.55263 -80.535528,76.8025 3.38984,34.18666 29.891338,72.02053 82.534378,108.94"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="0.40965599"
+           y="258.09653"
+           x="275.39938"
+           height="22.121439"
+           width="20.318951"
+           id="rect7991"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="4.8339405"
+           y="261.04602"
+           x="274.74393"
+           height="25.234819"
+           width="19.171902"
+           id="rect8007"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="2.0606499"
+           y="292.85864"
+           x="85.314903"
+           height="28.59721"
+           width="205.91806"
+           id="rect8009"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013"
+           d="m 142.23265,113.7353 c 92.41846,0 92.41846,0 92.41846,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015"
+           d="m 127.46173,121.27297 124.96605,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017"
+           d="m 160.91298,107.1808 55.28942,-0.14839 1.73473,0.47611"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8019"
+           d="m 83.242152,176.815 c 214.659878,0 214.659878,0 214.659878,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313"
+           d="m 113.08745,243.3234 c 156.42218,0 156.42218,0 156.42218,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315"
+           d="m 120.96649,252.59286 c 141.12757,0 141.35931,0 141.35931,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-4"
+           d="m 151.2063,84.597477 21.97687,12.127008 -9.30481,9.557455 0,0"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965"
+           d="M 86.678015,302.34029 C 291.33562,301.68876 291.33562,301.68876 291.33562,301.68876"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967"
+           d="m 289.66067,308.00955 c -202.729122,0 -200.966246,0 -202.729122,0 -1.762853,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+    </g>
+    <g
+       id="E"
+       transform="translate(818.78634,81.039163)">
+      <desc
+         id="desc8979">White Elephant (Khon, Nobleman)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer3">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4601"
+           d="m 178.49738,56.97426 27.80839,21.319764 -13.90419,11.123355 4.63473,10.196411 36.61438,14.83114 22.71018,12.51377 17.1485,16.68504 7.41557,12.97724 4.63474,18.07546 -3.24432,17.61198 -10.1964,24.1006 -10.65989,16.68503 -24.56407,26.41797 -38.0048,29.19881 62.1054,1.39042 -1.39042,29.3085 -163.60602,3.13462 0.46348,-33.37007 61.17845,-0.92695 -25.95449,-17.61197 -21.31977,-21.31977 -15.75809,-18.07545 -14.831136,-22.71018 -7.879043,-23.17366 -0.926947,-14.36767 6.488624,-17.61198 8.80599,-12.97725 19.002402,-16.22156 20.39281,-10.1964 20.8563,-8.80599 11.12335,-3.24432 2.78084,-1.85389 4.17126,-9.732934 -13.9042,-13.440721 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer2">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4601-7"
+           d="m 177.79923,57.26226 27.80839,21.319764 -13.90419,11.123355 4.63473,10.196411 36.61438,14.83114 22.71018,12.51377 17.1485,16.68504 7.41557,12.97724 4.63474,18.07546 -3.24432,17.61198 -10.1964,24.1006 -10.65989,16.68503 -24.56407,26.41797 -38.0048,29.19881 62.1054,1.39042 -1.39042,29.3085 -163.60602,3.13462 0.46348,-33.37007 61.17845,-0.92695 -25.95449,-17.61197 -21.31977,-21.31977 -15.75809,-18.07545 -14.83114,-22.71018 -7.87904,-23.17366 -0.92695,-14.36767 6.48863,-17.61198 8.80599,-12.97725 19.0024,-16.22156 20.39281,-10.1964 20.8563,-8.80599 11.12335,-3.24432 2.78084,-1.85389 4.17126,-9.732934 -13.9042,-13.440721 z"
+           style="fill:url(#linearGradient6084);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-7"
+         inkscape:label="Layer 1">
+        <rect
+           ry="7.4354501"
+           y="98.223351"
+           x="123.34409"
+           height="43.103004"
+           width="95.011993"
+           id="rect7399-9"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <use
+           style="fill:none"
+           transform="translate(-64.903988,-41.89831)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7401-2" />
+        <use
+           style="fill:none"
+           transform="translate(-54.630278,-23.322448)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7403-0" />
+        <use
+           style="fill:none"
+           transform="translate(-52.875268,-21.039501)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7405-2" />
+        <use
+           style="fill:none"
+           transform="translate(-50.010348,-24.881165)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7407-3" />
+        <use
+           style="fill:none"
+           transform="translate(-42.702768,-14.078738)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7409-7" />
+        <use
+           style="fill:none"
+           transform="translate(-42.829048,-7.8951471)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7411-5" />
+        <use
+           style="fill:none"
+           transform="translate(-43.893078,-16.473312)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7413-9" />
+        <use
+           style="fill:none"
+           transform="translate(-52.516478,-15.263686)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7415-2" />
+        <use
+           style="fill:none"
+           transform="translate(-45.488638,-3.7118887)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7417-2" />
+        <use
+           style="fill:none"
+           transform="translate(-52.287658,2.6307273)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7419-8" />
+        <use
+           style="fill:none"
+           transform="translate(-49.313998,-6.4787037)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7421-9" />
+        <use
+           style="fill:none"
+           transform="translate(-38.175978,15.642167)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7423-7" />
+        <use
+           style="fill:none"
+           transform="translate(-41.453328,-4.8572997)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7425-3" />
+        <use
+           style="fill:none"
+           transform="translate(-31.740128,6.8546172)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7427-6" />
+        <use
+           style="fill:none"
+           transform="translate(-42.463428,30.219905)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7429-1" />
+        <use
+           style="fill:none"
+           transform="translate(-33.334478,36.364809)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7431-2" />
+        <use
+           style="fill:none"
+           transform="translate(-29.673778,33.820059)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7433-9" />
+        <use
+           style="fill:none"
+           transform="translate(-42.849868,30.11827)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7435-3" />
+        <use
+           style="fill:none"
+           transform="translate(-36.914328,14.124709)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7437-1" />
+        <use
+           style="fill:none"
+           transform="translate(-19.254398,20.987022)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7439-9" />
+        <use
+           style="fill:none"
+           transform="translate(-33.871448,39.680308)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7441-4" />
+        <use
+           style="fill:none"
+           transform="translate(-20.180308,27.115187)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7443-7" />
+        <use
+           style="fill:none"
+           transform="translate(-30.206968,33.953632)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7445-8" />
+        <use
+           style="fill:none"
+           transform="translate(-71.992798,-40.853477)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7447-4" />
+        <use
+           style="fill:none"
+           transform="translate(-73.466038,-30.090479)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7449-5" />
+        <use
+           style="fill:none"
+           transform="translate(-58.965348,-41.130145)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7451-0" />
+        <use
+           style="fill:none"
+           transform="translate(-9.9403074,46.363562)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7453-3" />
+        <use
+           style="fill:none"
+           transform="translate(-50.307838,1.2081263)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7455-6" />
+        <use
+           style="fill:none"
+           transform="translate(-42.353338,-14.111704)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7457-1" />
+        <use
+           style="fill:none"
+           transform="translate(-56.755728,-4.9357457)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7459-0" />
+        <use
+           style="fill:none"
+           transform="translate(-40.494628,1.2178173)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7461-6" />
+        <use
+           style="fill:none"
+           transform="translate(-47.773908,20.269536)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7463-3" />
+        <use
+           style="fill:none"
+           transform="translate(-53.656258,11.353041)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7465-2" />
+        <use
+           style="fill:none"
+           transform="translate(-41.873218,19.652604)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7467-0" />
+        <use
+           style="fill:none"
+           transform="translate(-44.648678,17.511905)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7469-6" />
+        <use
+           style="fill:none"
+           transform="translate(-9.8052074,25.749294)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7471-1" />
+        <use
+           style="fill:none"
+           transform="translate(-8.8370674,42.959665)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7473-5" />
+        <use
+           style="fill:none"
+           transform="translate(-18.669548,37.083324)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7475-5" />
+        <use
+           style="fill:none"
+           transform="translate(-22.848008,21.444351)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7477-4" />
+        <use
+           style="fill:none"
+           transform="translate(-4.4861474,25.781344)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7479-7" />
+        <use
+           style="fill:none"
+           transform="translate(-0.48673735,36.134685)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7481-6" />
+        <use
+           style="fill:none"
+           transform="translate(-14.659768,38.821224)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7483-5" />
+        <use
+           style="fill:none"
+           transform="translate(10.706172,25.024276)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7485-6" />
+        <use
+           style="fill:none"
+           transform="translate(7.7617123,9.6753892)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7487-9" />
+        <use
+           style="fill:none"
+           transform="translate(-5.4250974,13.018049)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7489-3" />
+        <use
+           style="fill:none"
+           transform="translate(13.752192,19.389891)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7491-7" />
+        <use
+           style="fill:none"
+           transform="translate(4.3792323,1.5679133)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7493-4" />
+        <use
+           style="fill:none"
+           transform="translate(4.8274423,5.2908642)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7495-5" />
+        <use
+           style="fill:none"
+           transform="translate(14.092492,16.743036)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7497-2" />
+        <use
+           style="fill:none"
+           transform="translate(6.6919023,19.447885)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7499-5" />
+        <use
+           style="fill:none"
+           transform="translate(10.322812,8.8875972)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7501-4" />
+        <use
+           style="fill:none"
+           transform="translate(15.825152,9.3716602)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7503-7" />
+        <use
+           style="fill:none"
+           transform="translate(30.736052,22.464932)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7505-4" />
+        <use
+           style="fill:none"
+           transform="translate(33.254112,16.676737)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7507-4" />
+        <use
+           style="fill:none"
+           transform="translate(41.953052,1.6094843)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7509-3" />
+        <use
+           style="fill:none"
+           transform="translate(50.700322,4.4116953)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7511-0" />
+        <use
+           style="fill:none"
+           transform="translate(45.375102,1.7143633)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7513-7" />
+        <use
+           style="fill:none"
+           transform="translate(53.936022,-6.3420517)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7515-8" />
+        <use
+           style="fill:none"
+           transform="translate(45.693362,-3.8895887)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7517-6" />
+        <use
+           style="fill:none"
+           transform="translate(6.2227223,2.1699073)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7519-8" />
+        <use
+           style="fill:none"
+           transform="translate(6.1714023,24.798813)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7521-8" />
+        <use
+           style="fill:none"
+           transform="translate(16.744382,3.8861273)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7523-4" />
+        <use
+           style="fill:none"
+           transform="translate(5.9882723,7.4498762)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7525-3" />
+        <use
+           style="fill:none"
+           transform="translate(34.136022,4.1062143)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7527-1" />
+        <use
+           style="fill:none"
+           transform="translate(75.964582,1.0617493)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7759-4" />
+        <use
+           style="fill:none"
+           transform="translate(100.19318,-29.836403)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7761-9" />
+        <use
+           style="fill:none"
+           transform="translate(83.446442,-18.17492)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7775-2" />
+        <use
+           style="fill:none"
+           transform="translate(84.082282,-34.26385)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7777-0" />
+        <use
+           style="fill:none"
+           transform="translate(63.573602,25.081506)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7779-6" />
+        <use
+           style="fill:none"
+           transform="translate(81.793172,-14.960432)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7781-8" />
+        <use
+           transform="translate(52.161132,-57.954229)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7783-9" />
+        <use
+           style="fill:none"
+           transform="translate(55.473292,-30.183602)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7785-2" />
+        <use
+           style="fill:none"
+           transform="translate(64.050392,-26.10261)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7787-6" />
+        <use
+           style="fill:none"
+           transform="translate(44.804372,-45.309833)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7789-6" />
+        <use
+           style="fill:none"
+           transform="translate(67.665852,-41.773174)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7791-4" />
+        <use
+           style="fill:none"
+           transform="translate(66.862392,-33.135062)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7793-9" />
+        <use
+           style="fill:none"
+           transform="translate(44.932042,7.5836812)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7795-5" />
+        <use
+           style="fill:none"
+           transform="translate(53.711882,19.022767)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7797-0" />
+        <use
+           style="fill:none"
+           transform="translate(54.106182,2.0032623)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-9"
+           id="use7799-4" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7867-8"
+           d="M 191.01116,96.369469 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-7"
+           d="m 197.63505,100.38993 c 67.96584,20.28914 90.15057,51.2728 87.20996,79.62078 -3.55863,34.30541 -31.37965,72.27072 -86.64383,109.31842"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-1"
+           d="m 212.51671,286.56226 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.48880172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7942-7"
+           d="m 149.75304,78.041333 c 0,0 0,0 28.86932,-21.255381 28.24172,21.621853 28.24172,21.621853 28.24172,21.621853"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7969-2"
+           d="M 44.844832,250.39497 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-7"
+           d="m 160.06939,100.99596 c -66.46817,20.21641 -91.26821,50.40029 -88.392397,78.64667 3.480206,34.18244 30.688187,72.01164 84.734587,108.92655"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-2"
+           d="m 149.38274,75.722722 15.63884,14.612739 -6.13078,11.654429 0.22198,0.22162"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="2.3065262"
+           y="289.49747"
+           x="96.414536"
+           height="32.009426"
+           width="164.83687"
+           id="rect8009-2"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-2"
+           d="m 133.05635,110.45805 c 89.14121,0 89.14121,0 89.14121,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8015-6"
+           d="m 117.32555,117.99572 c 121.25826,0 121.25826,0 121.25826,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8017-1"
+           d="m 159.35676,101.12077 c 38.01034,0.3316 38.01034,0.3316 38.01034,0.3316"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8019-0"
+           d="m 71.444052,176.15955 c 214.659878,0 214.659878,0 214.659878,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-2-0"
+           d="m 207.95696,76.537143 -15.63884,13.685793 6.13078,11.654434 -0.22198,0.22162"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-6"
+           d="m 96.10148,300.15106 c 163.86486,-0.65443 163.86486,-0.65443 163.86486,-0.65443"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967-1"
+           d="m 260.09262,309.09331 c -163.48558,0 -162.06396,0 -163.48558,0 -1.42161,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7943"
+           d="m 72.403643,168.0859 c 212.187477,-1.17692 212.187477,-1.17692 212.187477,-1.17692 l 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7945"
+           d="m 115.00157,254.86694 c 126.52816,0 126.52816,0 126.52816,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7947"
+           d="m 124.7345,264.1364 c 105.2084,0.46348 105.2084,0.46348 105.2084,0.46348"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+    </g>
+    <g
+       id="F"
+       transform="matrix(0.9,0,0,0.9,307.15252,114.78324)">
+      <desc
+         id="desc8971">White Advisor (Met, Seed)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer6">
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path7473"
+           d="m 180.21207,15.457925 15.14595,13.503967 -7.57298,15.764815 14.74963,66.993853 c 25.20873,8.76275 38.47985,16.57261 57.1658,36.60284 24.35299,33.35429 3.54771,75.61522 -20.79782,104.9885 -11.62224,13.28399 -21.65804,23.55574 -33.7892,33.873 l 44.8316,0.83672 0.0327,32.1963 -136.29968,-0.3069 -0.27046,-31.61157 45.43787,-0.3069 -30.29191,-28.54248 c -7.66317,-9.14362 -15.32631,-20.02288 -22.98944,-31.61156 -5.10922,-10.72442 -9.811342,-21.52794 -11.900401,-32.8392 l -1.622777,-16.57306 c 1.185349,-9.70188 4.093302,-21.47212 8.846038,-28.20324 11.68876,-16.60743 23.47463,-24.2566 40.81694,-31.97012 l 16.80572,-6.70031 12.23619,-66.825873 -5.9502,-16.685539 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.87912208px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer7">
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path7473-7"
+           d="m 180.48545,15.358034 15.14591,13.517911 -7.57296,15.781092 14.46959,67.704013 c 11.51066,3.1363 22.71197,9.21389 34.21358,17.41032 8.89239,5.48921 16.35721,13.10435 21.6369,19.20559 4.41344,6.33093 8.10681,13.02165 10.00739,20.60814 3.54679,34.48619 -11.75525,61.85987 -29.34518,83.71488 l -35.5659,35.1813 45.97868,-0.33127 -0.54091,32.2827 -134.96097,-0.30723 -0.27046,-31.6442 45.43777,-0.30723 -30.29185,-28.57195 c -7.66311,-9.15305 -15.32623,-20.04355 -22.98934,-31.64419 -4.93219,-10.53563 -9.790351,-21.10363 -11.900374,-32.87311 -6.7423,-25.85945 8.224494,-50.47354 22.584174,-60.86265 13.01344,-11.5326 26.41188,-16.53717 42.59759,-22.47557 l 11.90015,-67.089543 -5.95017,-16.702768 z"
+           style="fill:url(#linearGradient4511);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.87957466px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-5"
+         inkscape:label="Layer 1">
+        <rect
+           ry="6.6679459"
+           y="45.913719"
+           x="167.66689"
+           height="13.79575"
+           width="81.403564"
+           id="rect7397-6"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:13.55939388;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="7.0710044"
+           y="107.55771"
+           x="135.68591"
+           height="40.990326"
+           width="78.408134"
+           id="rect7399-3"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:18.60362434;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <use
+           style="fill:none"
+           transform="translate(-46.598356,-21.729663)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7403-9" />
+        <use
+           style="fill:none"
+           transform="translate(-45.150506,-19.51459)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7405-4" />
+        <use
+           style="fill:none"
+           transform="translate(-42.787005,-23.242037)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7407-8" />
+        <use
+           style="fill:none"
+           transform="translate(-35.240233,-13.388673)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7409-1" />
+        <use
+           style="fill:none"
+           transform="translate(-35.344447,-7.5081692)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7411-2" />
+        <use
+           style="fill:none"
+           transform="translate(-36.222532,-15.665879)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7413-93" />
+        <use
+           style="fill:none"
+           transform="translate(-44.854513,-13.910496)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7415-9" />
+        <use
+           style="fill:none"
+           transform="translate(-37.539255,-3.5299522)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7417-0" />
+        <use
+           style="fill:none"
+           transform="translate(-44.665738,3.4519005)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7419-88" />
+        <use
+           style="fill:none"
+           transform="translate(-42.212529,-5.3866988)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7421-5" />
+        <use
+           style="fill:none"
+           transform="translate(-31.504524,14.875473)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7423-0" />
+        <use
+           style="fill:none"
+           transform="translate(-34.20914,-4.6192206)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7425-9" />
+        <use
+           style="fill:none"
+           transform="translate(-26.193375,6.5186407)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7427-63" />
+        <use
+           style="fill:none"
+           transform="translate(-35.04272,28.738686)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7429-8" />
+        <use
+           style="fill:none"
+           transform="translate(-27.5091,34.582405)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7431-5" />
+        <use
+           style="fill:none"
+           transform="translate(-24.488129,32.162382)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7433-6" />
+        <use
+           style="fill:none"
+           transform="translate(-35.361624,28.642033)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7435-1" />
+        <use
+           style="fill:none"
+           transform="translate(-30.463357,13.432392)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7437-15" />
+        <use
+           style="fill:none"
+           transform="translate(-15.889588,19.958351)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7439-98" />
+        <use
+           style="fill:none"
+           transform="translate(-27.952235,37.735389)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7441-48" />
+        <use
+           style="fill:none"
+           transform="translate(-16.65369,25.786146)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7443-1" />
+        <use
+           style="fill:none"
+           transform="translate(-24.928137,32.289413)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7445-0" />
+        <use
+           style="fill:none"
+           transform="translate(-8.2031898,44.091068)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7453-30" />
+        <use
+           style="fill:none"
+           transform="translate(-43.03242,2.071595)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7455-4" />
+        <use
+           style="fill:none"
+           transform="translate(-34.951864,-13.420024)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7457-4" />
+        <use
+           style="fill:none"
+           transform="translate(-33.417976,1.1581261)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7461-4" />
+        <use
+           style="fill:none"
+           transform="translate(-40.941984,20.566291)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7463-4" />
+        <use
+           style="fill:none"
+           transform="translate(-45.794808,11.914891)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7465-7" />
+        <use
+           style="fill:none"
+           transform="translate(-34.555651,18.689338)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7467-6" />
+        <use
+           style="fill:none"
+           transform="translate(-36.846084,16.653565)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7469-3" />
+        <use
+           style="fill:none"
+           transform="translate(-8.0916988,24.487203)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7471-17" />
+        <use
+           style="fill:none"
+           transform="translate(-7.2927458,40.854014)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7473-59" />
+        <use
+           style="fill:none"
+           transform="translate(-15.406949,35.265702)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7475-6" />
+        <use
+           style="fill:none"
+           transform="translate(-18.855196,20.393264)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7477-2" />
+        <use
+           style="fill:none"
+           transform="translate(-3.7021738,24.517681)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7479-1" />
+        <use
+           style="fill:none"
+           transform="translate(-0.40167881,34.36356)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7481-7" />
+        <use
+           style="fill:none"
+           transform="translate(-12.097898,36.918416)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7483-8" />
+        <use
+           style="fill:none"
+           transform="translate(8.835207,23.79772)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7485-5" />
+        <use
+           style="fill:none"
+           transform="translate(6.405305,9.2011535)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7487-7" />
+        <use
+           style="fill:none"
+           transform="translate(-4.4770348,12.379974)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7489-4" />
+        <use
+           style="fill:none"
+           transform="translate(11.348919,18.439502)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7491-1" />
+        <use
+           style="fill:none"
+           transform="translate(3.6139342,1.4910622)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7493-8" />
+        <use
+           style="fill:none"
+           transform="translate(3.9838192,5.0315349)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7495-59" />
+        <use
+           style="fill:none"
+           transform="translate(11.629747,15.922382)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7497-7" />
+        <use
+           style="fill:none"
+           transform="translate(5.5224512,18.494654)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7499-53" />
+        <use
+           style="fill:none"
+           transform="translate(8.518844,8.4519749)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7501-8" />
+        <use
+           style="fill:none"
+           transform="translate(13.059619,8.9123117)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7503-8" />
+        <use
+           style="fill:none"
+           transform="translate(25.364762,21.363822)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7505-3" />
+        <use
+           style="fill:none"
+           transform="translate(27.442773,15.859333)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7507-1" />
+        <use
+           style="fill:none"
+           transform="translate(34.621524,1.530596)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7509-8" />
+        <use
+           style="fill:none"
+           transform="translate(41.840167,4.1954577)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7511-9" />
+        <use
+           style="fill:none"
+           transform="translate(37.445552,1.6303341)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7513-6" />
+        <use
+           style="fill:none"
+           transform="translate(44.510411,-6.031199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7515-4" />
+        <use
+           style="fill:none"
+           transform="translate(37.708195,-3.6989423)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7517-3" />
+        <use
+           style="fill:none"
+           transform="translate(5.1352652,2.0635496)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7519-3" />
+        <use
+           style="fill:none"
+           transform="translate(5.0929142,23.583308)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7521-3" />
+        <use
+           style="fill:none"
+           transform="translate(13.81821,3.6956497)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7523-8" />
+        <use
+           style="fill:none"
+           transform="translate(4.9417862,7.0847236)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7525-6" />
+        <use
+           style="fill:none"
+           transform="translate(28.170564,3.9049498)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7527-0" />
+        <use
+           style="fill:none"
+           transform="translate(78.547773,-80.194199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7731-4" />
+        <use
+           style="fill:none"
+           transform="translate(79.534526,-86.970032)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7733-8" />
+        <use
+           style="fill:none"
+           transform="translate(77.069719,-75.385855)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7753-8" />
+        <use
+           style="fill:none"
+           transform="translate(71.085211,-61.896483)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7755-8" />
+        <use
+           style="fill:none"
+           transform="translate(79.091026,-48.152258)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7757-9" />
+        <use
+           style="fill:none"
+           transform="translate(61.139889,1.9295693)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7759-7" />
+        <use
+           style="fill:none"
+           transform="translate(81.128016,-28.049951)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7761-7" />
+        <use
+           style="fill:none"
+           transform="translate(74.54694,-35.386005)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7763-6" />
+        <use
+           style="fill:none"
+           transform="translate(67.312274,-16.735176)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7775-4" />
+        <use
+           style="fill:none"
+           transform="translate(67.836835,-32.345766)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7777-3" />
+        <use
+           style="fill:none"
+           transform="translate(52.463767,23.852146)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7779-0" />
+        <use
+           style="fill:none"
+           transform="translate(65.948358,-13.616257)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7781-3" />
+        <use
+           style="fill:none"
+           transform="matrix(1.0010688,0,0,0.94299839,42.880836,-44.770314)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7783-0" />
+        <use
+           style="fill:none"
+           transform="translate(45.779033,-28.704164)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7785-9" />
+        <use
+           style="fill:none"
+           transform="translate(52.857241,-24.823199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7787-2" />
+        <use
+           style="fill:none"
+           transform="matrix(1.0010688,0,0,0.94299839,36.803222,-33.431101)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7789-5" />
+        <use
+           style="fill:none"
+           transform="translate(54.293599,-39.631829)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7791-40" />
+        <use
+           style="fill:none"
+           transform="translate(53.630757,-31.250538)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7793-5" />
+        <use
+           style="fill:none"
+           transform="translate(37.079924,7.2119696)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7795-9" />
+        <use
+           style="fill:none"
+           transform="translate(44.325439,18.090373)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7797-4" />
+        <use
+           style="fill:none"
+           transform="translate(44.650829,1.9050732)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-3"
+           id="use7799-6" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-9"
+           d="m 201.58658,112.23975 c 53.4282,19.22787 69.72934,46.61358 67.41771,73.47879 -2.79744,32.511 -23.04494,66.93218 -66.48833,102.04204"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-2"
+           d="m 209.27512,286.66524 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.31890976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7969-24"
+           d="M 69.411186,251.77719 z"
+           style="fill:none;stroke:#000000;stroke-width:0.8946805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-77"
+           d="m 159.48893,111.94642 c -53.4282,19.22787 -68.773144,46.17283 -66.461524,73.03806 2.797453,32.511 24.667674,68.49046 68.111054,103.60033"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="2.3149922"
+           y="288.17261"
+           x="113.49566"
+           height="32.126919"
+           width="135.96426"
+           id="rect8009-5"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-4"
+           d="m 140.9362,119.6003 c 76.34935,0 76.34935,0 76.34935,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015-8"
+           d="m 128.73354,126.3599 103.23779,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017-12"
+           d="m 156.36851,113.72235 45.67607,-0.13307 1.4331,0.42697"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-8"
+           d="m 116.94443,242.4291 c 129.08656,0 129.08656,0 129.08656,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315-9"
+           d="m 123.44657,251.24422 c 116.46476,0 116.65601,0 116.65601,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4412"
+           d="m 201.77841,113.12072 0,0 -13.7991,-69.172912 c 0,0 1.72667,-1.469481 6.98383,-13.681026 0,0 -0.64369,-0.881691 -15.1887,-13.017288 l 0,0 0,0 0,0 -15.18867,12.704403 6.23791,14.650696 -11.18847,68.566117"
+           style="fill:none;stroke:#000000;stroke-width:4.30363798;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7123"
+           d="m 160.50774,104.05655 c 40.01176,0 40.01176,0 40.01176,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7125"
+           d="m 164.52806,84.210105 c 31.77967,0 31.77967,0 31.77967,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7127"
+           d="m 165.29384,78.59907 c 29.67377,0 29.67377,0 29.67377,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7951"
+           d="m 92.68983,178.80897 c 175.55774,0.44075 175.55774,0.44075 175.55774,0.44075"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-3"
+           d="m 114.10901,300.63394 c 135.2286,-0.62235 135.2286,-0.62235 135.2286,-0.62235"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7967-6"
+           d="m 249.8243,309.13789 c -27.73767,-0.62062 -74.56158,-0.55393 -134.9156,0 -1.17314,0.0108 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+      <path
+         style="fill:none;stroke:none"
+         d="m 106.66696,-30.467844 c 0,44.496726 0,44.496726 0,44.496726 l 139.87603,-0.01513 0.53033,-44.206824 -129.01721,-0.252485 z"
+         id="path3843"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+    <g
+       id="R"
+       transform="translate(547.07673,83.202533)">
+      <desc
+         id="desc8977">White Boat (Rua, Rook)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base colour"
+         id="layer19">
+        <path
+           inkscape:connector-curvature="0"
+           id="path10308"
+           d="m 182.87055,135.03743 34.0834,18.68033 33.10022,9.50402 27.5289,12.12583 18.02488,12.78127 9.50402,13.43673 1.3109,25.89027 -1.3109,19.99123 -5.89905,19.33577 -10.4872,12.78128 -27.5289,20.64667 44.24288,-0.32772 0,19.33577 -248.087826,0.32773 0,-19.99123 43.587426,0.65545 -26.218001,-18.02487 -13.436725,-17.69715 -5.571325,-17.0417 -1.3109,-38.99928 9.1763,-16.71397 18.3526,-14.4199 23.923921,-10.81493 20.9744,-7.20995 19.99123,-5.2436 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradiant top"
+         id="layer18">
+        <path
+           inkscape:connector-curvature="0"
+           id="path10308-9"
+           d="m 182.38071,135.23479 34.0834,18.68033 33.10022,9.50402 27.5289,12.12583 18.02488,12.78127 9.50402,13.43673 1.3109,25.89027 -1.3109,19.99123 -5.89905,19.33577 -10.4872,12.78128 -27.5289,20.64667 44.24288,-0.32772 0,19.33577 -248.087829,0.32773 0,-19.99123 43.587429,0.65545 -26.217999,-18.02487 -13.43673,-17.69715 -5.57132,-17.0417 -1.3109,-38.99928 9.1763,-16.71397 18.3526,-14.4199 23.923919,-10.81493 20.9744,-7.20995 19.99123,-5.2436 z"
+           style="fill:url(#linearGradient12663);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 3"
+         id="layer7-8">
+        <rect
+           ry="1.388453"
+           y="154.56525"
+           x="140.63086"
+           height="144.25529"
+           width="79.564346"
+           id="rect4610"
+           style="fill:none;stroke:#000000;stroke-width:1.43576396px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-47"
+           d="m 219.44056,154.78784 c 67.093,15.881 89.14949,38.36377 87.60998,60.68874 -1.87428,27.17972 7.36717,55.25783 -47.18729,84.25632"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-24"
+           d="m 231.71751,296.72596 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.13756776px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-0"
+           d="M 59.756729,309.4113 C 305.32923,308.5111 305.32923,308.5111 305.32923,308.5111"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967-62"
+           d="m 304.83632,316.85017 c -245.004105,0 -242.873626,0 -245.004105,0 -2.130465,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.49516487px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <rect
+           ry="1.3884516"
+           y="300.07492"
+           x="56.97345"
+           height="19.268602"
+           width="248.52936"
+           id="rect8009-9"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-9"
+           d="m 121.29966,160.97515 c 121.64504,0 121.64504,0 121.64504,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015-0"
+           d="m 92.16244,172.61257 177.61521,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017-8"
+           d="m 139.18413,155.96869 82.88703,-0.20181 2.60061,0.64751"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-1"
+           d="m 103.99497,166.17801 c 155.19056,0 155.19056,0 155.19056,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315-3"
+           d="m 56.998144,255.65128 c 247.319876,0 247.725986,0 247.725986,0"
+           style="fill:none;stroke:#000000;stroke-width:3.20112228;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path4412-1"
+           d="m 220.68836,155.63658 c 0,0 -13.59128,-8.91022 -37.35891,-20.82541 l 0,0 0,0 0,0 -43.1307,21.39957"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6071"
+           d="m 72.362665,244.49941 c 218.310825,0 218.310825,0 218.310825,0"
+           style="fill:none;stroke:#b60000;stroke-width:1.43576396px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6083"
+           d="m 57.695535,202.75546 c 246.989625,0.22501 246.989625,0.22501 246.989625,0.22501"
+           style="fill:none;stroke:#000000;stroke-width:3.03392625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-4"
+           d="m 142.4059,155.41387 c -67.093003,15.881 -89.149493,38.36377 -87.609983,60.68874 1.87428,27.17972 -7.36717,55.25783 47.187293,84.25632"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+      <path
+         style="fill:none;stroke:none"
+         d="m 120.15278,7.733597 c 0,40.04705 0,40.04705 0,40.04705 l 125.88843,-0.0136 0.47729,-39.78615 -116.11548,-0.22723 z"
+         id="path3843-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+    <g
+       id="N"
+       transform="translate(1112.1159,79.3616)">
+      <desc
+         id="desc8985">White Horse (Ma)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer17">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path9164"
+           d="m 184.14176,50.055101 c 52.40583,30.963352 101.19043,65.964629 117.2587,117.722179 l -1.39042,156.19044 -246.104232,-0.46347 -2.31737,-160.3617 C 70.574548,118.26928 119.60027,76.910204 169.77409,49.591628 l -4.17126,39.395216 20.85629,-0.463473 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g9208"
+         inkscape:label="gardient top">
+        <path
+           style="fill:url(#linearGradient8078);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 184.14176,50.055101 c 52.40583,30.963352 101.19043,65.964629 117.2587,117.722179 l -1.39042,156.19044 -246.104232,-0.46347 -2.31737,-160.3617 C 70.574548,118.26928 119.60027,76.910204 169.77409,49.591628 l -4.17126,39.395216 20.85629,-0.463473 z"
+           id="path9210"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-4"
+         inkscape:label="Layer 1">
+        <rect
+           transform="scale(-1,1)"
+           ry="8.0185995"
+           y="83.042877"
+           x="-241.91574"
+           height="46.483501"
+           width="111.479"
+           id="rect7399-0"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:23.62230492;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7867-4"
+           d="M 162.52096,81.043591 z"
+           style="fill:none;stroke:#000000;stroke-width:1.12487173px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-29"
+           d="m 137.28817,286.1529 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.67471099px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <rect
+           transform="scale(-1,1)"
+           ry="2.4583752"
+           y="289.51987"
+           x="-300.59454"
+           height="34.116749"
+           width="247.95403"
+           id="rect8009-4"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8835"
+           d="m 51.717388,164.26226 c 1.15126,125.65518 1.15126,125.65518 1.15126,125.65518"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-2"
+           d="M 170.40813,49.739754 C 101.04495,87.524402 52.501068,140.34942 51.436178,171.06914 c -1.46207,42.17749 22.4897,90.04828 100.506942,117.89208"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-2"
+           d="m 182.19632,49.032897 c 69.36319,37.784648 117.90707,90.609673 118.97196,121.329383 1.46207,42.17748 -22.48971,90.04829 -100.50696,117.89208"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8883"
+           d="m 300.83826,166.66666 0.21256,124.28083"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-2"
+           d="M 299.71611,306.8235 C 54.377353,306.12117 54.377353,306.12117 54.377353,306.12117"
+           style="fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path8902"
+           d="m 120.51507,105.0482 c 5.334,45.48115 8.54723,91.65333 27.30884,130.69358 17.7851,17.6183 33.60003,13.05906 48.76577,1.19175 20.75566,-41.40083 26.76396,-87.17009 33.64836,-132.67983"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="0.54396933"
+           rx="4.0525527"
+           cy="144.68547"
+           cx="-146.63318"
+           id="path8904"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.00427389;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-146.63318"
+           sodipodi:cy="144.68547"
+           sodipodi:rx="4.0525527"
+           sodipodi:ry="0.54396933"
+           d="m -142.58063,144.68547 c 0,0.30043 -1.81439,0.54397 -4.05255,0.54397 -2.23816,0 -4.05255,-0.24354 -4.05255,-0.54397 0,-0.30043 1.81439,-0.54397 4.05255,-0.54397 2.23816,0 4.05255,0.24354 4.05255,0.54397 z" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="0.54396933"
+           rx="4.0525527"
+           cy="144.86215"
+           cx="-205.75378"
+           id="path8904-2"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.00427389;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-205.75378"
+           sodipodi:cy="144.86215"
+           sodipodi:rx="4.0525527"
+           sodipodi:ry="0.54396933"
+           d="m -201.70123,144.86215 c 0,0.30043 -1.81439,0.54397 -4.05255,0.54397 -2.23817,0 -4.05256,-0.24354 -4.05256,-0.54397 0,-0.30042 1.81439,-0.54397 4.05256,-0.54397 2.23816,0 4.05255,0.24355 4.05255,0.54397 z" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="6.6800156"
+           rx="0.34631962"
+           cy="93.968521"
+           cx="-149.22867"
+           id="path8968"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.47502375;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-149.22867"
+           sodipodi:cy="93.968521"
+           sodipodi:rx="0.34631962"
+           sodipodi:ry="6.6800156"
+           d="m -148.88235,93.968521 c 0,3.689271 -0.15505,6.680019 -0.34632,6.680019 -0.19127,0 -0.34632,-2.990748 -0.34632,-6.680019 0,-3.689271 0.15505,-6.680015 0.34632,-6.680015 0.19127,0 0.34632,2.990744 0.34632,6.680015 z" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="6.6800156"
+           rx="0.34631962"
+           cy="93.968521"
+           cx="-203.83115"
+           id="path8968-1"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.47502375;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-203.83115"
+           sodipodi:cy="93.968521"
+           sodipodi:rx="0.34631962"
+           sodipodi:ry="6.6800156"
+           d="m -203.48483,93.968521 c 0,3.689271 -0.15505,6.680019 -0.34632,6.680019 -0.19126,0 -0.34632,-2.990748 -0.34632,-6.680019 0,-3.689271 0.15506,-6.680015 0.34632,-6.680015 0.19127,0 0.34632,2.990744 0.34632,6.680015 z" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8987"
+           d="m 150.27216,72.546882 c -18.14748,17.042237 -14.41488,15.785673 -6.05183,38.365298"
+           style="fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8987-9"
+           d="m 201.4616,72.79368 c 18.14747,17.042227 14.41487,15.785664 6.05183,38.36529"
+           style="fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="2.8842514"
+           rx="0.61694747"
+           cy="236.49719"
+           cx="-165.85223"
+           id="path8904-0"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:6.29291916;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-165.85223"
+           sodipodi:cy="236.49719"
+           sodipodi:rx="0.61694747"
+           sodipodi:ry="2.8842514"
+           d="m -165.23529,236.49719 c 0,1.59293 -0.27621,2.88425 -0.61694,2.88425 -0.34073,0 -0.61695,-1.29132 -0.61695,-2.88425 0,-1.59293 0.27622,-2.88425 0.61695,-2.88425 0.34073,0 0.61694,1.29132 0.61694,2.88425 z" />
+        <ellipse
+           transform="scale(-1,1)"
+           ry="2.8842514"
+           rx="0.61694747"
+           cy="235.99736"
+           cx="-180.53482"
+           id="path8904-0-0"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:6.29291916;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="-180.53482"
+           sodipodi:cy="235.99736"
+           sodipodi:rx="0.61694747"
+           sodipodi:ry="2.8842514"
+           d="m -179.91787,235.99736 c 0,1.59293 -0.27622,2.88425 -0.61695,2.88425 -0.34073,0 -0.61695,-1.29132 -0.61695,-2.88425 0,-1.59293 0.27622,-2.88425 0.61695,-2.88425 0.34073,0 0.61695,1.29132 0.61695,2.88425 z" />
+      </g>
+    </g>
+    <g
+       id="P"
+       transform="translate(1358.7469,109.10248)">
+      <desc
+         id="desc8989">White Pawn (Bia, Cowry Shell)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer8">
+        <path
+           inkscape:connector-curvature="0"
+           id="path8324"
+           d="m 182.60842,73.923969 33.37006,7.41557 32.44312,17.611979 20.39282,24.100602 16.68503,29.66228 3.70778,24.1006 -7.41557,39.85869 -20.39281,32.44312 -24.10061,24.1006 -35.22395,11.12335 -38.93175,0.92695 L 127.91859,271.36352 99.183249,247.26291 80.644324,207.40422 77.863485,186.31619 81.57127,143.44493 97.329356,121.19822 115.86829,93.38984 142.74973,81.339539 z"
+           style="fill:#fffbd6;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer9">
+        <path
+           inkscape:connector-curvature="0"
+           id="path8324-4"
+           d="m 182.60842,73.923976 33.37006,7.41557 32.44312,17.61198 20.39282,24.100594 16.68503,29.66228 3.70778,24.1006 -7.41557,39.85869 -20.39281,32.44312 -24.10061,24.1006 -35.22395,11.12335 -38.93175,0.92695 -35.22395,-13.90419 -28.735344,-24.10061 -18.53892,-39.85869 -2.78084,-21.08803 3.70779,-42.87126 15.75808,-22.24671 18.538934,-27.808374 26.88144,-12.0503 z"
+           style="fill:url(#linearGradient8347);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:none"
+         inkscape:label="Layer 0"
+         id="layer6-4">
+        <rect
+           y="30.941006"
+           x="30.943001"
+           height="291.746"
+           width="291.746"
+           id="rect5919"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-59"
+         inkscape:label="Layer 1">
+        <g
+           transform="matrix(1.0014278,0,0,1.0014238,-11.3932,30.387217)"
+           id="g3020"
+           style="fill:none;display:inline">
+          <ellipse
+             ry="104.62258"
+             rx="104.42029"
+             cy="150.0562"
+             cx="192.37167"
+             style="fill:none;stroke:#000000;stroke-width:21;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+             id="path3022"
+             sodipodi:cx="192.37167"
+             sodipodi:cy="150.0562"
+             sodipodi:rx="104.42029"
+             sodipodi:ry="104.62258"
+             d="m 296.79196,150.0562 c 0,57.78145 -46.75055,104.62258 -104.42029,104.62258 -57.66973,0 -104.420285,-46.84113 -104.420285,-104.62258 0,-57.781458 46.750555,-104.622583 104.420285,-104.622583 57.66974,0 104.42029,46.841125 104.42029,104.622583 z" />
+        </g>
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 2"
+         id="layer2-3">
+        <ellipse
+           ry="72.267258"
+           rx="75.077538"
+           cy="180.19504"
+           cx="180.78746"
+           style="fill:none;stroke:#000000;stroke-width:14.79925823;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5"
+           sodipodi:cx="180.78746"
+           sodipodi:cy="180.19504"
+           sodipodi:rx="75.077538"
+           sodipodi:ry="72.267258"
+           d="m 255.865,180.19504 c 0,39.9121 -33.61336,72.26726 -75.07754,72.26726 -41.46418,0 -75.07754,-32.35516 -75.07754,-72.26726 0,-39.91211 33.61336,-72.26726 75.07754,-72.26726 41.46418,0 75.07754,32.35515 75.07754,72.26726 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 3"
+         id="layer3-5">
+        <ellipse
+           transform="matrix(0.99678953,0.08006638,-0.06686515,0.99776202,0,0)"
+           ry="40.864048"
+           rx="41.200871"
+           cy="165.46802"
+           cx="192.71358"
+           style="fill:none;stroke:#000000;stroke-width:8.24400139;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9"
+           sodipodi:cx="192.71358"
+           sodipodi:cy="165.46802"
+           sodipodi:rx="41.200871"
+           sodipodi:ry="40.864048"
+           d="m 233.91445,165.46802 c 0,22.56859 -18.44626,40.86405 -41.20087,40.86405 -22.75462,0 -41.20087,-18.29546 -41.20087,-40.86405 0,-22.56859 18.44625,-40.86405 41.20087,-40.86405 22.75461,0 41.20087,18.29546 41.20087,40.86405 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 4"
+         id="layer4-7">
+        <ellipse
+           transform="matrix(0.99668818,0.08131836,-0.06583355,0.99783062,0,0)"
+           ry="18.172737"
+           rx="18.041676"
+           cy="165.15633"
+           cx="192.71057"
+           style="fill:none;stroke:#000000;stroke-width:3.63800049;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9-8"
+           sodipodi:cx="192.71057"
+           sodipodi:cy="165.15633"
+           sodipodi:rx="18.041676"
+           sodipodi:ry="18.172737"
+           d="m 210.75225,165.15633 c 0,10.03652 -8.07754,18.17273 -18.04168,18.17273 -9.96414,0 -18.04167,-8.13621 -18.04167,-18.17273 0,-10.03653 8.07753,-18.17274 18.04167,-18.17274 9.96414,0 18.04168,8.13621 18.04168,18.17274 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 5"
+         id="layer5-0">
+        <ellipse
+           transform="matrix(0.99697426,0.0777324,-0.06887617,0.99762522,0,0)"
+           ry="8.6921406"
+           rx="9.0256882"
+           cy="165.58498"
+           cx="193.04311"
+           style="fill:none;stroke:#000000;stroke-width:1.77958071;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9-8-7"
+           sodipodi:cx="193.04311"
+           sodipodi:cy="165.58498"
+           sodipodi:rx="9.0256882"
+           sodipodi:ry="8.6921406"
+           d="m 202.06879,165.58498 c 0,4.80053 -4.04093,8.69214 -9.02568,8.69214 -4.98475,0 -9.02569,-3.89161 -9.02569,-8.69214 0,-4.80054 4.04094,-8.69214 9.02569,-8.69214 4.98475,0 9.02568,3.8916 9.02568,8.69214 z" />
+      </g>
+    </g>
+    <g
+       id="e"
+       transform="translate(829.04057,504.25053)"
+       inkscape:label="#e">
+      <desc
+         id="desc8981">Black Elephant (Khon, Nobleman)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer3-3">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4601-1"
+           d="m 181.11918,55.00791 27.80839,21.319764 -13.90419,11.123355 4.63473,10.196411 36.61438,14.83114 22.71018,12.51377 17.1485,16.68504 7.41557,12.97724 4.63474,18.07546 -3.24432,17.61198 -10.1964,24.1006 -10.65989,16.68503 -24.56407,26.41797 -38.0048,29.19881 62.1054,1.39042 -1.39042,29.3085 -163.60602,3.13462 0.46348,-33.37007 61.17845,-0.92695 -25.95449,-17.61197 -21.31977,-21.31977 -15.75809,-18.07545 -14.831136,-22.71018 -7.879043,-23.17366 -0.926947,-14.36767 6.488624,-17.61198 8.80599,-12.97725 19.002402,-16.22156 20.39281,-10.1964 20.8563,-8.80599 11.12335,-3.24432 2.78084,-1.85389 4.17126,-9.732934 -13.9042,-13.440721 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer2-1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4601-7-9"
+           d="m 180.42103,55.29591 27.80839,21.319764 -13.90419,11.123355 4.63473,10.196411 36.61438,14.83114 22.71018,12.51377 17.1485,16.68504 7.41557,12.97724 4.63474,18.07546 -3.24432,17.61198 -10.1964,24.1006 -10.65989,16.68503 -24.56407,26.41797 -38.0048,29.19881 62.1054,1.39042 -1.39042,29.3085 -163.60602,3.13462 0.46348,-33.37007 61.17845,-0.92695 -25.95449,-17.61197 -21.31977,-21.31977 -15.75809,-18.07545 -14.83114,-22.71018 -7.87904,-23.17366 -0.92695,-14.36767 6.48863,-17.61198 8.80599,-12.97725 19.0024,-16.22156 20.39281,-10.1964 20.8563,-8.80599 11.12335,-3.24432 2.78084,-1.85389 4.17126,-9.732934 -13.9042,-13.440721 z"
+           style="fill:url(#linearGradient5223);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-0"
+         inkscape:label="Layer 1">
+        <rect
+           ry="7.4354501"
+           y="96.257004"
+           x="125.96589"
+           height="43.103004"
+           width="95.011993"
+           id="rect7399-5"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <use
+           style="fill:none"
+           transform="translate(-64.903988,-41.89831)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7401-6" />
+        <use
+           style="fill:none"
+           transform="translate(-54.630278,-23.322448)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7403-7" />
+        <use
+           style="fill:none"
+           transform="translate(-52.875268,-21.039501)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7405-7" />
+        <use
+           style="fill:none"
+           transform="translate(-50.010348,-24.881165)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7407-4" />
+        <use
+           style="fill:none"
+           transform="translate(-42.702768,-14.078738)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7409-0" />
+        <use
+           style="fill:none"
+           transform="translate(-42.829048,-7.8951471)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7411-6" />
+        <use
+           style="fill:none"
+           transform="translate(-43.893078,-16.473312)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7413-4" />
+        <use
+           style="fill:none"
+           transform="translate(-52.516478,-15.263686)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7415-7" />
+        <use
+           style="fill:none"
+           transform="translate(-45.488638,-3.7118887)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7417-4" />
+        <use
+           style="fill:none"
+           transform="translate(-52.287658,2.6307273)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7419-85" />
+        <use
+           style="fill:none"
+           transform="translate(-49.313998,-6.4787041)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7421-8" />
+        <use
+           style="fill:none"
+           transform="translate(-38.175978,15.642167)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7423-2" />
+        <use
+           style="fill:none"
+           transform="translate(-41.453328,-4.8573001)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7425-6" />
+        <use
+           style="fill:none"
+           transform="translate(-31.740128,6.8546172)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7427-0" />
+        <use
+           style="fill:none"
+           transform="translate(-42.463428,30.219905)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7429-6" />
+        <use
+           style="fill:none"
+           transform="translate(-33.334478,36.364809)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7431-6" />
+        <use
+           style="fill:none"
+           transform="translate(-29.673778,33.820059)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7433-4" />
+        <use
+           style="fill:none"
+           transform="translate(-42.849868,30.11827)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7435-6" />
+        <use
+           style="fill:none"
+           transform="translate(-36.914328,14.124709)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7437-2" />
+        <use
+           style="fill:none"
+           transform="translate(-19.254398,20.987022)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7439-8" />
+        <use
+           style="fill:none"
+           transform="translate(-33.871448,39.680308)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7441-9" />
+        <use
+           style="fill:none"
+           transform="translate(-20.180308,27.115187)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7443-6" />
+        <use
+           style="fill:none"
+           transform="translate(-30.206968,33.953632)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7445-07" />
+        <use
+           style="fill:none"
+           transform="translate(-71.992798,-40.853477)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7447-0" />
+        <use
+           style="fill:none"
+           transform="translate(-73.466038,-30.090479)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7449-1" />
+        <use
+           style="fill:none"
+           transform="translate(-58.965348,-41.130145)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7451-01" />
+        <use
+           style="fill:none"
+           transform="translate(-9.9403081,46.363562)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7453-37" />
+        <use
+           style="fill:none"
+           transform="translate(-50.307838,1.2081263)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7455-7" />
+        <use
+           style="fill:none"
+           transform="translate(-42.353338,-14.111704)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7457-2" />
+        <use
+           style="fill:none"
+           transform="translate(-56.755728,-4.9357461)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7459-6" />
+        <use
+           style="fill:none"
+           transform="translate(-40.494628,1.2178173)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7461-45" />
+        <use
+           style="fill:none"
+           transform="translate(-47.773908,20.269536)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7463-2" />
+        <use
+           style="fill:none"
+           transform="translate(-53.656258,11.353041)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7465-0" />
+        <use
+           style="fill:none"
+           transform="translate(-41.873218,19.652604)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7467-2" />
+        <use
+           style="fill:none"
+           transform="translate(-44.648678,17.511905)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7469-9" />
+        <use
+           style="fill:none"
+           transform="translate(-9.8052081,25.749294)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7471-0" />
+        <use
+           style="fill:none"
+           transform="translate(-8.8370681,42.959665)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7473-9" />
+        <use
+           style="fill:none"
+           transform="translate(-18.669548,37.083324)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7475-9" />
+        <use
+           style="fill:none"
+           transform="translate(-22.848008,21.444351)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7477-45" />
+        <use
+           style="fill:none"
+           transform="translate(-4.4861482,25.781344)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7479-10" />
+        <use
+           style="fill:none"
+           transform="translate(-0.48673771,36.134685)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7481-3" />
+        <use
+           style="fill:none"
+           transform="translate(-14.659768,38.821224)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7483-7" />
+        <use
+           style="fill:none"
+           transform="translate(10.706172,25.024276)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7485-8" />
+        <use
+           style="fill:none"
+           transform="translate(7.7617123,9.6753892)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7487-8" />
+        <use
+           style="fill:none"
+           transform="translate(-5.4250982,13.018049)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7489-6" />
+        <use
+           style="fill:none"
+           transform="translate(13.752192,19.389891)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7491-0" />
+        <use
+           style="fill:none"
+           transform="translate(4.3792323,1.5679133)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7493-46" />
+        <use
+           style="fill:none"
+           transform="translate(4.8274423,5.2908642)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7495-7" />
+        <use
+           style="fill:none"
+           transform="translate(14.092492,16.743036)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7497-6" />
+        <use
+           style="fill:none"
+           transform="translate(6.6919023,19.447885)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7499-0" />
+        <use
+           style="fill:none"
+           transform="translate(10.322812,8.8875972)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7501-97" />
+        <use
+           style="fill:none"
+           transform="translate(15.825152,9.3716602)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7503-5" />
+        <use
+           style="fill:none"
+           transform="translate(30.736052,22.464932)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7505-9" />
+        <use
+           style="fill:none"
+           transform="translate(33.254112,16.676737)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7507-7" />
+        <use
+           style="fill:none"
+           transform="translate(41.953052,1.6094843)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7509-85" />
+        <use
+           style="fill:none"
+           transform="translate(50.700322,4.4116953)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7511-3" />
+        <use
+           style="fill:none"
+           transform="translate(45.375102,1.7143633)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7513-3" />
+        <use
+           style="fill:none"
+           transform="translate(53.936022,-6.3420521)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7515-83" />
+        <use
+           style="fill:none"
+           transform="translate(45.693362,-3.8895887)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7517-7" />
+        <use
+           style="fill:none"
+           transform="translate(6.2227223,2.1699073)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7519-9" />
+        <use
+           style="fill:none"
+           transform="translate(6.1714023,24.798813)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7521-37" />
+        <use
+           style="fill:none"
+           transform="translate(29.853382,24.860527)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7523-87" />
+        <use
+           style="fill:none"
+           transform="translate(5.9882723,7.4498762)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7525-41" />
+        <use
+           style="fill:none"
+           transform="translate(34.136022,4.1062143)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7527-9" />
+        <use
+           transform="translate(88.019802,-64.720062)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7755-0" />
+        <use
+           style="fill:none"
+           transform="translate(97.724052,-50.554684)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7757-98" />
+        <use
+           style="fill:none"
+           transform="translate(75.964582,1.0617493)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7759-8" />
+        <use
+           style="fill:none"
+           transform="translate(100.19318,-29.836403)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7761-5" />
+        <use
+           style="fill:none"
+           transform="translate(92.215932,-37.397243)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7763-8" />
+        <use
+           style="fill:none"
+           transform="translate(83.446442,-18.17492)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7775-43" />
+        <use
+           style="fill:none"
+           transform="translate(84.082282,-34.26385)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7777-7" />
+        <use
+           style="fill:none"
+           transform="translate(63.573602,25.081506)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7779-1" />
+        <use
+           style="fill:none"
+           transform="translate(81.793172,-14.960432)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7781-38" />
+        <use
+           transform="translate(52.161132,-57.954229)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7783-09" />
+        <use
+           style="fill:none"
+           transform="translate(55.473292,-30.183602)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7785-7" />
+        <use
+           style="fill:none"
+           transform="translate(64.050392,-26.10261)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7787-9" />
+        <use
+           style="fill:none"
+           transform="translate(44.804372,-45.309833)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7789-9" />
+        <use
+           style="fill:none"
+           transform="translate(67.665852,-41.773174)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7791-3" />
+        <use
+           style="fill:none"
+           transform="translate(66.862392,-33.135062)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7793-2" />
+        <use
+           style="fill:none"
+           transform="translate(44.932042,7.5836812)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7795-4" />
+        <use
+           style="fill:none"
+           transform="translate(53.711882,19.022767)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7797-3" />
+        <use
+           style="fill:none"
+           transform="translate(54.106182,2.0032623)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-5"
+           id="use7799-7" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7867-1"
+           d="M 193.63296,94.403119 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-22"
+           d="m 200.25685,98.42358 c 67.96584,20.28914 90.15057,51.2728 87.20996,79.62078 -3.55863,34.30541 -31.37965,72.27072 -86.64383,109.31842"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-0"
+           d="m 215.13851,284.59591 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.48880172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7942-2"
+           d="m 152.37484,76.074983 c 0,0 0,0 28.86932,-21.255381 28.24172,21.621853 28.24172,21.621853 28.24172,21.621853"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7969-1"
+           d="M 47.466632,248.42862 z"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-75"
+           d="m 162.69119,99.02961 c -66.46817,20.21641 -91.26821,50.40029 -88.392397,78.64667 3.480206,34.18244 30.688187,72.01164 84.734587,108.92655"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-2-1"
+           d="m 152.00454,73.756372 15.63884,14.612739 -6.13078,11.654429 0.22198,0.22162"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="2.3065262"
+           y="287.53113"
+           x="99.036339"
+           height="32.009426"
+           width="164.83687"
+           id="rect8009-7"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-41"
+           d="m 135.67815,108.4917 c 89.14121,0 89.14121,0 89.14121,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8015-7"
+           d="m 119.94735,116.02937 c 121.25826,0 121.25826,0 121.25826,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8017-11"
+           d="m 161.97856,99.15442 c 38.01034,0.3316 38.01034,0.3316 38.01034,0.3316"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8019-1"
+           d="m 74.065852,174.1932 c 214.659878,0 214.659878,0 214.659878,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-2-0-7"
+           d="m 210.57876,74.570793 -15.63884,13.685793 6.13078,11.654434 -0.22198,0.22162"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-04"
+           d="m 98.72328,298.18471 c 163.86486,-0.65443 163.86486,-0.65443 163.86486,-0.65443"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967-0"
+           d="m 262.71442,307.12696 c -163.48558,0 -162.06396,0 -163.48558,0 -1.42161,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7943-8"
+           d="m 75.025443,166.11955 c 212.187477,-1.17692 212.187477,-1.17692 212.187477,-1.17692 l 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7945-5"
+           d="m 117.62337,252.90059 c 126.52816,0 126.52816,0 126.52816,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7947-1"
+           d="m 127.3563,262.17005 c 105.2084,0.46348 105.2084,0.46348 105.2084,0.46348"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+    </g>
+    <g
+       id="k"
+       inkscape:label="#k">
+      <desc
+         id="desc4914">Black King (Khun, Lord)</desc>
+      <g
+         transform="translate(48.02097,503.50172)"
+         style="display:inline"
+         inkscape:label="base"
+         id="layer4-6">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6751-0"
+           d="m 180.46373,-2.7808296 36.1509,87.1329476 -20.39282,12.050302 11.12336,11.58683 28.73533,10.19641 26.88144,16.22156 19.92935,23.63713 4.63473,23.17365 -6.02515,25.02755 -9.73294,19.46587 -25.95449,31.97965 -40.32216,34.29701 74.1557,0.92695 1.39042,29.77197 -206.245545,0 0,-29.77197 82.961685,-0.46348 -36.1509,-27.80839 -20.85629,-21.78323 -16.221559,-23.63713 -9.269463,-24.1006 -2.317365,-23.17366 7.41557,-20.39282 16.685037,-18.53892 22.24671,-13.9042 28.27186,-11.12335 7.87904,-2.78084 7.41557,-9.732937 -20.85629,-8.805989 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(48.02097,503.50172)"
+         style="display:inline"
+         inkscape:label="Gradient"
+         id="layer5-8">
+        <path
+           inkscape:connector-curvature="0"
+           id="path6751-6-5"
+           d="m 178.7276,-4.4096182 36.1509,87.1329482 -20.39282,12.050303 11.12336,11.586827 28.73533,10.19641 26.88144,16.22156 19.92935,23.63713 4.63473,23.17365 -6.02515,25.02755 -9.73294,19.46587 -25.95449,31.97965 -40.32216,34.29701 74.1557,0.92695 1.39042,29.77197 -206.245541,0 0,-29.77197 82.961681,-0.46348 -36.1509,-27.80839 -20.85629,-21.78323 -16.221561,-23.63713 -9.26946,-24.1006 -2.31737,-23.17366 7.41557,-20.39282 16.685041,-18.53892 22.24671,-13.9042 28.27186,-11.12335 7.87904,-2.78084 7.41557,-9.732935 -20.85629,-8.805989 z"
+           style="fill:url(#linearGradient4889);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+      </g>
+      <g
+         transform="translate(48.02097,503.50172)"
+         style="display:inline"
+         id="layer1-39"
+         inkscape:label="Layer 1">
+        <rect
+           y="25.378557"
+           x="150.22554"
+           height="15.294614"
+           width="53.299412"
+           id="rect7395-4"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="7.4354501"
+           y="99.534248"
+           x="123.3441"
+           height="43.103004"
+           width="95.011993"
+           id="rect7399-54"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-40"
+           d="m 203.20003,104.45761 c 64.74226,20.21891 84.49536,49.0161 81.69422,77.26596 -3.38984,34.18666 -29.89134,72.02054 -82.53438,108.94"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-3"
+           d="m 212.51671,287.87316 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.48880172px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path7942-28"
+           d="M 139.736,84.934394 178.57789,-7.1604101 215.98782,84.747865"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-3"
+           d="m 152.1877,104.14917 c -64.742261,20.21891 -83.336671,48.55263 -80.535531,76.8025 3.38984,34.18666 29.891341,72.02053 82.534381,108.94"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="2.0606499"
+           y="290.8923"
+           x="72.861343"
+           height="28.59721"
+           width="205.91806"
+           id="rect8009-3"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-49"
+           d="m 129.7791,111.76895 c 92.41846,0 92.41846,0 92.41846,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015-2"
+           d="m 115.00818,119.30662 124.96605,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017-7"
+           d="m 148.45943,105.21445 55.28942,-0.14839 1.73473,0.47611"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8019-4"
+           d="m 70.788599,174.84865 c 214.659881,0 214.659881,0 214.659881,0"
+           style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-2"
+           d="m 100.6339,241.35705 c 156.42218,0 156.42218,0 156.42218,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315-5"
+           d="m 108.51294,250.62651 c 141.12757,0 141.35931,0 141.35931,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path7946-4-2"
+           d="m 138.75275,82.631127 21.97687,12.127008 -9.30481,9.557455 0,0"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-4"
+           d="M 74.224469,300.37394 C 278.88207,299.72241 278.88207,299.72241 278.88207,299.72241"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967-4"
+           d="m 277.20712,306.0432 c -202.729121,0 -200.966251,0 -202.729121,0 -1.76285,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+    </g>
+    <g
+       id="f"
+       transform="matrix(0.9,0,0,0.9,299.15252,536.02826)">
+      <desc
+         id="desc8973">Black Advisor (Met, Seed)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer6-3">
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path7473-3"
+           d="m 180.21207,15.457925 15.14595,13.503967 -7.57298,15.764815 14.74963,66.993853 c 25.20873,8.76275 38.47985,16.57261 57.1658,36.60284 24.35299,33.35429 3.54771,75.61522 -20.79782,104.9885 -11.62224,13.28399 -21.65804,23.55574 -33.7892,33.873 l 44.8316,0.83672 0.0327,32.1963 -136.29968,-0.3069 -0.27046,-31.61157 45.43787,-0.3069 -30.29191,-28.54248 c -7.66317,-9.14362 -15.32631,-20.02288 -22.98944,-31.61156 -5.10922,-10.72442 -9.811342,-21.52794 -11.900401,-32.8392 l -1.622777,-16.57306 c 1.185349,-9.70188 4.093302,-21.47212 8.846038,-28.20324 11.68876,-16.60743 23.47463,-24.2566 40.81694,-31.97012 l 16.80572,-6.70031 12.23619,-66.825873 -5.9502,-16.685539 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.87912208px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer7-3">
+        <path
+           sodipodi:nodetypes="cccccccccccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path7473-7-7"
+           d="m 180.48545,15.358034 15.14591,13.517911 -7.57296,15.781092 14.46959,67.704013 c 11.51066,3.1363 22.71197,9.21389 34.21358,17.41032 8.89239,5.48921 16.35721,13.10435 21.6369,19.20559 4.41344,6.33093 8.10681,13.02165 10.00739,20.60814 3.54679,34.48619 -11.75525,61.85987 -29.34518,83.71488 l -35.5659,35.1813 45.97868,-0.33127 -0.54091,32.2827 -134.96097,-0.30723 -0.27046,-31.6442 45.43777,-0.30723 -30.29185,-28.57195 c -7.66311,-9.15305 -15.32623,-20.04355 -22.98934,-31.64419 -4.93219,-10.53563 -9.790351,-21.10363 -11.900374,-32.87311 -6.7423,-25.85945 8.224494,-50.47354 22.584174,-60.86265 13.01344,-11.5326 26.41188,-16.53717 42.59759,-22.47557 l 11.90015,-67.089543 -5.95017,-16.702768 z"
+           style="fill:url(#linearGradient4425);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.87957466px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-9"
+         inkscape:label="Layer 1">
+        <rect
+           ry="6.6679459"
+           y="45.913719"
+           x="167.66689"
+           height="13.79575"
+           width="81.403564"
+           id="rect7397-8"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:13.55939388;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <rect
+           ry="7.0710044"
+           y="107.55771"
+           x="135.68591"
+           height="40.990326"
+           width="78.408134"
+           id="rect7399-6"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:18.60362434;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+        <use
+           style="fill:none"
+           transform="translate(-46.598356,-21.729663)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7403-70" />
+        <use
+           style="fill:none"
+           transform="translate(-45.150506,-19.51459)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7405-48" />
+        <use
+           style="fill:none"
+           transform="translate(-42.787005,-23.242037)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7407-48" />
+        <use
+           style="fill:none"
+           transform="translate(-35.240233,-13.388673)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7409-16" />
+        <use
+           style="fill:none"
+           transform="translate(-35.344447,-7.5081692)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7411-8" />
+        <use
+           style="fill:none"
+           transform="translate(-36.222532,-15.665879)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7413-5" />
+        <use
+           style="fill:none"
+           transform="translate(-44.854513,-13.910496)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7415-21" />
+        <use
+           style="fill:none"
+           transform="translate(-37.539255,-3.5299522)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7417-9" />
+        <use
+           style="fill:none"
+           transform="translate(-44.665738,3.4519005)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7419-9" />
+        <use
+           style="fill:none"
+           transform="translate(-42.212529,-5.3866988)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7421-6" />
+        <use
+           style="fill:none"
+           transform="translate(-31.504524,14.875473)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7423-06" />
+        <use
+           style="fill:none"
+           transform="translate(-34.20914,-4.6192206)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7425-49" />
+        <use
+           style="fill:none"
+           transform="translate(-26.193375,6.5186407)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7427-9" />
+        <use
+           style="fill:none"
+           transform="translate(-35.04272,28.738686)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7429-08" />
+        <use
+           style="fill:none"
+           transform="translate(-27.5091,34.582405)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7431-9" />
+        <use
+           style="fill:none"
+           transform="translate(-24.488129,32.162382)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7433-3" />
+        <use
+           style="fill:none"
+           transform="translate(-35.361624,28.642033)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7435-14" />
+        <use
+           style="fill:none"
+           transform="translate(-30.463357,13.432392)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7437-8" />
+        <use
+           style="fill:none"
+           transform="translate(-15.889588,19.958351)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7439-96" />
+        <use
+           style="fill:none"
+           transform="translate(-27.952235,37.735389)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7441-77" />
+        <use
+           style="fill:none"
+           transform="translate(-16.65369,25.786146)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7443-3" />
+        <use
+           style="fill:none"
+           transform="translate(-24.928137,32.289413)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7445-7" />
+        <use
+           style="fill:none"
+           transform="translate(-8.2031898,44.091068)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7453-1" />
+        <use
+           style="fill:none"
+           transform="translate(-43.03242,2.071595)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7455-2" />
+        <use
+           style="fill:none"
+           transform="translate(-34.951864,-13.420024)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7457-21" />
+        <use
+           style="fill:none"
+           transform="translate(-33.417976,1.1581261)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7461-5" />
+        <use
+           style="fill:none"
+           transform="translate(-40.941984,20.566291)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7463-0" />
+        <use
+           style="fill:none"
+           transform="translate(-45.794808,11.914891)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7465-9" />
+        <use
+           style="fill:none"
+           transform="translate(-34.555651,18.689338)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7467-04" />
+        <use
+           style="fill:none"
+           transform="translate(-36.846084,16.653565)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7469-0" />
+        <use
+           style="fill:none"
+           transform="translate(-8.0916988,24.487203)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7471-13" />
+        <use
+           style="fill:none"
+           transform="translate(-7.2927458,40.854014)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7473-74" />
+        <use
+           style="fill:none"
+           transform="translate(-15.406949,35.265702)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7475-1" />
+        <use
+           style="fill:none"
+           transform="translate(-18.855196,20.393264)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7477-1" />
+        <use
+           style="fill:none"
+           transform="translate(-3.7021738,24.517681)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7479-3" />
+        <use
+           style="fill:none"
+           transform="translate(-0.40167881,34.36356)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7481-0" />
+        <use
+           style="fill:none"
+           transform="translate(-12.097898,36.918416)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7483-3" />
+        <use
+           style="fill:none"
+           transform="translate(8.835207,23.79772)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7485-2" />
+        <use
+           style="fill:none"
+           transform="translate(6.405305,9.2011535)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7487-17" />
+        <use
+           style="fill:none"
+           transform="translate(-4.4770348,12.379974)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7489-5" />
+        <use
+           style="fill:none"
+           transform="translate(11.348919,18.439502)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7491-65" />
+        <use
+           style="fill:none"
+           transform="translate(3.6139342,1.4910622)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7493-42" />
+        <use
+           style="fill:none"
+           transform="translate(3.9838192,5.0315349)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7495-2" />
+        <use
+           style="fill:none"
+           transform="translate(11.629747,15.922382)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7497-1" />
+        <use
+           style="fill:none"
+           transform="translate(5.5224512,18.494654)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7499-7" />
+        <use
+           style="fill:none"
+           transform="translate(8.518844,8.4519749)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7501-2" />
+        <use
+           style="fill:none"
+           transform="translate(13.059619,8.9123117)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7503-4" />
+        <use
+           style="fill:none"
+           transform="translate(25.364762,21.363822)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7505-1" />
+        <use
+           style="fill:none"
+           transform="translate(27.442773,15.859333)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7507-6" />
+        <use
+           style="fill:none"
+           transform="translate(34.621524,1.530596)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7509-57" />
+        <use
+           style="fill:none"
+           transform="translate(41.840167,4.1954577)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7511-8" />
+        <use
+           style="fill:none"
+           transform="translate(37.445552,1.6303341)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7513-59" />
+        <use
+           style="fill:none"
+           transform="translate(44.510411,-6.031199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7515-2" />
+        <use
+           style="fill:none"
+           transform="translate(37.708195,-3.6989423)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7517-73" />
+        <use
+           style="fill:none"
+           transform="translate(5.1352652,2.0635496)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7519-6" />
+        <use
+           style="fill:none"
+           transform="translate(5.0929142,23.583308)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7521-4" />
+        <use
+           style="fill:none"
+           transform="translate(13.81821,3.6956497)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7523-7" />
+        <use
+           style="fill:none"
+           transform="translate(4.9417862,7.0847236)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7525-9" />
+        <use
+           style="fill:none"
+           transform="translate(28.170564,3.9049498)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7527-7" />
+        <use
+           style="fill:none"
+           transform="translate(78.547773,-80.194199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7731-2" />
+        <use
+           style="fill:none"
+           transform="translate(79.534526,-86.970032)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7733-2" />
+        <use
+           style="fill:none"
+           transform="translate(77.069719,-75.385855)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7753-1" />
+        <use
+           style="fill:none"
+           transform="translate(71.085211,-61.896483)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7755-6" />
+        <use
+           style="fill:none"
+           transform="translate(79.091026,-48.152258)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7757-3" />
+        <use
+           style="fill:none"
+           transform="translate(61.139889,1.9295693)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7759-0" />
+        <use
+           style="fill:none"
+           transform="translate(81.128016,-28.049951)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7761-2" />
+        <use
+           style="fill:none"
+           transform="translate(74.54694,-35.386005)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7763-1" />
+        <use
+           style="fill:none"
+           transform="translate(67.312274,-16.735176)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7775-5" />
+        <use
+           style="fill:none"
+           transform="translate(67.836835,-32.345766)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7777-6" />
+        <use
+           style="fill:none"
+           transform="translate(52.463767,23.852146)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7779-5" />
+        <use
+           style="fill:none"
+           transform="translate(65.948358,-13.616257)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7781-0" />
+        <use
+           style="fill:none"
+           transform="matrix(1.0010688,0,0,0.94299839,42.880836,-44.770314)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7783-03" />
+        <use
+           style="fill:none"
+           transform="translate(45.779033,-28.704164)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7785-4" />
+        <use
+           style="fill:none"
+           transform="translate(52.857241,-24.823199)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7787-66" />
+        <use
+           style="fill:none"
+           transform="matrix(1.0010688,0,0,0.94299839,36.803222,-33.431101)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7789-0" />
+        <use
+           style="fill:none"
+           transform="translate(54.293599,-39.631829)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7791-25" />
+        <use
+           style="fill:none"
+           transform="translate(53.630757,-31.250538)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7793-8" />
+        <use
+           style="fill:none"
+           transform="translate(37.079924,7.2119696)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7795-95" />
+        <use
+           style="fill:none"
+           transform="translate(44.325439,18.090373)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7797-06" />
+        <use
+           style="fill:none"
+           transform="translate(44.650829,1.9050732)"
+           height="1"
+           width="1"
+           y="0"
+           x="0"
+           xlink:href="#rect7399-6"
+           id="use7799-0" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-83"
+           d="m 201.58658,112.23975 c 53.4282,19.22787 69.72934,46.61358 67.41771,73.47879 -2.79744,32.511 -23.04494,66.93218 -66.48833,102.04204"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-7"
+           d="m 209.27512,286.66524 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.31890976px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7969-8"
+           d="M 69.411186,251.77719 z"
+           style="fill:none;stroke:#000000;stroke-width:0.8946805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-21"
+           d="m 159.48893,111.94642 c -53.4282,19.22787 -68.773144,46.17283 -66.461524,73.03806 2.797453,32.511 24.667674,68.49046 68.111054,103.60033"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <rect
+           ry="2.3149922"
+           y="288.17261"
+           x="113.49566"
+           height="32.126919"
+           width="135.96426"
+           id="rect8009-0"
+           style="fill:none;stroke:#000000;stroke-width:4.4294343;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-5"
+           d="m 140.9362,119.6003 c 76.34935,0 76.34935,0 76.34935,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015-85"
+           d="m 128.73354,126.3599 103.23779,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017-5"
+           d="m 156.36851,113.72235 45.67607,-0.13307 1.4331,0.42697"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-0"
+           d="m 116.94443,242.4291 c 129.08656,0 129.08656,0 129.08656,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315-7"
+           d="m 123.44657,251.24422 c 116.46476,0 116.65601,0 116.65601,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="ccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path4412-3"
+           d="m 201.77841,113.12072 0,0 -13.7991,-69.172912 c 0,0 1.72667,-1.469481 6.98383,-13.681026 0,0 -0.64369,-0.881691 -15.1887,-13.017288 l 0,0 0,0 0,0 -15.18867,12.704403 6.23791,14.650696 -11.18847,68.566117"
+           style="fill:none;stroke:#000000;stroke-width:4.30363798;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7123-8"
+           d="m 160.50774,104.05655 c 40.01176,0 40.01176,0 40.01176,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7125-2"
+           d="m 164.52806,84.210105 c 31.77967,0 31.77967,0 31.77967,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7127-3"
+           d="m 165.29384,78.59907 c 29.67377,0 29.67377,0 29.67377,0"
+           style="fill:none;stroke:#000000;stroke-width:2.58218265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7951-0"
+           d="m 92.68983,178.80897 c 175.55774,0.44075 175.55774,0.44075 175.55774,0.44075"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-7"
+           d="m 114.10901,300.63394 c 135.2286,-0.62235 135.2286,-0.62235 135.2286,-0.62235"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7967-7"
+           d="m 249.8243,309.13789 c -27.73767,-0.62062 -74.56158,-0.55393 -134.9156,0 -1.17314,0.0108 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.65766048;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+      <path
+         style="fill:none;stroke:none"
+         d="m 115.55553,-31.479636 c 0,45.000047 0,45.000047 0,45.000047 l 125.88834,-0.0153 0.47729,-44.706867 -116.1154,-0.25534 z"
+         id="path3843-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+    <g
+       id="r"
+       transform="translate(562.70717,502.81859)">
+      <desc
+         id="desc8975">Black Boat (Rua, Rook)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base colour"
+         id="layer19-4">
+        <path
+           inkscape:connector-curvature="0"
+           id="path10308-5"
+           d="m 185.24015,136.66641 34.0834,18.68033 33.10022,9.50402 27.5289,12.12583 18.02488,12.78127 9.50402,13.43673 1.3109,25.89027 -1.3109,19.99123 -5.89905,19.33577 -10.4872,12.78128 -27.5289,20.64667 44.24288,-0.32772 0,19.33577 -248.087828,0.32773 0,-19.99123 43.587428,0.65545 -26.218003,-18.02487 -13.436725,-17.69715 -5.571325,-17.0417 -1.3109,-38.99928 9.1763,-16.71397 18.3526,-14.4199 23.923923,-10.81493 20.9744,-7.20995 19.99123,-5.2436 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradiant top"
+         id="layer18-6">
+        <path
+           inkscape:connector-curvature="0"
+           id="path10308-9-5"
+           d="m 184.75031,136.86377 34.0834,18.68033 33.10022,9.50402 27.5289,12.12583 18.02488,12.78127 9.50402,13.43673 1.3109,25.89027 -1.3109,19.99123 -5.89905,19.33577 -10.4872,12.78128 -27.5289,20.64667 44.24288,-0.32772 0,19.33577 -248.087831,0.32773 0,-19.99123 43.587431,0.65545 -26.218001,-18.02487 -13.43673,-17.69715 -5.57132,-17.0417 -1.3109,-38.99928 9.1763,-16.71397 18.3526,-14.4199 23.923921,-10.81493 20.9744,-7.20995 19.99123,-5.2436 z"
+           style="fill:url(#linearGradient12663-5);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 3"
+         id="layer7-6">
+        <rect
+           ry="1.388453"
+           y="156.19423"
+           x="143.00047"
+           height="144.25529"
+           width="79.564346"
+           id="rect4610-8"
+           style="fill:none;stroke:#000000;stroke-width:1.43576396px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-48"
+           d="m 221.81016,156.41682 c 67.093,15.881 89.14949,38.36377 87.60998,60.68874 -1.87428,27.17972 7.36717,55.25783 -47.18729,84.25632"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-8"
+           d="m 234.08711,298.35494 0,0"
+           style="fill:none;stroke:#000000;stroke-width:2.13756776px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-38"
+           d="m 62.126327,311.04028 c 245.572503,-0.9002 245.572503,-0.9002 245.572503,-0.9002"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path7967-75"
+           d="m 307.20592,318.47915 c -245.004107,0 -242.873628,0 -245.004107,0 -2.130465,0 0,0 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.49516487px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <rect
+           ry="1.3884516"
+           y="301.70389"
+           x="59.343048"
+           height="19.268602"
+           width="248.52936"
+           id="rect8009-24"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8013-50"
+           d="m 123.66926,162.60413 c 121.64504,0 121.64504,0 121.64504,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8015-5"
+           d="m 94.532037,174.24155 177.615213,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="ccc"
+           inkscape:connector-curvature="0"
+           id="path8017-73"
+           d="m 141.55373,157.59767 82.88703,-0.20181 2.60061,0.64751"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4313-27"
+           d="m 106.36457,167.80699 c 155.19056,0 155.19056,0 155.19056,0 l 0,0"
+           style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4315-2"
+           d="m 59.367742,257.28026 c 247.319878,0 247.725988,0 247.725988,0"
+           style="fill:none;stroke:#000000;stroke-width:3.20112228;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccccc"
+           inkscape:connector-curvature="0"
+           id="path4412-13"
+           d="m 223.05796,157.26556 c 0,0 -13.59128,-8.91022 -37.35891,-20.82541 l 0,0 0,0 0,0 -43.1307,21.39957"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6071-4"
+           d="m 74.732263,246.12839 c 218.310827,0 218.310827,0 218.310827,0"
+           style="fill:none;stroke:#b60000;stroke-width:1.43576396px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0;display:inline" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path6083-9"
+           d="m 60.065133,204.38444 c 246.989627,0.22501 246.989627,0.22501 246.989627,0.22501"
+           style="fill:none;stroke:#000000;stroke-width:3.03392625;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-4-4"
+           d="m 144.7755,157.04285 c -67.093005,15.881 -89.149495,38.36377 -87.609985,60.68874 1.87428,27.17972 -7.36717,55.25783 47.187295,84.25632"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      </g>
+      <path
+         style="fill:none;stroke:none"
+         d="m 121.15278,9.36218 c 0,40.04705 0,40.04705 0,40.04705 L 247.04121,49.39563 247.5185,9.60948 131.40301,9.38225 z"
+         id="path3843-36"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+    </g>
+    <g
+       id="n"
+       transform="translate(1129.3659,500.60663)">
+      <desc
+         id="desc8983">Black Horse (Ma)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="gardient"
+         id="layer17-6">
+        <path
+           sodipodi:nodetypes="ccccccccc"
+           inkscape:connector-curvature="0"
+           id="path9164-0"
+           d="M 168.70422,50.055101 C 116.29839,81.018453 67.513792,116.01973 51.445522,167.77728 l 1.39042,156.19044 246.104228,-0.46347 2.31737,-160.3617 C 282.27143,118.26928 233.24571,76.910204 183.07189,49.591628 l 4.17126,39.395216 -20.85629,-0.463473 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         id="g9208-1"
+         inkscape:label="gardient top">
+        <path
+           style="fill:url(#linearGradient12655);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 168.70422,50.055101 C 116.29839,81.018453 67.513792,116.01973 51.445522,167.77728 l 1.39042,156.19044 246.104228,-0.46347 2.31737,-160.3617 C 282.27143,118.26928 233.24571,76.910204 183.07189,49.591628 l 4.17126,39.395216 -20.85629,-0.463473 z"
+           id="path9210-0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-2"
+         inkscape:label="Layer 1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path7867-5"
+           d="M 190.32502,81.043591 z"
+           style="fill:none;stroke:#000000;stroke-width:1.12487173px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path7873-6-85"
+           d="m 215.55781,286.1529 0,0"
+           style="fill:none;stroke:#000000;stroke-width:1.67471099px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+        <rect
+           ry="2.4583752"
+           y="289.51987"
+           x="52.251438"
+           height="34.116749"
+           width="247.95403"
+           id="rect8009-8"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path8835-9"
+           d="m 301.12859,164.26226 c -1.15126,125.65518 -1.15126,125.65518 -1.15126,125.65518"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-5"
+           d="m 182.43785,49.739754 c 69.36318,37.784648 117.90706,90.609666 118.97195,121.329386 1.46207,42.17749 -22.4897,90.04828 -100.50694,117.89208"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="csc"
+           inkscape:connector-curvature="0"
+           id="path7892-8-5"
+           d="M 170.64966,49.032897 C 101.28647,86.817545 52.742592,139.64257 51.677702,170.36228 c -1.46207,42.17748 22.48971,90.04829 100.506958,117.89208"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8883-3"
+           d="m 52.007722,166.66666 -0.21256,124.28083"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 2"
+         id="layer2-8">
+        <path
+           inkscape:connector-curvature="0"
+           id="path7965-60"
+           d="M 53.742082,301.3167 C 299.08084,300.61437 299.08084,300.61437 299.08084,300.61437"
+           style="fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path8902-3"
+           d="m 232.94312,99.541393 c -5.334,45.481157 -8.54723,91.653337 -27.30884,130.693587 -17.7851,17.6183 -33.60003,13.05906 -48.76577,1.19175 C 136.11285,190.0259 130.10455,144.25664 123.22015,98.746893"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <ellipse
+           ry="0.54396933"
+           rx="4.0525527"
+           cy="139.17867"
+           cx="206.82501"
+           id="path8904-3"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.00427389;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="206.82501"
+           sodipodi:cy="139.17867"
+           sodipodi:rx="4.0525527"
+           sodipodi:ry="0.54396933"
+           d="m 210.87756,139.17867 c 0,0.30042 -1.81438,0.54396 -4.05255,0.54396 -2.23816,0 -4.05255,-0.24354 -4.05255,-0.54396 0,-0.30043 1.81439,-0.54397 4.05255,-0.54397 2.23817,0 4.05255,0.24354 4.05255,0.54397 z" />
+        <ellipse
+           ry="0.54396933"
+           rx="4.0525527"
+           cy="139.35535"
+           cx="147.70441"
+           id="path8904-2-6"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.00427389;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="147.70441"
+           sodipodi:cy="139.35535"
+           sodipodi:rx="4.0525527"
+           sodipodi:ry="0.54396933"
+           d="m 151.75696,139.35535 c 0,0.30042 -1.81439,0.54397 -4.05255,0.54397 -2.23817,0 -4.05256,-0.24355 -4.05256,-0.54397 0,-0.30043 1.81439,-0.54397 4.05256,-0.54397 2.23816,0 4.05255,0.24354 4.05255,0.54397 z" />
+        <ellipse
+           ry="6.6800156"
+           rx="0.34631962"
+           cy="88.461716"
+           cx="204.22952"
+           id="path8968-18"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.47502375;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           sodipodi:cx="204.22952"
+           sodipodi:cy="88.461716"
+           sodipodi:rx="0.34631962"
+           sodipodi:ry="6.6800156"
+           d="m 204.57584,88.461716 c 0,3.68927 -0.15505,6.680015 -0.34632,6.680015 -0.19126,0 -0.34632,-2.990745 -0.34632,-6.680015 0,-3.689271 0.15506,-6.680016 0.34632,-6.680016 0.19127,0 0.34632,2.990745 0.34632,6.680016 z" />
+        <ellipse
+           ry="6.6800156"
+           rx="0.34631962"
+           cy="88.461716"
+           cx="149.62704"
+           id="path8968-1-7"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:7.47502375;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="149.62704"
+           sodipodi:cy="88.461716"
+           sodipodi:rx="0.34631962"
+           sodipodi:ry="6.6800156"
+           d="m 149.97336,88.461716 c 0,3.68927 -0.15505,6.680015 -0.34632,6.680015 -0.19126,0 -0.34631,-2.990745 -0.34631,-6.680015 0,-3.689271 0.15505,-6.680016 0.34631,-6.680016 0.19127,0 0.34632,2.990745 0.34632,6.680016 z" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8987-0"
+           d="m 203.18603,67.040079 c 18.14748,17.042237 14.41488,15.785673 6.05183,38.365301"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path8987-9-5"
+           d="m 151.99659,67.286877 c -18.14747,17.042227 -14.41487,15.785664 -6.05183,38.365293"
+           style="fill:none;stroke:#000000;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+        <ellipse
+           ry="2.8842514"
+           rx="0.61694747"
+           cy="230.99039"
+           cx="187.60597"
+           id="path8904-0-1"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:6.29291916;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="187.60597"
+           sodipodi:cy="230.99039"
+           sodipodi:rx="0.61694747"
+           sodipodi:ry="2.8842514"
+           d="m 188.22292,230.99039 c 0,1.59293 -0.27622,2.88425 -0.61695,2.88425 -0.34073,0 -0.61695,-1.29132 -0.61695,-2.88425 0,-1.59293 0.27622,-2.88425 0.61695,-2.88425 0.34073,0 0.61695,1.29132 0.61695,2.88425 z" />
+        <ellipse
+           ry="2.8842514"
+           rx="0.61694747"
+           cy="230.49055"
+           cx="172.92339"
+           id="path8904-0-0-1"
+           style="opacity:0.24800002;fill:#e9dd9a;fill-opacity:0.61176471;fill-rule:evenodd;stroke:#000000;stroke-width:6.29291916;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           sodipodi:cx="172.92339"
+           sodipodi:cy="230.49055"
+           sodipodi:rx="0.61694747"
+           sodipodi:ry="2.8842514"
+           d="m 173.54033,230.49055 c 0,1.59293 -0.27621,2.88426 -0.61694,2.88426 -0.34074,0 -0.61695,-1.29133 -0.61695,-2.88426 0,-1.59292 0.27621,-2.88425 0.61695,-2.88425 0.34073,0 0.61694,1.29133 0.61694,2.88425 z" />
+      </g>
+    </g>
+    <g
+       id="p"
+       transform="translate(1383.2576,530.3475)"
+       inkscape:label="#p">
+      <desc
+         id="desc8987">Black Pawn (Bia, Cowry Shell)</desc>
+      <g
+         style="display:inline"
+         inkscape:label="base"
+         id="layer8-2">
+        <path
+           inkscape:connector-curvature="0"
+           id="path8324-8"
+           d="m 177.97368,73.923969 33.37006,7.41557 32.44312,17.611979 20.39282,24.100602 16.68503,29.66228 3.70778,24.1006 -7.41557,39.85869 -20.39281,32.44312 -24.10061,24.1006 -35.22395,11.12335 -38.93175,0.92695 -35.22395,-13.90419 -28.735332,-24.10061 -18.538925,-39.85869 -2.780839,-21.08803 3.707785,-42.87126 15.758086,-22.24671 18.538925,-27.80838 26.88144,-12.050301 z"
+           style="fill:#804d00;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="gradient"
+         id="layer9-1">
+        <path
+           inkscape:connector-curvature="0"
+           id="path8324-4-2"
+           d="m 177.97368,73.923976 33.37006,7.41557 32.44312,17.61198 20.39282,24.100594 16.68503,29.66228 3.70778,24.1006 -7.41557,39.85869 -20.39281,32.44312 -24.10061,24.1006 -35.22395,11.12335 -38.93175,0.92695 -35.22395,-13.90419 -28.735335,-24.10061 -18.53892,-39.85869 -2.78084,-21.08803 3.70779,-42.87126 15.75808,-22.24671 18.538925,-27.808374 26.88144,-12.0503 z"
+           style="fill:url(#linearGradient8347-2);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+      <g
+         style="display:none"
+         inkscape:label="Layer 0"
+         id="layer6-47">
+        <rect
+           y="30.941006"
+           x="30.943001"
+           height="291.746"
+           width="291.746"
+           id="rect5919-8"
+           style="opacity:0.24800002;fill:none;stroke:#b50000;stroke-width:21;stroke-miterlimit:4;stroke-opacity:0;stroke-dasharray:none" />
+      </g>
+      <g
+         style="display:inline"
+         id="layer1-6"
+         inkscape:label="Layer 1">
+        <g
+           transform="matrix(1.0014278,0,0,1.0014238,-16.027931,30.387217)"
+           id="g3020-3"
+           style="fill:none;display:inline">
+          <ellipse
+             ry="104.62258"
+             rx="104.42029"
+             cy="150.0562"
+             cx="192.37167"
+             style="fill:none;stroke:#000000;stroke-width:21;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+             id="path3022-7"
+             sodipodi:cx="192.37167"
+             sodipodi:cy="150.0562"
+             sodipodi:rx="104.42029"
+             sodipodi:ry="104.62258"
+             d="m 296.79196,150.0562 c 0,57.78145 -46.75055,104.62258 -104.42029,104.62258 -57.66973,0 -104.420285,-46.84113 -104.420285,-104.62258 0,-57.781458 46.750555,-104.622583 104.420285,-104.622583 57.66974,0 104.42029,46.841125 104.42029,104.622583 z" />
+        </g>
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 2"
+         id="layer2-7">
+        <ellipse
+           ry="72.267258"
+           rx="75.077538"
+           cy="180.19504"
+           cx="176.15274"
+           style="fill:none;stroke:#000000;stroke-width:14.79925823;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-2"
+           sodipodi:cx="176.15274"
+           sodipodi:cy="180.19504"
+           sodipodi:rx="75.077538"
+           sodipodi:ry="72.267258"
+           d="m 251.23028,180.19504 c 0,39.9121 -33.61336,72.26726 -75.07754,72.26726 -41.46418,0 -75.07754,-32.35516 -75.07754,-72.26726 0,-39.91211 33.61336,-72.26726 75.07754,-72.26726 41.46418,0 75.07754,32.35515 75.07754,72.26726 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 3"
+         id="layer3-37">
+        <ellipse
+           transform="matrix(0.99678953,0.08006638,-0.06686515,0.99776202,0,0)"
+           ry="40.864048"
+           rx="41.200871"
+           cy="165.83914"
+           cx="188.08882"
+           style="fill:none;stroke:#000000;stroke-width:8.24400139;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9-2"
+           sodipodi:cx="188.08882"
+           sodipodi:cy="165.83914"
+           sodipodi:rx="41.200871"
+           sodipodi:ry="40.864048"
+           d="m 229.28969,165.83914 c 0,22.56859 -18.44626,40.86405 -41.20087,40.86405 -22.75461,0 -41.20087,-18.29546 -41.20087,-40.86405 0,-22.56859 18.44626,-40.86405 41.20087,-40.86405 22.75461,0 41.20087,18.29546 41.20087,40.86405 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 4"
+         id="layer4-5">
+        <ellipse
+           transform="matrix(0.99668818,0.08131836,-0.06583355,0.99783062,0,0)"
+           ry="18.172737"
+           rx="18.041676"
+           cy="165.53326"
+           cx="188.08534"
+           style="fill:none;stroke:#000000;stroke-width:3.63800049;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9-8-3"
+           sodipodi:cx="188.08534"
+           sodipodi:cy="165.53326"
+           sodipodi:rx="18.041676"
+           sodipodi:ry="18.172737"
+           d="m 206.12702,165.53326 c 0,10.03653 -8.07754,18.17274 -18.04168,18.17274 -9.96414,0 -18.04167,-8.13621 -18.04167,-18.17274 0,-10.03652 8.07753,-18.17273 18.04167,-18.17273 9.96414,0 18.04168,8.13621 18.04168,18.17273 z" />
+      </g>
+      <g
+         style="display:inline"
+         inkscape:label="Layer 5"
+         id="layer5-7">
+        <ellipse
+           transform="matrix(0.99697426,0.0777324,-0.06887617,0.99762522,0,0)"
+           ry="8.6921406"
+           rx="9.0256882"
+           cy="165.94527"
+           cx="188.4192"
+           style="fill:none;stroke:#000000;stroke-width:1.77958071;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+           id="path3022-5-9-8-7-6"
+           sodipodi:cx="188.4192"
+           sodipodi:cy="165.94527"
+           sodipodi:rx="9.0256882"
+           sodipodi:ry="8.6921406"
+           d="m 197.44489,165.94527 c 0,4.80053 -4.04094,8.69214 -9.02569,8.69214 -4.98475,0 -9.02568,-3.89161 -9.02568,-8.69214 0,-4.80054 4.04093,-8.69214 9.02568,-8.69214 4.98475,0 9.02569,3.8916 9.02569,8.69214 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/projects/gui/res/chessboard/makruk.txt
+++ b/projects/gui/res/chessboard/makruk.txt
@@ -1,0 +1,9 @@
+The file makruk.svg provides a set of chess pieces designed by Peter Thomson
+for the PyChess project (http://pychess.org). It is intended to be used for
+Makruk and related South-East Asian variants.
+
+Boat and Advisor glyphs have been adapted by alwey for cutechess autoscaling.
+
+The set is copyright (C) 2015 Peter Thomson and published under the
+GNU General Public License 3, https://gnu.org/copyleft/gpl.html.
+


### PR DESCRIPTION
This PR adds a set of pieces designed by Peter Thomson (@Cajone).
They are intended to be used for Makruk and related South-East Asian variants like Ouk Chatrang and Karouk.

Boat and Advisor glyphs were adapted for cutechess autoscaling.


![m2](https://user-images.githubusercontent.com/6425738/42002047-2c4a023a-7a66-11e8-92f4-a94ffc699350.png)

_Initial position of Makruk with the Makruk piece set by @cajone - taken from PyChess and arranged for Cutechess: prevent glyphs of Boat (Rua) and Advisor (Met) from scaling much._

