### PR TITLE
Support FEN full move counter

### DIFF
--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -29,6 +29,7 @@ WesternBoard::WesternBoard(WesternZobrist* zobrist)
 	  m_sign(1),
 	  m_enpassantSquare(0),
 	  m_enpassantTarget(0),
+	  m_plyOffset(0),
 	  m_reversibleMoveCount(0),
 	  m_kingCanCapture(true),
 	  m_hasCastling(true),
@@ -613,7 +614,7 @@ QString WesternBoard::vFenString(FenNotation notation) const
 
 	// Full move number
 	fen += ' ';
-	fen += QString::number(m_history.size() / 2 + 1);
+	fen += QString::number((m_history.size() + m_plyOffset) / 2 + 1);
 
 	return fen;
 }
@@ -799,11 +800,25 @@ bool WesternBoard::vSetFenString(const QStringList& fen)
 		if (!ok || tmp < 0)
 			return false;
 		m_reversibleMoveCount = tmp;
+		++token;
 	}
 	else
 		m_reversibleMoveCount = 0;
 
-	// The full move number is ignored. It's rarely useful
+	// Read the full move number and calculate m_plyOffset
+	if (token != fen.end())
+	{
+		bool ok;
+		int tmp = token->toInt(&ok);
+		if (!ok || tmp < 1)
+			return false;
+		m_plyOffset = 2 * (tmp - 1);
+	}
+	else
+		m_plyOffset = 0;
+
+	if (m_sign != 1)
+		m_plyOffset++;
 
 	m_history.clear();
 	return true;

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -261,6 +261,7 @@ class LIB_EXPORT WesternBoard : public Board
 		int m_kingSquare[2];
 		int m_enpassantSquare;
 		int m_enpassantTarget;
+		int m_plyOffset;
 		int m_reversibleMoveCount;
 		bool m_kingCanCapture;
 		bool m_hasCastling;

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -182,27 +182,27 @@ void tst_Board::moveStrings_data() const
 		<< "standard"
 		<< "Qd4"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
-		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 2";
 	QTest::newRow("coord2")
 		<< "standard"
 		<< "g7d4"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
-		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 2";
 	QTest::newRow("san3")
 		<< "standard"
 		<< "Qf6"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
-		<< "3r1rk1/8/1p1pbq1p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+		<< "3r1rk1/8/1p1pbq1p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 2";
 	QTest::newRow("coord3")
 		<< "standard"
 		<< "g7f6"
-		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
-		<< "3r1rk1/8/1p1pbq1p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 11"
+		<< "3r1rk1/8/1p1pbq1p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 12";
 	QTest::newRow("fifty moves draw")
 		<< "standard"
 		<< "h2a2"
-		<< "8/k7/2K5/8/8/8/7R/8 w - - 99 1"
-		<< "8/k7/2K5/8/8/8/R7/8 b - - 100 1";
+		<< "8/k7/2K5/8/8/8/7R/8 w - - 99 61"
+		<< "8/k7/2K5/8/8/8/R7/8 b - - 100 61";
 	QTest::newRow("fifty moves mate")
 		<< "standard"
 		<< "h2a2"
@@ -217,7 +217,7 @@ void tst_Board::moveStrings_data() const
 		<< "crazyhouse"
 		<< "Qd4"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K[-] b - - 2 1"
-		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K[-] w - - 3 1";
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K[-] w - - 3 2";
 	QTest::newRow("crazyhouse2")
 		<< "crazyhouse"
 		<< "d4 h6 Bxh6 gxh6 g4 h5 gxh5"
@@ -262,7 +262,7 @@ void tst_Board::moveStrings_data() const
 		<< "berolina"
 		<< "Qd4"
 		<< "3r1rk1/6q1/1p1pb2p/p1p2np1/P1P2p2/1PNP4/1Q2PPBP/1R2R2K b - - 2 1"
-		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 1";
+		<< "3r1rk1/8/1p1pb2p/p1p2np1/P1Pq1p2/1PNP4/1Q2PPBP/1R2R2K w - - 3 2";
 	QTest::newRow("3check san1")
 		<< "3check"
 		<< "e4 e5 Nf3 Nc6 d4 exd4"
@@ -277,7 +277,7 @@ void tst_Board::moveStrings_data() const
 		<< "embassy"
 		<< "O-O-O O-O-O Ng4"
 		<< "r3kcab1r/pppq1p1ppp/2np2pn2/4pb4/4B5/2NPB1PN2/PPPQPP1PPP/R3KCA2R b KQkq - 3 1"
-		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 6 2";
+		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 6 3";
 	QTest::newRow("embassy castling san2")
 		<< "embassy"
 		<< "Cf1 O-O g3"
@@ -287,7 +287,7 @@ void tst_Board::moveStrings_data() const
 		<< "embassy"
 		<< "e8b8 e1b1 h6g4"
 		<< "r3kcab1r/pppq1p1ppp/2np2pn2/4pb4/4B5/2NPB1PN2/PPPQPP1PPP/R3KCA2R b KQkq - 3 1"
-		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 6 2";
+		<< "1kr2cab1r/pppq1p1ppp/2np2p3/4pb4/4B1n3/2NPB1PN2/PPPQPP1PPP/1KR2CA2R w - - 6 3";
 	QTest::newRow("janus castling san1")
 		<< "janus"
 		<< "Kb8 Be3 Ng6 Ki1"
@@ -342,7 +342,7 @@ void tst_Board::moveStrings_data() const
 		<< "circulargryphon"
 		<< "Qxa7 e3 a5 Kb4 Nc6 Nc4+ Ke7 Ba6 Ng4 h4 Be2"
 		<< "8/R4k2/5n2/8/5n2/2K5/q3P2P/8 b - - 0 1"
-		<< "8/4k3/R1b5/8/1K3n1N/8/4r3/8 w - - 1 6";
+		<< "8/4k3/R1b5/8/1K3n1N/8/4r3/8 w - - 1 7";
 	QTest::newRow("giveaway san1")
 		<< "giveaway"
 		<< "e3"


### PR DESCRIPTION
This PR amends support for the FEN full move counter.

WesternBoard::vSetFenString currently ignores the full move field in a given FEN. This implementation reads the full move counter and corrects the FEN notation (move number) for black starting positions and odd history sizes.

The problem:

consider a (black to move) setup-position (obtained from 1. e4)
FEN  `rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1`

in cutechess we obtain after playing 1. ... e5
an incorrect FEN ` rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1`
the correct FEN is `rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2`.

HTH
