### PR TITLE
Game adjudication on trusted mate score

### DIFF
--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -117,7 +117,7 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 
 		/*! Returns a list of supported chess variants. */
 		QStringList variants() const;
-		
+
 	public slots:
 		// Inherited from ChessPlayer
 		virtual void go();

--- a/projects/lib/src/chessplayer.cpp
+++ b/projects/lib/src/chessplayer.cpp
@@ -270,6 +270,7 @@ void ChessPlayer::emitMove(const Chess::Move& move)
 
 	m_timeControl.update();
 	m_eval.setTime(m_timeControl.lastMoveTime());
+	m_eval.setIsTrusted(!areClaimsValidated());
 
 	m_timer->stop();
 	if (m_timeControl.expired() && !canPlayAfterTimeout())

--- a/projects/lib/src/gameadjudicator.cpp
+++ b/projects/lib/src/gameadjudicator.cpp
@@ -112,8 +112,19 @@ void GameAdjudicator::addEval(const Chess::Board* board, const MoveEvaluation& e
 			count = 0;
 
 		if (count >= m_resignMoveCount)
+		{
 			m_result = Chess::Result(Chess::Result::Adjudication,
 						 side.opposite());
+			return;
+		}
+	}
+
+	// Trust-feature
+	if (eval.isTrusted()
+	&&  eval.score() >= eval.MATE_SCORE - 200)
+	{
+		m_result = Chess::Result(Chess::Result::Adjudication, side, "trusted mate score");
+		return;
 	}
 
 	// Limit game length

--- a/projects/lib/src/moveevaluation.cpp
+++ b/projects/lib/src/moveevaluation.cpp
@@ -20,6 +20,7 @@
 
 MoveEvaluation::MoveEvaluation()
 	: m_isBookEval(false),
+	  m_isTrusted(false),
 	  m_depth(0),
 	  m_selDepth(0),
 	  m_score(NULL_SCORE),
@@ -36,6 +37,7 @@ MoveEvaluation::MoveEvaluation()
 bool MoveEvaluation::operator==(const MoveEvaluation& other) const
 {
 	if (m_isBookEval == other.m_isBookEval
+	&&  m_isTrusted == other.m_isTrusted
 	&&  m_depth == other.m_depth
 	&&  m_selDepth == other.m_selDepth
 	&&  m_score == other.m_score
@@ -54,6 +56,7 @@ bool MoveEvaluation::operator==(const MoveEvaluation& other) const
 bool MoveEvaluation::operator!=(const MoveEvaluation& other) const
 {
 	if (m_isBookEval != other.m_isBookEval
+	||  m_isTrusted != other.m_isTrusted
 	||  m_depth != other.m_depth
 	||  m_selDepth != other.m_selDepth
 	||  m_score != other.m_score
@@ -91,6 +94,11 @@ bool MoveEvaluation::isBookEval() const
 	return m_isBookEval;
 }
 
+bool MoveEvaluation::isTrusted() const
+{
+	return m_isTrusted;
+}
+
 int MoveEvaluation::depth() const
 {
 	return m_depth;
@@ -121,7 +129,7 @@ QString MoveEvaluation::scoreText() const
 			str += "+";
 
 		// Detect mate-in-n scores
-		if (absScore > 98800
+		if (absScore > MATE_SCORE - 200
 		&&  (absScore = 1000 - (absScore % 1000)) < 200)
 		{
 			if (m_score < 0)
@@ -202,6 +210,11 @@ void MoveEvaluation::clear()
 void MoveEvaluation::setBookEval(bool isBookEval)
 {
 	m_isBookEval = isBookEval;
+}
+
+void MoveEvaluation::setIsTrusted(bool isTrusted)
+{
+	m_isTrusted = isTrusted;
 }
 
 void MoveEvaluation::setDepth(int depth)

--- a/projects/lib/src/moveevaluation.h
+++ b/projects/lib/src/moveevaluation.h
@@ -35,8 +35,11 @@
 class LIB_EXPORT MoveEvaluation
 {
 	public:
+		/*! Mate score reference */
+		constexpr static int MATE_SCORE = 1000000;
+
 		/*! A value for a null or empty score. */
-		static const int NULL_SCORE = 0xFFFFFFF;
+		constexpr static int NULL_SCORE = 0xFFFFFFF;
 
 		/*! Constructs an empty MoveEvaluation object. */
 		MoveEvaluation();
@@ -51,6 +54,9 @@ class LIB_EXPORT MoveEvaluation
 		
 		/*! Returns true if the evaluation points to a book move. */
 		bool isBookEval() const;
+
+		/*! Returns true if the eval is trusted for adjudication. */
+		bool isTrusted() const;
 
 		/*!
 		 * How many plies were searched?
@@ -135,6 +141,9 @@ class LIB_EXPORT MoveEvaluation
 		/*! Sets book evaluation. */
 		void setBookEval(bool isBookEval);
 
+		/*! Sets trusted property. */
+		void setIsTrusted(bool isTrusted);
+
 		/*! Sets the search depth to \a depth. */
 		void setDepth(int depth);
 
@@ -176,6 +185,7 @@ class LIB_EXPORT MoveEvaluation
 
 	private:
 		bool m_isBookEval;
+		bool m_isTrusted;
 		int m_depth;
 		int m_selDepth;
 		int m_score;

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -417,9 +417,9 @@ void UciEngine::parseInfo(const QVarLengthArray<QStringRef>& tokens,
 				{
 					score = tokens[i].toString().toInt();
 					if (score > 0)
-						score = 99000 + 1 - score * 2;
+						score = eval->MATE_SCORE + 1 - score * 2;
 					else if (score < 0)
-						score = -99000 - score * 2;
+						score = -eval->MATE_SCORE - score * 2;
 				}
 				else if (tokens[i - 1] == "lowerbound"
 				     ||  tokens[i - 1] == "upperbound")

--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -569,7 +569,6 @@ void XboardEngine::setFeature(const QString& name, const QString& val)
 // shift assumed mate scores further out
 int XboardEngine::adaptScore(int score) const
 {
-	constexpr static int mateScore = 99000;
 	constexpr static int newCECPMateScore = 100000;
 	int absScore = qAbs<int>(score);
 
@@ -577,7 +576,7 @@ int XboardEngine::adaptScore(int score) const
 	if (absScore > newCECPMateScore
 	&&  absScore < newCECPMateScore + 100)
 	{
-		absScore = 2 * newCECPMateScore - 2 * absScore + mateScore;
+		absScore = 2 * newCECPMateScore - 2 * absScore + m_eval.MATE_SCORE;
 		if (score >= absScore)
 			absScore++;
 	}
@@ -585,8 +584,8 @@ int XboardEngine::adaptScore(int score) const
 	// map assumed mate scores onto equivalents w/ higher absolute values
 	int distance = 1000 - (absScore % 1000);
 	if (absScore > 9900 &&  distance < 100)
-		score = (score > 0) ? mateScore - distance
-				    : -mateScore + distance;
+		score = (score > 0) ? m_eval.MATE_SCORE - distance
+				    : -m_eval.MATE_SCORE + distance;
 
 	return score;
 }


### PR DESCRIPTION
This patch adds the option to accept adjudication based on a winning (mate in x) score of a trusted engine. Previously "trust" was only used for result claims of CECP engines.

While there, the mate score representation was changed (also the value of the mate score from 99000 to 1000000 - read one million). This change is only internal and has (should have) no impact on the UI and the output, because the changes of the last year already provided an abstraction.
  
This PR resolves #288.

I hope this is useful.