### PR TITLE
Pasting general FENs to targeted variants

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -977,12 +977,17 @@ void MainWindow::pasteFen()
 	if (cb->text().isEmpty())
 		return;
 
-	auto board = Chess::BoardFactory::create("standard");
+	QString variant = m_game.isNull() || m_game->board() == nullptr ?
+				"standard" : m_game->board()->variant();
+
+	auto board = Chess::BoardFactory::create(variant);
 	if (!board->setFenString(cb->text()))
 	{
-		QMessageBox msgBox(QMessageBox::Critical, tr("FEN error"),
-		    tr("Invalid FEN string for the \"standard\" variant:"),
-		    QMessageBox::Ok, this);
+		QMessageBox msgBox(QMessageBox::Critical,
+				   tr("FEN error"),
+				   tr("Invalid FEN string for the \"%1\" variant:")
+				   .arg(variant),
+				   QMessageBox::Ok, this);
 		msgBox.setInformativeText(cb->text());
 		msgBox.exec();
 


### PR DESCRIPTION
Small patch: Suggestion to get the variant information from the targeted (template) game.
I tested this with standard chess, crazyhouse and grid chess.

A new game might also "inherit" other properties from the targeted game, like time control settings, engine setups, etc. "Paste & Inherit".
