### PR TITLE
Support Rifle Chess and Shooting Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -127,10 +127,14 @@ Modern Chess (9x9)
 Pocket Knight Chess
 .It racingkings
 Racing Kings Chess
+.It rifle
+Rifle Chess
 .It seirawan
 S-Chess (Seirawan Chess)
 .It shatranj
 Shatranj
+.It shoot
+Shoot Chess
 .It simplifiedgryphon
 Simplified Gryphon Chess
 .It sittuyin

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -56,8 +56,10 @@ Options:
 			'modern': Modern Chess (9x9)
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
+			'rifle': Rifle Chess
 			'seirawan': S-Chess (Seirawan Chess)
 			'shatranj': Shatranj
+			'shoot': Shoot Chess
 			'slippedgrid': Slipped Grid Chess
 			'simplifiedgryphon': Simplified Gryphon Chess
 			'sittuyin': Sittuyin (Myanmar Chess)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -49,6 +49,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/aseanboard.cpp \
     $$PWD/aiwokboard.cpp \
     $$PWD/sittuyinboard.cpp \
+    $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
     $$PWD/amazonboard.cpp \
@@ -108,6 +109,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/aseanboard.h \
     $$PWD/aiwokboard.h \
     $$PWD/sittuyinboard.h \
+    $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \
     $$PWD/amazonboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -55,6 +55,7 @@
 #include "oukboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
+#include "rifleboard.h"
 #include "seirawanboard.h"
 #include "shatranjboard.h"
 #include "sittuyinboard.h"
@@ -111,8 +112,10 @@ REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
+REGISTER_BOARD(RifleBoard, "rifle")
 REGISTER_BOARD(SeirawanBoard, "seirawan")
 REGISTER_BOARD(ShatranjBoard, "shatranj")
+REGISTER_BOARD(ShootBoard, "shoot")
 REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
 REGISTER_BOARD(SittuyinBoard, "sittuyin")
 REGISTER_BOARD(SlippedGridBoard, "slippedgrid")

