### PR TITLE
Display variant label in GameDatabaseDialog

### DIFF
--- a/projects/gui/src/gamedatabasedlg.cpp
+++ b/projects/gui/src/gamedatabasedlg.cpp
@@ -449,6 +449,8 @@ void GameDatabaseDialog::gameSelectionChanged(const QModelIndex& current,
 	ui->m_siteLabel->setText(m_game.tagValue("Site"));
 	ui->m_eventLabel->setText(m_game.tagValue("Event"));
 	ui->m_resultLabel->setText(m_game.tagValue("Result"));
+	ui->m_variantLabel->setText(m_game.tagValue("Variant"));
+	ui->label_variant->setVisible(!ui->m_variantLabel->text().isEmpty());
 
 	m_gameViewer->setGame(&m_game);
 }

--- a/projects/gui/ui/gamedatabasedlg.ui
+++ b/projects/gui/ui/gamedatabasedlg.ui
@@ -342,6 +342,30 @@
              </property>
             </widget>
            </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_variant">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+               <kerning>true</kerning>
+              </font>
+             </property>
+             <property name="text">
+              <string>Variant:</string>
+             </property>
+             <property name="visible">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QLabel" name="m_variantLabel">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </widget>


### PR DESCRIPTION
This patch adds a variant label to the GameDatabaseDialog. It will only be visible if the Variant tag of the currently selected game is not empty.

It helps browsing mixed databases with games of various chess variants.


![i1](https://user-images.githubusercontent.com/6425738/43680627-d939fe46-983e-11e8-835c-45309b568e16.png)
