### PR TITLE
Support Pyramid Tournament Type

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -190,6 +190,8 @@ Round-robin tournament (default)
 First engine plays against the rest
 .It knockout
 Single-elimination tournament
+.It pyramid
+Every engine plays against all of its predecessors
 .El
 .It Fl event Ar arg
 Set the event name to

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -88,6 +88,7 @@ Options:
 			'round-robin': Round-robin tournament (default)
 			'gauntlet': First engine plays against the rest
 			'knockout': Single-elimination tournament.
+			'pyramid': Every engine plays against all predecessors
   -event EVENT		Set the event/tournament name to EVENT
   -games N		Play N games per encounter. This value should be set to
 			an even number in tournaments with more than two players

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -48,6 +48,8 @@ QString TournamentSettingsWidget::tournamentType() const
 		return "gauntlet";
 	else if (ui->m_knockoutRadio->isChecked())
 		return "knockout";
+	else if (ui->m_pyramidRadio->isChecked())
+		return "pyramid";
 
 	Q_UNREACHABLE();
 	return QString();
@@ -95,6 +97,8 @@ void TournamentSettingsWidget::readSettings()
 		ui->m_gauntletRadio->setChecked(true);
 	else if (type == "knockout")
 		ui->m_knockoutRadio->setChecked(true);
+	else if (type == "pyramid")
+		ui->m_pyramidRadio->setChecked(true);
 
 	ui->m_seedsSpin->setValue(s.value("seeds", 0).toInt());
 	ui->m_gamesPerEncounterSpin->setValue(s.value("games_per_encounter", 1).toInt());
@@ -123,6 +127,11 @@ void TournamentSettingsWidget::enableSettingsUpdates()
 	{
 		if (checked)
 			QSettings().setValue("tournament/type", "knockout");
+	});
+	connect(ui->m_pyramidRadio, &QRadioButton::toggled, [=](bool checked)
+	{
+		if (checked)
+			QSettings().setValue("tournament/type", "pyramid");
 	});
 
 	connect(ui->m_seedsSpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -59,6 +59,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QRadioButton" name="m_pyramidRadio">
+          <property name="text">
+           <string>Pyramid</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>

--- a/projects/lib/src/pyramidtournament.cpp
+++ b/projects/lib/src/pyramidtournament.cpp
@@ -1,0 +1,67 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include "pyramidtournament.h"
+#include <algorithm>
+
+PyramidTournament::PyramidTournament(GameManager* gameManager,
+					   QObject *parent)
+	: Tournament(gameManager, parent),
+	  m_pairNumber(0),
+	  m_currentPlayer(1)
+{
+}
+
+QString PyramidTournament::type() const
+{
+	return "pyramid";
+}
+
+void PyramidTournament::initializePairing()
+{
+	m_pairNumber = 0;
+	m_currentPlayer = 1;
+	setCurrentRound(1);
+}
+
+int PyramidTournament::gamesPerCycle() const
+{
+	return (playerCount() * (playerCount() - 1)) / 2;
+}
+
+TournamentPair* PyramidTournament::nextPair(int gameNumber)
+{
+	if (gameNumber >= finalGameCount())
+		return nullptr;
+	if (gameNumber % gamesPerEncounter() != 0)
+		return currentPair();
+
+	if (m_pairNumber >= m_currentPlayer)
+	{
+		m_pairNumber = 0;
+		setCurrentRound(currentRound() + 1);
+		if (++m_currentPlayer >= playerCount())
+			m_currentPlayer = 1;
+	}
+
+	int white = m_currentPlayer;
+	int black = m_pairNumber++;
+
+	return pair(white, black);
+}

--- a/projects/lib/src/pyramidtournament.h
+++ b/projects/lib/src/pyramidtournament.h
@@ -1,0 +1,53 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef PYRAMIDTOURNAMENT_H
+#define PYRAMIDTOURNAMENT_H
+
+#include "tournament.h"
+
+/*!
+ * \brief Pyramid type chess tournament.
+ *
+ * In a Pyramid tournament each player meets all
+ * of their predecessors in sequence.
+ */
+class LIB_EXPORT PyramidTournament : public Tournament
+{
+	Q_OBJECT
+
+	public:
+		/*! Creates a new Pyramid tournament. */
+		explicit PyramidTournament(GameManager* gameManager,
+					      QObject *parent = nullptr);
+		// Inherited from Tournament
+		virtual QString type() const;
+
+	protected:
+		// Inherited from Tournament
+		virtual void initializePairing();
+		virtual int gamesPerCycle() const;
+		virtual TournamentPair* nextPair(int gameNumber);
+
+	private:
+		int m_pairNumber;
+		int m_currentPlayer;
+};
+
+#endif // PYRAMIDTOURNAMENT_H

--- a/projects/lib/src/src.pri
+++ b/projects/lib/src/src.pri
@@ -42,6 +42,7 @@ HEADERS += $$PWD/chessengine.h \
     $$PWD/gameadjudicator.h \
     $$PWD/elo.h \
     $$PWD/knockouttournament.h \
+    $$PWD/pyramidtournament.h \
     $$PWD/tournamentplayer.h \
     $$PWD/tournamentpair.h \
     $$PWD/worker.h
@@ -85,6 +86,7 @@ SOURCES += $$PWD/chessengine.cpp \
     $$PWD/gameadjudicator.cpp \
     $$PWD/elo.cpp \
     $$PWD/knockouttournament.cpp \
+    $$PWD/pyramidtournament.cpp \
     $$PWD/tournamentplayer.cpp \
     $$PWD/tournamentpair.cpp \
     $$PWD/worker.cpp

--- a/projects/lib/src/tournamentfactory.cpp
+++ b/projects/lib/src/tournamentfactory.cpp
@@ -20,6 +20,7 @@
 #include "roundrobintournament.h"
 #include "gauntlettournament.h"
 #include "knockouttournament.h"
+#include "pyramidtournament.h"
 
 Tournament* TournamentFactory::create(const QString& type,
 				      GameManager* manager,
@@ -31,6 +32,8 @@ Tournament* TournamentFactory::create(const QString& type,
 		return new GauntletTournament(manager, parent);
 	if (type == "knockout")
 		return new KnockoutTournament(manager, parent);
+	if (type == "pyramid")
+		return new PyramidTournament(manager, parent);
 
 	return nullptr;
 }


### PR DESCRIPTION
This PR supports a  "pyramid tournament". This is essentially a round-robin tournament where the sequence of pairings is different. Every listed player meets all of their predecessors in the list, in sequence.

Example: Participants 0, 1, 2, 3. 

First, Player 0 will play against nobody - skipped.
Then player 1 will be paired against player 0 (round 1).
After that player 2 will play 0, then play against 1 (round 2).
Finally, player 3 will play 0, 1, and at last 2 (round 3).

The CLI options `-games n` and `-rounds m` and their counterparts in the GUI can be used to further specify the tournament. They work as for round-robin tournaments.

I hope this is useful.