--- a/projects/lib/src/board/rifleboard.cpp
+++ b/projects/lib/src/board/rifleboard.cpp
@@ -1,0 +1,155 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "rifleboard.h"
+#include "westernzobrist.h"
+#include "boardtransition.h"
+
+namespace Chess {
+
+RifleBoard::RifleBoard()
+	: WesternBoard(new WesternZobrist())
+{
+}
+
+Board* RifleBoard::copy() const
+{
+	return new RifleBoard(*this);
+}
+
+QString RifleBoard::variant() const
+{
+	return "rifle";
+}
+
+QString RifleBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+void RifleBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	bool isCapture = (captureType(move) != Piece::NoPiece);
+
+	WesternBoard::vMakeMove(move, transition);
+
+	if (isCapture)
+	{
+		setSquare(source, pieceAt(target));
+		setSquare(target, Piece::NoPiece);
+		if (transition != nullptr)
+		{
+			transition->addSquare(chessSquare(source));
+			transition->addSquare(chessSquare(target));
+		}
+	}
+}
+
+void RifleBoard::vUndoMove(const Move& move)
+{
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+
+	if (pieceAt(target) == Piece::NoPiece
+	&&  pieceAt(source) != Piece::NoPiece)
+	{
+		setSquare(target, pieceAt(source));
+		setSquare(source, Piece::NoPiece);
+	}
+	WesternBoard::vUndoMove(move);
+}
+
+bool RifleBoard::inCheck(Side side, int square) const
+{
+	// After King has made a capture WesternBoard's kingSquare is incorrect
+	Piece king(side, King);
+	int ksq = kingSquare(side);
+
+	if (square == 0 &&  pieceAt(ksq) != king)
+	{
+		square = 2 * width() + 1;
+		const int size = arraySize() - square;
+		while (square < size && pieceAt(square) != king)
+			square++;
+	}
+	return WesternBoard::inCheck(side, square);
+}
+
+void RifleBoard::addPromotions(int sourceSquare, int targetSquare,
+			       QVarLengthArray< Move >& moves) const
+{
+	// prevent capturing Pawn from promoting on seventh rank
+	if (pieceAt(targetSquare).isEmpty())
+		return WesternBoard::addPromotions(sourceSquare,
+						   targetSquare,
+						   moves);
+	moves.append(Move(sourceSquare, targetSquare));
+}
+
+
+ShootBoard::ShootBoard()
+	: RifleBoard(),
+	  m_testKey(0),
+	  m_canCapture(false)
+{
+}
+
+Board* ShootBoard::copy() const
+{
+	return new ShootBoard(*this);
+}
+
+QString ShootBoard::variant() const
+{
+	return "shoot";
+}
+
+bool ShootBoard::vIsLegalMove(const Move& move)
+{
+	if (!WesternBoard::vIsLegalMove(move))
+		return false;
+
+	if (captureType(move) != Piece::NoPiece)
+		return true;
+
+	//try to use old results to gain higher efficiency
+	if (key() != m_testKey)
+	{
+		m_testKey = key();
+		m_canCapture = false;
+		QVarLengthArray<Move> moves;
+		generateMoves(moves);
+
+		// search for any legal capture move
+		for (int i = 0; i < moves.size(); i++)
+		{
+			if (captureType(moves[i]) != Piece::NoPiece
+			&&  WesternBoard::vIsLegalMove(moves[i]))
+			{
+				m_canCapture = true;
+				break;
+			}
+		}
+	}
+	// move is illegal if a capture move exists else legal
+	return !m_canCapture;
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/rifleboard.h
+++ b/projects/lib/src/board/rifleboard.h
@@ -1,0 +1,92 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef RIFLEBOARD_H
+#define RIFLEBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Rifle Chess
+ *
+ * Rifle Chess is a variant of standard chess with a different
+ * way to capture pieces.
+ *
+ * An attacking piece stays on its square and removes (shoots)
+ * an opponent piece without replacing it.
+ *
+ * Introduced by William B. Seabrook, USA 1921 / 1927.
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Rifle_chess
+ */
+class LIB_EXPORT RifleBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new RifleBoard object. */
+		RifleBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual bool inCheck(Side side, int square = 0) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
+};
+
+
+/*!
+ * \brief A board for Shoot Chess
+ *
+ * Shoot Chess or Shooting Chess is a variant of Rifle Chess.
+ * If a side can make a legal capturing move they must capture.
+ *
+ * Reference: S. Reuben, British Chess Magazine, February 1990
+ *
+ * \sa Rifle Chess
+ * \sa Antichess
+ */
+class LIB_EXPORT ShootBoard : public RifleBoard
+{
+	public:
+		/*! Creates a new ShootBoard object. */
+		ShootBoard();
+
+		// Inherited from ShootBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual bool vIsLegalMove(const Move& move);
+	private:
+		quint64 m_testKey;
+		bool m_canCapture;
+};
+
+} // namespace Chess
+#endif // RIFLEBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -543,6 +543,11 @@ void tst_Board::moveStrings_data() const
 		<< "Cc3 g6 Cxc7#"
 		<< "rnbckbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBCKBNR w KQkq - 0 1"
 		<< "rnbckbnr/ppCppp1p/6p1/8/8/8/PPPPPPPP/RNB1KBNR b KQkq - 0 2";
+	QTest::newRow("shoot san1")
+		<< "shoot"
+		<< "e4 e5 Bb5 c6 Bxc6 Nc6 Bxc6 Nf6 Bxd7+ Nd7 Bxd7+ Bd7 Bxd7+ Qd7 Bxd7+"
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< "r3kb1r/pp3ppp/8/1B2p3/4P3/8/PPPP1PPP/RNBQK1NR b KQkq - 0 8";
 
 }
 
@@ -1468,6 +1473,19 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 8133, 5 plies: 104326
 		<< Q_UINT64_C(104326);
 
+	variant = "rifle";
+	QTest::newRow("rifle startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 197326, 5 plies: 4866988, 6 plies: 119235709
+		<< Q_UINT64_C(197326);
+
+	variant = "shoot";
+	QTest::newRow("shoot startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 153023, 5 plies: 2735167, 6 plies: 46678307
+		<< Q_UINT64_C(153023);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
This PR adds support of _Rifle Chess_ and _Shooting Chess_.

These variants of chess have a different way to capture pieces: An attacking piece removes (shoots) an opponent piece without replacing it.

Shoot Chess or Shooting Chess is a variant of Rifle Chess: It is obligatory to make a capturing move if possible.

This implementation has been tested by manual play. I hope this is useful.