### PR TITLE
Support Almost Chess, Amazon Chess, and Chigorin Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -43,6 +43,8 @@ Five-check Chess
 Ai-Wok (Makruk variant)
 .It almost
 Almost Chess
+.It amazon
+Amazon Chess
 .It andernach
 Andernach Chess
 .It antiandernach

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -41,6 +41,8 @@ Three-check Chess
 Five-check Chess
 .It aiwok
 Ai-Wok (Makruk variant)
+.It almost
+Almost Chess
 .It andernach
 Andernach Chess
 .It antiandernach

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -71,6 +71,8 @@ Change-Over Chess
 Checkless Chess
 .It chessgi
 Chessgi / Drop Chess
+.It chigorin
+Chigorin Chess
 .It circulargryphon
 Circular Gryphon Chess
 .It coregal

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -13,6 +13,7 @@ Options:
 			'3check': Three-check Chess
 			'5check': Five-check Chess
 			'aiwok': Ai-Wok (Makruk variant)
+			'almost': Almost Chess
 			'andernach': Andernach Chess
 			'antiandernach': Anti-Andernach Chess
 			'antichess': Antichess (Losing Chess)

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -14,6 +14,7 @@ Options:
 			'5check': Five-check Chess
 			'aiwok': Ai-Wok (Makruk variant)
 			'almost': Almost Chess
+			'amazon': Amazon Chess
 			'andernach': Andernach Chess
 			'antiandernach': Anti-Andernach Chess
 			'antichess': Antichess (Losing Chess)

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -29,6 +29,7 @@ Options:
 			'checkless': Checkless Chess
 			'courier': Courier Chess
 			'chessgi': Chessgi (Drop Chess)
+			'chigorin': Chigorin Chess
 			'circulargryphon': Circular Gryphon Chess
 			'coregal': Co-regal Chess
 			'crazyhouse': Crazyhouse (Drop Chess)

--- a/projects/lib/src/board/almostboard.cpp
+++ b/projects/lib/src/board/almostboard.cpp
@@ -1,0 +1,46 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "almostboard.h"
+#include "westernzobrist.h"
+
+
+namespace Chess {
+
+AlmostBoard::AlmostBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Chancellor, tr("chancellor"), "C", KnightMovement | RookMovement);
+}
+
+Board* AlmostBoard::copy() const
+{
+	return new AlmostBoard(*this);
+}
+
+QString AlmostBoard::variant() const
+{
+	return "almost";
+}
+
+QString AlmostBoard::defaultFenString() const
+{
+	return "rnbckbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBCKBNR w KQkq - 0 1";
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/almostboard.h
+++ b/projects/lib/src/board/almostboard.h
@@ -1,0 +1,57 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ALMOSTBOARD_H
+#define ALMOSTBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Almost Chess
+ *
+ * Almost Chess is a variant of standard chess where the Queens are
+ * replaced by Chancellor pieces with Rook and Knight movements.
+ *
+ * This variant was introduced in 1977 by Ralph Betza, USA.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Almost_Chess
+ *
+ * \sa ChancellorBoard
+ * \sa CapablancaBoard
+ */
+class LIB_EXPORT AlmostBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new AlmostBoard object. */
+		AlmostBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+	protected:
+		enum AlmostPieceType
+		{
+			Chancellor = Queen //!< Chancellor (knight + rook) replaces Queen
+		};
+};
+
+} // namespace Chess
+#endif // ALMOSTBOARD_H

--- a/projects/lib/src/board/amazonboard.cpp
+++ b/projects/lib/src/board/amazonboard.cpp
@@ -1,0 +1,47 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "amazonboard.h"
+#include "westernzobrist.h"
+
+
+namespace Chess {
+
+AmazonBoard::AmazonBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Amazon, tr("amazon"), "A",
+		     KnightMovement | BishopMovement | RookMovement, "Q");
+}
+
+Board* AmazonBoard::copy() const
+{
+	return new AmazonBoard(*this);
+}
+
+QString AmazonBoard::variant() const
+{
+	return "amazon";
+}
+
+QString AmazonBoard::defaultFenString() const
+{
+	return "rnbakbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBAKBNR w KQkq - 0 1";
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/amazonboard.h
+++ b/projects/lib/src/board/amazonboard.h
@@ -1,0 +1,56 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef AMAZONBOARD_H
+#define AMAZONBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Amazon Chess
+ *
+ * Amazon Chess is a variant of standard chess where the Queen is
+ * replaced by the Amazon (or Empress) with Queen and Knight movements.
+ *
+ * This variant was described in Italy, 16th century. It was widely
+ * adopted in Russia and Georgia.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Amazon_Chess
+ *
+ */
+class LIB_EXPORT AmazonBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new AmazonBoard object. */
+		AmazonBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+	protected:
+		enum AmazonPieceType
+		{
+			Amazon = Queen //!< Amazon (queen + rook) replaces Queen
+		};
+};
+
+} // namespace Chess
+#endif // AMAZONBOARD_H

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -50,6 +50,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/aiwokboard.cpp \
     $$PWD/sittuyinboard.cpp \
     $$PWD/losalamosboard.cpp \
