### PR TITLE
Game export to clipboard from game database

### DIFF
--- a/projects/gui/src/gamedatabasedlg.h
+++ b/projects/gui/src/gamedatabasedlg.h
@@ -61,6 +61,8 @@ class GameDatabaseDialog : public QDialog
 		void onAdvancedSearch();
 		void exportPgn(const QString& filename);
 		void createOpeningBook();
+		void copyGame();
+		void copyFen();
 		void updateUi();
 
 	private:
@@ -68,6 +70,7 @@ class GameDatabaseDialog : public QDialog
 		int databaseIndexFromGame(int game) const;
 
 		GameViewer* m_gameViewer;
+		PgnGame m_game;
 		QVector<PgnGame::MoveData> m_moves;
 
 		GameDatabaseManager* m_dbManager;

--- a/projects/gui/ui/gamedatabasedlg.ui
+++ b/projects/gui/ui/gamedatabasedlg.ui
@@ -84,6 +84,38 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="m_copyGameBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Copy PGN</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="m_copyFenBtn">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Copy FEN</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
Export a single PGN game displayed in the database game viewer via a new button "Copy game".
This adds complementary functionality /wrt to #400.



![db1](https://user-images.githubusercontent.com/6425738/42942099-2969133a-8b5f-11e8-923d-8602dd6f969f.png)
