### PR TITLE
Support Los Alamos Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -107,6 +107,8 @@ King of the Hill Chess
 Knightmate
 .It loop
 Loop Chess (Drop Chess Variant)
+.It losalamos
+Los Alamos Chess
 .It losers
 Loser's Chess
 .It makruk

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -46,6 +46,7 @@ Options:
 			'kingofthehill': King of the Hill Chess
 			'knightmate': Knightmate
 			'loop': Loop Chess (Drop Chess)
+			'losalamos': Los Alamos Chess
 			'losers': Loser's Chess
 			'makruk': Makruk (Thai Chess)
 			'modern': Modern Chess (9x9)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -48,6 +48,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/oukboard.cpp \
     $$PWD/aseanboard.cpp \
     $$PWD/sittuyinboard.cpp \
+    $$PWD/losalamosboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -102,6 +103,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/oukboard.h \
     $$PWD/aseanboard.h \
     $$PWD/sittuyinboard.h \
+    $$PWD/losalamosboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -42,6 +42,7 @@
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
 #include "loopboard.h"
+#include "losalamosboard.h"
 #include "losersboard.h"
 #include "ncheckboard.h"
 #include "makrukboard.h"
@@ -95,6 +96,7 @@ REGISTER_BOARD(KarOukBoard,"karouk")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
+REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(ModernBoard, "modern")

--- a/projects/lib/src/board/losalamosboard.cpp
+++ b/projects/lib/src/board/losalamosboard.cpp
@@ -1,0 +1,73 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "losalamosboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+LosAlamosBoard::LosAlamosBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Bishop, tr("no-bishop"), "", 0);
+}
+
+Board* LosAlamosBoard::copy() const
+{
+	return new LosAlamosBoard(*this);
+}
+
+QString LosAlamosBoard::variant() const
+{
+	return "losalamos";
+}
+
+int LosAlamosBoard::height() const
+{
+	return 6;
+}
+
+int LosAlamosBoard::width() const
+{
+	return 6;
+}
+
+QString LosAlamosBoard::defaultFenString() const
+{
+	return "rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1";
+}
+
+bool LosAlamosBoard::hasCastling() const
+{
+	return false;
+}
+
+bool LosAlamosBoard::pawnHasDoubleStep() const
+{
+	return false;
+}
+
+void LosAlamosBoard::addPromotions(int sourceSquare,
+				int targetSquare,
+				QVarLengthArray<Move>& moves) const
+{
+	moves.append(Move(sourceSquare, targetSquare, Knight));
+	moves.append(Move(sourceSquare, targetSquare, Rook));
+	moves.append(Move(sourceSquare, targetSquare, Queen));
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/losalamosboard.h
+++ b/projects/lib/src/board/losalamosboard.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LOSALAMOSBOARD_H
+#define LOSALAMOSBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Los Alamos chess
+ *
+ * Los Alamos chess is a variant of standard chess which is played on a
+ * 6x6 board. This variant has no bishops, no pawn double steps, and no
+ * castling. It was introduced in 1956 by Paul Stein, Mark Wells, and
+ * others with the first chess-like program on the MANIAC I computer of
+ * Los Alamos Scientific Laboratory.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Los_Alamos_chess
+ */
+class LIB_EXPORT LosAlamosBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new LosAlamosBoard object. */
+		LosAlamosBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual bool hasCastling() const;
+		virtual bool pawnHasDoubleStep() const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+};
+
+} // namespace Chess
+#endif // LOSALAMOSBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -533,6 +533,11 @@ void tst_Board::moveStrings_data() const
 		<< "Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3"
 		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 0 1"
 		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 16 9";
+	QTest::newRow("losalamos san1")
+		<< "losalamos"
+		<< "d3 d4"
+		<< "rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1"
+		<< "rnqknr/ppp1pp/3p2/3P2/PPP1PP/RNQKNR w - - 0 2";
 
 }
 
@@ -1382,6 +1387,18 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR[EHeh] w BCDFGbcdfgKQkq - 0 1"
 		<< 4 // 4 plies: 782599, 5 plies: 27639803, 6 plies: 967587141 (sjaakii: 967584909)
 		<< Q_UINT64_C(782599);
+
+	variant = "losalamos";
+	QTest::newRow("losalamos startpos")
+		<< variant
+		<< "rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1"
+		<< 5 // 4 plies: 14332, 5 plies: 191846, 6 plies: 2549164
+		<< Q_UINT64_C(191846);
+	QTest::newRow("losalamos promotion")
+		<< variant
+		<< "6/2P3/6/1K1k2/6/6 w - - 0 1"
+		<< 5 // 4 plies: 3117, 5 plies: 39171, 6 plies: 187431
+		<< Q_UINT64_C(39171);
 
 }
 


### PR DESCRIPTION
This PR adds support of Los Alamos Chess.

Los Alamos chess is a variant of standard chess which is played on a 6x6 board. This variant has no bishops, no pawn double steps, and no castling. It was introduced in 1956 by Paul Stein, Mark Wells, and
others with the first chess-like program on the MANIAC I computer of Los Alamos Scientific Laboratory. Due to the limited resources of the computer it was not yet practical to implement standard chess.

This implementation has been tested with _Sjaak II 1.4.1_, _NebiyuAlien_, and _Fairy-Stockfish_.