+    $$PWD/almostboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -106,6 +107,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/aiwokboard.h \
     $$PWD/sittuyinboard.h \
     $$PWD/losalamosboard.h \
+    $$PWD/almostboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -51,6 +51,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/sittuyinboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
+    $$PWD/amazonboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -108,6 +109,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/sittuyinboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \
+    $$PWD/amazonboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -52,6 +52,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
     $$PWD/amazonboard.cpp \
+    $$PWD/chigorinboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -110,6 +111,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \
     $$PWD/amazonboard.h \
+    $$PWD/chigorinboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -19,6 +19,7 @@
 #include "boardfactory.h"
 #include "aiwokboard.h"
 #include "almostboard.h"
+#include "amazonboard.h"
 #include "andernachboard.h"
 #include "antiboard.h"
 #include "aseanboard.h"
@@ -67,6 +68,7 @@ REGISTER_BOARD(ThreeCheckBoard, "3check")
 REGISTER_BOARD(FiveCheckBoard, "5check")
 REGISTER_BOARD(AiWokBoard, "ai-wok")
 REGISTER_BOARD(AlmostBoard, "almost")
+REGISTER_BOARD(AmazonBoard, "amazon")
 REGISTER_BOARD(AndernachBoard, "andernach")
 REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
 REGISTER_BOARD(AntiBoard, "antichess")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -18,6 +18,7 @@
 
 #include "boardfactory.h"
 #include "aiwokboard.h"
+#include "almostboard.h"
 #include "andernachboard.h"
 #include "antiboard.h"
 #include "aseanboard.h"
@@ -65,6 +66,7 @@ namespace Chess {
 REGISTER_BOARD(ThreeCheckBoard, "3check")
 REGISTER_BOARD(FiveCheckBoard, "5check")
 REGISTER_BOARD(AiWokBoard, "ai-wok")
+REGISTER_BOARD(AlmostBoard, "almost")
 REGISTER_BOARD(AndernachBoard, "andernach")
 REGISTER_BOARD(AntiAndernachBoard, "antiandernach")
 REGISTER_BOARD(AntiBoard, "antichess")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -30,6 +30,7 @@
 #include "chancellorboard.h"
 #include "checklessboard.h"
 #include "chessgiboard.h"
+#include "chigorinboard.h"
 #include "coregalboard.h"
 #include "courierboard.h"
 #include "crazyhouseboard.h"
@@ -82,6 +83,7 @@ REGISTER_BOARD(ChancellorBoard, "chancellor")
 REGISTER_BOARD(ChangeOverBoard, "changeover")
 REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
+REGISTER_BOARD(ChigorinBoard, "chigorin")
 REGISTER_BOARD(CircularGryphonBoard, "circulargryphon")
 REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CourierBoard, "courier")

--- a/projects/lib/src/board/chigorinboard.cpp
+++ b/projects/lib/src/board/chigorinboard.cpp
@@ -1,0 +1,64 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chigorinboard.h"
+#include "westernzobrist.h"
+
+
+namespace Chess {
+
+ChigorinBoard::ChigorinBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Chancellor, tr("chancellor"), "C", KnightMovement | RookMovement);
+}
+
+Board* ChigorinBoard::copy() const
+{
+	return new ChigorinBoard(*this);
+}
+
+QString ChigorinBoard::variant() const
+{
+	return "chigorin";
+}
+
+QString ChigorinBoard::defaultFenString() const
+{
+	return "rbbqkbbr/pppppppp/8/8/8/8/PPPPPPPP/RNNCKNNR w KQkq - 0 1";
+}
+
+void ChigorinBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	Side side = sideToMove();
+
+	if (side == Side::White)
+	{
+		moves.append(Move(sourceSquare, targetSquare, Knight));
+		moves.append(Move(sourceSquare, targetSquare, Rook));
+		moves.append(Move(sourceSquare, targetSquare, Chancellor));
+	}
+	if (side == Side::Black)
+	{
+		moves.append(Move(sourceSquare, targetSquare, Bishop));
+		moves.append(Move(sourceSquare, targetSquare, Rook));
+		moves.append(Move(sourceSquare, targetSquare, Queen));
+	}
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/chigorinboard.h
+++ b/projects/lib/src/board/chigorinboard.h
@@ -1,0 +1,65 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHIGORINBOARD_H
+#define CHIGORINBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Chigorin Chess
+ *
+ * Chigorin Chess is a variant of standard chess where the
+ * white side has no pieces with Bishop movement but four
+ * Knights and one Chancellor with Rook and Knight movements.
+ * Black has no pieces with Knight movement but four Bishops
+ * and one Queen. Pawn promotion is only allowed to the piece
+ * types that a side had at the start of the game (with the
+ * exceptions of Pawn and King).
+ *
+ * This variant was introduced by Ralph Betza in 2002
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Chigorin_Chess
+ *
+ * \sa ChancellorBoard
+ */
+class LIB_EXPORT ChigorinBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new ChigorinBoard object. */
+		ChigorinBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+	protected:
+		enum ChigorinPieceType
+		{
+			Chancellor = 8 //!< Chancellor (knight + rook)
+		};
+		// Inherited from WesternBoard
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+			     QVarLengthArray< Move >& moves) const;
+};
+
+} // namespace Chess
+#endif // CHIGORINBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -538,6 +538,11 @@ void tst_Board::moveStrings_data() const
 		<< "d3 d4"
 		<< "rnqknr/pppppp/6/6/PPPPPP/RNQKNR w - - 0 1"
 		<< "rnqknr/ppp1pp/3p2/3P2/PPP1PP/RNQKNR w - - 0 2";
