### PR TITLE
Add option to discard unfinished games from PGN output

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -1,4 +1,4 @@
-.Dd February 8, 2018
+.Dd July 26, 2018
 .Dt CUTECHESS-CLI 6
 .Os
 .Sh NAME
@@ -276,12 +276,15 @@ is either
 (the book is accessed directly on disk).
 The default mode is
 .Cm ram .
-.It Fl pgnout Ar file Bq Cm min
+.It Fl pgnout Ar file Bq Cm min Cm Bq fi
 Save the games to
 .Ar file
 in PGN format. Use the
 .Cm min
 argument to save in a minimal PGN format.
+Only finished games will be saved if argument
+.Cm fi
+is given.
 .It Fl epdout Ar file
 Save the games to
 .Ar file

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -122,8 +122,10 @@ Options:
   -bookmode MODE	Set Polyglot book mode to MODE, which can be one of:
 			'ram': The whole book is loaded into RAM (default)
 			'disk': The book is accessed directly on disk.
-  -pgnout FILE [min]	Save the games to FILE in PGN format. Use the 'min'
-			argument to save in a minimal/compact PGN format.
+  -pgnout FILE [min][fi]
+			Save the games to FILE in PGN format. Use the 'min'
+			argument to save in a minimal/compact PGN format. Only
+			finished games are saved for argument 'fi'.
   -epdout FILE		Save the end position of the games to FILE in FEN format.
   -recover		Restart crashed engines instead of stopping the match
   -repeat [N]		Play each opening twice (or N times). Unless the -noswap

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -257,7 +257,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-debug", QVariant::Bool, 0, 0);
 	parser.addOption("-openings", QVariant::StringList);
 	parser.addOption("-bookmode", QVariant::String);
-	parser.addOption("-pgnout", QVariant::StringList, 1, 2);
+	parser.addOption("-pgnout", QVariant::StringList, 1, 3);
 	parser.addOption("-epdout", QVariant::String, 1, 1);
 	parser.addOption("-repeat", QVariant::Int, 0, 1);
 	parser.addOption("-noswap", QVariant::Bool, 0, 0);
@@ -495,12 +495,17 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		{
 			PgnGame::PgnMode mode = PgnGame::Verbose;
 			QStringList list = value.toStringList();
-			if (list.size() == 2)
+			if (list.size() == 2 || list.size() == 3)
 			{
-				if (list.at(1) == "min")
-					mode = PgnGame::Minimal;
-				else
-					ok = false;
+				for (int i = 1; i < list.size(); i++)
+				{
+					if (list.at(i) == "min")
+						mode = PgnGame::Minimal;
+					else if (list.at(i) == "fi")
+						tournament->setPgnWriteUnfinishedGames(false);
+					else
+						ok = false;
+				}
 			}
 			if (ok)
 				tournament->setPgnOutput(list.at(0), mode);

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -277,6 +277,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 
 	t->setOpeningRepetitions(ts->openingRepetition()? 2: 1);
 	t->setRecoveryMode(ts->engineRecovery());
+	t->setPgnWriteUnfinishedGames(ts->savingOfUnfinishedGames());
 
 	const auto engines = m_addedEnginesManager->engines();
 	for (EngineConfiguration config : engines)

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -83,6 +83,11 @@ bool TournamentSettingsWidget::engineRecovery() const
 	return ui->m_recoverCheck->isChecked();
 }
 
+bool TournamentSettingsWidget::savingOfUnfinishedGames() const
+{
+	return ui->m_saveUnfinishedGamesCheck->isChecked();
+}
+
 void TournamentSettingsWidget::readSettings()
 {
 	QSettings s;
@@ -103,6 +108,8 @@ void TournamentSettingsWidget::readSettings()
 
 	ui->m_repeatCheck->setChecked(s.value("repeat").toBool());
 	ui->m_recoverCheck->setChecked(s.value("recover").toBool());
+	ui->m_saveUnfinishedGamesCheck->setChecked(
+		s.value("save_unfinished_games", true).toBool());
 
 	s.endGroup();
 }
@@ -153,5 +160,9 @@ void TournamentSettingsWidget::enableSettingsUpdates()
 	connect(ui->m_recoverCheck, &QCheckBox::toggled, [=](bool checked)
 	{
 		QSettings().setValue("tournament/recover", checked);
+	});
+	connect(ui->m_saveUnfinishedGamesCheck, &QCheckBox::toggled, [=](bool checked)
+	{
+		QSettings().setValue("tournament/save_unfinished_games", checked);
 	});
 }

--- a/projects/gui/src/tournamentsettingswidget.h
+++ b/projects/gui/src/tournamentsettingswidget.h
@@ -40,6 +40,7 @@ class TournamentSettingsWidget : public QWidget
 		int delayBetweenGames() const;
 		bool openingRepetition() const;
 		bool engineRecovery() const;
+		bool savingOfUnfinishedGames() const;
 
 		void enableSettingsUpdates();
 

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>286</height>
+    <height>314</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -183,6 +183,16 @@
         </property>
         <property name="text">
          <string>Recover crashed engines</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="m_saveUnfinishedGamesCheck">
+        <property name="text">
+         <string>Save unfinished games</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -180,6 +180,14 @@ class LIB_EXPORT Tournament : public QObject
 				  PgnGame::PgnMode mode = PgnGame::Verbose);
 
 		/*!
+		 * Sets the PgnGame mode to write unfinished games to \a enabled.
+		 *
+		 * If \a enabled is true (the default) then the generated PGN games
+		 * are saved even if they have no result.
+		 */
+		void setPgnWriteUnfinishedGames(bool enabled);
+
+		/*!
 		 * Sets PgnGame cleanup mode to \a enabled.
 		 *
 		 * If \a enabled is true (the default) then the generated PgnGame
@@ -432,6 +440,7 @@ class LIB_EXPORT Tournament : public QObject
 		int m_openingRepetitions;
 		bool m_recover;
 		bool m_pgnCleanup;
+		bool m_pgnWriteUnfinishedGames;
 		bool m_finished;
 		bool m_bookOwnership;
 		GameAdjudicator m_adjudicator;


### PR DESCRIPTION
This patch adds the option to omit unfinished games from PGN output. When stopping a tournament also stalled and disconnected games are left out.

The CLI has an additional optional parameter for `-pgnout` :
```
-pgnout FILE [min][fi]
                        Save the games to FILE in PGN format. Use the 'min'
                        argument to save in a minimal/compact PGN format. Only
                        finished games are written when argument 'fi' is set.
```
TournamentSettingsDialog of the GUI has an additional checkbox "Save unfinished games".
The default behaviour is unchanged: cutechess GUI and CLI will write all PGN games.
This resolves #230 .