### PR TITLE
Support Ai-Wok, a Makruk variant

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -39,6 +39,8 @@ is one of:
 Three-check Chess
 .It 5check
 Five-check Chess
+.It aiwok
+Ai-Wok (Makruk variant)
 .It andernach
 Andernach Chess
 .It antiandernach

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -12,6 +12,7 @@ Options:
   -variant VARIANT	Set the chess variant to VARIANT, which can be one of:
 			'3check': Three-check Chess
 			'5check': Five-check Chess
+			'aiwok': Ai-Wok (Makruk variant)
 			'andernach': Andernach Chess
 			'antiandernach': Anti-Andernach Chess
 			'antichess': Antichess (Losing Chess)

--- a/projects/lib/src/board/aiwokboard.cpp
+++ b/projects/lib/src/board/aiwokboard.cpp
@@ -1,0 +1,49 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aiwokboard.h"
+
+namespace Chess {
+
+AiWokBoard::AiWokBoard()
+	: MakrukBoard()
+{
+	setPieceType(AiWok, tr("ai-wok"), "A", FerzMovement | KnightMovement | RookMovement, "C");
+}
+
+Board* AiWokBoard::copy() const
+{
+	return new AiWokBoard(*this);
+}
+
+QString AiWokBoard::variant() const
+{
+	return "ai-wok";
+}
+
+QString AiWokBoard::defaultFenString() const
+{
+	return "rnsaksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKASNR w - - 0 1";
+}
+
+bool AiWokBoard::insufficientMaterial() const
+{
+	return pieceCount(Side::NoSide, AiWok) == 0
+	&&     MakrukBoard::insufficientMaterial();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/aiwokboard.h
+++ b/projects/lib/src/board/aiwokboard.h
@@ -1,0 +1,55 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef AIWOKBOARD_H
+#define AIWOKBOARD_H
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Ai-Wok
+ *
+ * Ai-Wok is a variant of Makruk where the Advisor (Met) is replaced by
+ * the Ai-Wok which has powers of Ferz (Met), Knight (Ma) and Rook (Rua)
+ *
+ * \note Rules:
+ */
+class LIB_EXPORT AiWokBoard : public MakrukBoard
+{
+	public:
+		/*! Creates a new AiWokBoard object. */
+		AiWokBoard();
+
+		// Inherited from MakrukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		/*! Ai-Wok replaces Advisor (Met, Ferz). */
+		enum AiWokPieceType
+		{
+			AiWok = Met	//!< Ai-Wok (ferz + knight + rook)
+		};
+		// Inherited from MakrukBoard
+		virtual bool insufficientMaterial() const;
+};
+
+} // namespace Chess
+#endif // AIWOKBOARD_H

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -47,6 +47,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/makrukboard.cpp \
     $$PWD/oukboard.cpp \
     $$PWD/aseanboard.cpp \
+    $$PWD/aiwokboard.cpp \
     $$PWD/sittuyinboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
@@ -101,6 +102,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/makrukboard.h \
     $$PWD/oukboard.h \
     $$PWD/aseanboard.h \
+    $$PWD/aiwokboard.h \
     $$PWD/sittuyinboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -16,6 +16,7 @@
 */
 
 #include "boardfactory.h"
+#include "aiwokboard.h"
 #include "andernachboard.h"
 #include "antiboard.h"
 #include "aseanboard.h"
@@ -61,6 +62,7 @@ namespace Chess {
 
 REGISTER_BOARD(ThreeCheckBoard, "3check")
 REGISTER_BOARD(FiveCheckBoard, "5check")
+REGISTER_BOARD(AiWokBoard, "ai-wok")
 REGISTER_BOARD(AndernachBoard, "andernach")
 REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
 REGISTER_BOARD(AntiBoard, "antichess")

--- a/projects/lib/src/board/makrukboard.h
+++ b/projects/lib/src/board/makrukboard.h
@@ -154,7 +154,7 @@ class LIB_EXPORT MakrukBoard : public ShatranjBoard
 		 * Returns true if material on board is known to be not
 		 * sufficient to enforce mate, else false.
 		 */
-		bool insufficientMaterial() const;
+		virtual bool insufficientMaterial() const;
 
 		// Inherited from ShatranjBoard
 		virtual void vInitialize();

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -901,6 +901,13 @@ void tst_Board::results_data() const
 		<< variant
 		<< "8/8/8/5K2/1q6/8/8/k7 w - - 0 71"
 		<< "1/2-1/2";
+
+	variant = "ai-wok";
+
+	QTest::newRow("ai-wok black win")
+		<< variant
+		<< "8/8/8/2sp2k1/8/3P4/4K1a1/7r w - - 0 1"
+		<< "0-1";
 }
 
 void tst_Board::results()
@@ -1340,6 +1347,18 @@ void tst_Board::perft_data() const
 		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
 		<< 4 // 1 ply: 35, 2 plies: 825, 3 plies: 26791, 4 plies: 657824
 		<< Q_UINT64_C(657824);
+
+	variant = "ai-wok";
+	QTest::newRow("ai-wok startpos")
+		<< variant
+		<< "rnsaksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKASNR w 0 1"
+		<< 4 // 3 plies: 18102, 4 plies: 485045, 5 plies: 13275068
+		<< Q_UINT64_C(485045);
+	QTest::newRow("ai-wok endgame")
+		<< variant
+		<< "8/8/8/2sp2k1/7p/3P4/6K1/7r w - - 0 1"
+		<< 5 // 4 plies: 6855, 5 plies: 30055, 6 plies: 631293
+		<< Q_UINT64_C(30055);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
This PR adds support for _Ai-Wok_, a variant of Makruk where the Met (Advisor) is replaced by a powerful piece, the Ai-Wok, which has all movements of Rook (Rua), Knight (Ma), and Advisor (Met).
Pawns promote to Ai-Wok when reaching their sixth rank.

This lightweight implementation is based on `MakrukBoard`. Only the evaluation of material has to be adapted. 

When using the defaultFenString `"rnsaksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKASNR w - - 0 1"`the standard chess counting is in action while the Makruk counters have no effect.

The implementation has been tested using _Sjaak II 1.4.1_, _Fairymax 5.0b_ and the new _Fairy-Stockfish_ implementation.

I hope this is useful.