+	QTest::newRow("almost san1")
+		<< "almost"
+		<< "Cc3 g6 Cxc7#"
+		<< "rnbckbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBCKBNR w KQkq - 0 1"
+		<< "rnbckbnr/ppCppp1p/6p1/8/8/8/PPPPPPPP/RNB1KBNR b KQkq - 0 2";
 
 }
 
@@ -913,6 +918,14 @@ void tst_Board::results_data() const
 		<< variant
 		<< "8/8/8/2sp2k1/8/3P4/4K1a1/7r w - - 0 1"
 		<< "0-1";
+
+	variant = "almost";
+
+	QTest::newRow("almost fool's mate")
+		<< variant
+		<< "rnbckbnr/ppCppp1p/6p1/8/8/8/PPPPPPPP/RNB1KBNR b KQkq - 0 2"
+		<< "1-0";
+
 }
 
 void tst_Board::results()
@@ -1418,6 +1431,18 @@ void tst_Board::perft_data() const
 		<< "6/2P3/6/1K1k2/6/6 w - - 0 1"
 		<< 5 // 4 plies: 3117, 5 plies: 39171, 6 plies: 187431
 		<< Q_UINT64_C(39171);
+
+	variant = "almost";
+	QTest::newRow("almost startpos")
+		<< variant
+		<< "rnbckbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBCKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 290522, 5 plies: 7812388, 6 plies: 208096934
+		<< Q_UINT64_C(290522);
+	QTest::newRow("almost promotion")
+		<< variant
+		<< "8/KP2k3/8/8/8/8/8/8 w - - 0 1"
+		<< 5 // 4 plies: 3036, 5 plies: 41476
+		<< Q_UINT64_C(41476);
 
 }
 

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1456,6 +1456,18 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 2885, 5 plies: 41738
 		<< Q_UINT64_C(41738);
 
+	variant = "chigorin";
+	QTest::newRow("chigorin startpos")
+		<< variant
+		<< "rbbqkbbr/pppppppp/8/8/8/8/PPPPPPPP/RNNCKNNR w KQkq - 0 1"
+		<< 4 // 4 plies: 229973, 5 plies: 6624527, 6 plies: 156383743
+		<< Q_UINT64_C(229973);
+	QTest::newRow("chigorin promotion")
+		<< variant
+		<< "8/KP6/8/4k3/8/8/6p1/8 w - - 0 1"
+		<< 5 // 4 plies: 8133, 5 plies: 104326
+		<< Q_UINT64_C(104326);
+
 }
 
 void tst_Board::perft()

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1444,6 +1444,18 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 3036, 5 plies: 41476
 		<< Q_UINT64_C(41476);
 
+	variant = "amazon";
+	QTest::newRow("amazon startpos")
+		<< variant
+		<< "rnbakbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBAKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 318185, 5 plies: 9319911, 6 plies: 268050499
+		<< Q_UINT64_C(318185);
+	QTest::newRow("amazon promotion")
+		<< variant
+		<< "8/KP2k3/8/8/8/8/8/8 w - - 0 1"
+		<< 5 // 4 plies: 2885, 5 plies: 41738
+		<< Q_UINT64_C(41738);
+
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This PR comprises of 3 patches each adding support of one chess variant.
These are lightweight implementations.

_Almost Chess_: This variant by R. Betza replaces the Queen by a Chancellor piece with Rook and Knight movements.

_Amazon Chess_: Here the Queen has additional powers of a Knight. This is an established variant (16th century) and  has been the standard way to play chess in Russia and Georgia.

_Chigorin Chess_: White has no pieces with Bishop movement but four Knights and one Chancellor with Rook and Knight movements. Black has no pieces with Knight movement but four Bishops
and one Queen. Pawn can only promote to piece types present at the start, so no Queen for White and no Chancellor for Black.

The variants have been tested with _Fairy-Stockfish_ (all), and with _Sjaak II_ (Amazon Chess, Almost Chess - the latter renamed from Chancellor Chess 8x8 in Sjaak II's variant config).