### PR TITLE
CECP engine forfeits on claim of illegal move

### DIFF
--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -759,6 +759,13 @@ void XboardEngine::parseLine(const QString& line)
 			pos += rx.matchedLength();
 		}
 	}
+	else if (command.startsWith("Illegal"))
+	{
+		forfeit(Chess::Result::Adjudication,
+			tr("%1 claims illegal %2")
+			.arg(this->side().toString())
+			.arg(args));
+	}
 	else if (command == "Error")
 	{
 		// If the engine complains about an unknown result command,


### PR DESCRIPTION
As long as cutechess has an arbiter function, illegal moves are not (read: should not be) transmitted to engines. So a claim of an illegal move should not be valid. At present, without adjudication the claiming engine waits and finally forfeits on time.

This patch avoids the wait and adjudicates against the CECP engine claiming an illegal move. This resolves #109 .