### PR TITLE
Support The Game of Codrus, a Losing Chess variant

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -75,6 +75,8 @@ Chessgi / Drop Chess
 Chigorin Chess
 .It circulargryphon
 Circular Gryphon Chess
+.It codrus
+Game of Codrus (Losing Chess Variant)
 .It coregal
 Co-regal Chess
 .It courier

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -27,11 +27,12 @@ Options:
 			'chancellor': Chancellor Chess (9x9)
 			'changeover': Change-Over Chess
 			'checkless': Checkless Chess
-			'courier': Courier Chess
 			'chessgi': Chessgi (Drop Chess)
 			'chigorin': Chigorin Chess
 			'circulargryphon': Circular Gryphon Chess
+			'codrus': Game of Codrus (Losing Chess variant)
 			'coregal': Co-regal Chess
+			'courier': Courier Chess
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'discplacedgrid': Displaced Grid Chess
 			'embassy': Embassy Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -34,6 +34,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/antiboard.cpp \
     $$PWD/giveawayboard.cpp \
     $$PWD/suicideboard.cpp \
+    $$PWD/codrusboard.cpp \
     $$PWD/gothicboard.cpp \
     $$PWD/grandboard.cpp \
     $$PWD/crazyhouseboard.cpp \
@@ -93,6 +94,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/antiboard.h \
     $$PWD/giveawayboard.h \
     $$PWD/suicideboard.h \
+    $$PWD/codrusboard.h \
     $$PWD/gothicboard.h \
     $$PWD/grandboard.h \
     $$PWD/crazyhouseboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -31,6 +31,7 @@
 #include "checklessboard.h"
 #include "chessgiboard.h"
 #include "chigorinboard.h"
+#include "codrusboard.h"
 #include "coregalboard.h"
 #include "courierboard.h"
 #include "crazyhouseboard.h"
@@ -85,6 +86,7 @@ REGISTER_BOARD(ChecklessBoard, "checkless")
 REGISTER_BOARD(ChessgiBoard, "chessgi")
 REGISTER_BOARD(ChigorinBoard, "chigorin")
 REGISTER_BOARD(CircularGryphonBoard, "circulargryphon")
+REGISTER_BOARD(CodrusBoard, "codrus")
 REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CourierBoard, "courier")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")

--- a/projects/lib/src/board/codrusboard.cpp
+++ b/projects/lib/src/board/codrusboard.cpp
@@ -1,0 +1,95 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "codrusboard.h"
+
+namespace Chess {
+
+CodrusBoard::CodrusBoard()
+	: GiveawayBoard()
+{
+}
+
+Board* CodrusBoard::copy() const
+{
+	return new CodrusBoard(*this);
+}
+
+QString CodrusBoard::variant() const
+{
+	return "codrus";
+}
+
+bool CodrusBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	return whiteKings + blackKings > 0;
+}
+
+void CodrusBoard::addPromotions(int sourceSquare,
+				int targetSquare,
+				QVarLengthArray<Move>& moves) const
+{
+	moves.append(Move(sourceSquare, targetSquare, Knight));
+	moves.append(Move(sourceSquare, targetSquare, Bishop));
+	moves.append(Move(sourceSquare, targetSquare, Rook));
+	moves.append(Move(sourceSquare, targetSquare, Queen));
+}
+
+int CodrusBoard::pieceCount(Side side, int ptype) const
+{
+	int count = 0;
+	for (int i = 0; i < arraySize(); i++)
+	{
+		if ((ptype == Piece::NoPiece || ptype == pieceAt(i).type())
+	        &&  (side == Side::NoSide || side == pieceAt(i).side()))
+			++count;
+	}
+	return count;
+}
+
+bool CodrusBoard::vIsLegalMove(const Move& move)
+{
+	Side side(sideToMove());
+	int ksq = kingSquare(side);
+
+	// no moves when without King
+	if (pieceAt(ksq) != Piece(side, King)
+	&&  pieceCount(side, King) < 1)
+		  return false;
+
+	return Chess::GiveawayBoard::vIsLegalMove(move);
+}
+
+Result CodrusBoard::vResultOfStalemate() const
+{
+	QString str { tr("Draw by stalemate") };
+	return Result(Result::Draw, Side::NoSide, str);
+}
+
+Result CodrusBoard::result()
+{
+	const Side side = sideToMove();
+	if (pieceCount(side, King) == 0)
+	{
+		QString str = tr("%1 wins").arg(side.toString());
+		return Result(Result::Win, side, str);
+	}
+	return GiveawayBoard::result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/codrusboard.h
+++ b/projects/lib/src/board/codrusboard.h
@@ -1,0 +1,82 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CODRUSBOARD_H
+#define CODRUSBOARD_H
+
+#include "giveawayboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for the Game of Codrus, a Losing Chess variant
+ *
+ * The Game of Codrus is a predecessor of Losing Chess.
+ *
+ * The King has no royal powers, so there is no check and the King can be
+ * captured. Castling is allowed. If a side can capture then they must make
+ * a capture move.
+ *
+ * The side whose King is captured wins.
+ *
+ * The Game of Codrus has been described in J. Brede's Alamanach, Denmark 1844.
+ * It is named after the Athenian King Codrus who sacrificed himself to save
+ * his people (1068 BC).
+ *
+ * \note Rules: J. Brede (1844): Almanach für Freunde vom Schachspiel,
+ * Altona, (then) Denmark: J. F. Hammreich. p. 82f (in German language).
+ * Retrieved from: http://www.binnewirtz.com/Brede.htm.
+ *
+ * \note Also see Pritchard, D. B. (2007). Beasley, John, ed. The Classified
+ * Encyclopedia of Chess Variants. Harpenden, UK: John Beasley. ch. 10.9.
+ * Retrieved from https://www.jsbeasley.co.uk/encyc.htm.
+ *
+ * \sa AntiBoard
+ * \sa GiveawayBoard
+ */
+
+class LIB_EXPORT CodrusBoard : public GiveawayBoard
+{
+	public:
+		/*! Creates a new CodrusBoard object. */
+		CodrusBoard();
+
+		// Inherited from GiveawayBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual Result result();
+
+	protected:
+		// Inherited from GiveawayBoard
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray<Move>& moves) const;
+		virtual bool vIsLegalMove(const Move& move);
+
+		/*! Rules outcome of stalemate */
+		virtual Result vResultOfStalemate() const;
+
+	private:
+		int pieceCount(Side side,
+			       int ptype = Piece::NoPiece) const;
+
+}; // namespace Chess
+}
+#endif // CODRUSBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -926,6 +926,13 @@ void tst_Board::results_data() const
 		<< "rnbckbnr/ppCppp1p/6p1/8/8/8/PPPPPPPP/RNB1KBNR b KQkq - 0 2"
 		<< "1-0";
 
+	variant = "codrus";
+
+	QTest::newRow("codrus black win")
+		<< variant
+		<< "7r/4b1pp/P7/6R1/8/2N1K3/1P1PP1PP/2B2BNR b - - 0 18"
+		<< "0-1";
+
 }
 
 void tst_Board::results()
@@ -1301,6 +1308,19 @@ void tst_Board::perft_data() const
 		<< "8/k1KP4/8/8/8/8/8/6n1 b - - 0 1"
 		<< 7 // 7 plies: 2891980
 		<< Q_UINT64_C(2891980);
+
+	variant = "codrus";
+
+	QTest::newRow("codrus startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 153299, 5 plies: 2732672, 6 plies: 46263517, 7 plies: 762067389
+		<< Q_UINT64_C(153299);
+	QTest::newRow("codrus endgame1")
+		<< variant
+		<< "5bnr/2pp2pp/P4k2/R3Q1P1/8/2N1K3/1P1PP1PP/2B2BNR w - - 1 15"
+		<< 4 // 1 ply: 3, 2 plies: 1, 3 plies: 2, 4 plies: 19
+		<< Q_UINT64_C(19);
 
 	variant = "threekings";
 	QTest::newRow("threekings startpos")


### PR DESCRIPTION
This PR supports The Game of Codrus, a predecess of Losing Chess.

The Game of Codrus has been described in J. Brede's Alamanach, Altona, then Denmark 1844.
It is named after the Athenian King Codrus who sacrificed himself to save his people (1068 BC).

In this chess variant, the King has no royal powers, so there is no check and the King can be
captured. Castling is allowed. If a side can capture then they must make a capture move.

**The side whose King is captured wins.**

Rules: : J. Brede (1844): Almanach für Freunde vom Schachspiel, Altona, Denmark: J. F. Hammreich. p. 82f. (in German language) retrieved from: http://www.binnewirtz.com/Brede.htm.
Also see Pritchard, D. B. (2007). Beasley, John, ed. The Classified Encyclopedia of Chess Variants. Harpenden, UK: John Beasley. ch. 10.9. Retrieved from https://www.jsbeasley.co.uk/encyc.htm .

This implementation has been tested with [Fairy-Stockfish](https://github.com/ianfab/Fairy-Stockfish).
The tests had a very low draw rate and short games.

I hope this is useful.

-------------------------

_Original post before discussion with @ianfab  and major rewrite of code :_

This PR supports The Game of Codrus, a predecess of Losing Chess.
The Game of Codrus has been described in J. Brede's Alamanach, Altona, then Denmark 1844.
It is named after the Athenian King Codrus who sacrificed himself to save his people (1068 BC).

In this chess variant, the King has no royal powers, so there is no check and the King can be
captured. Pawns can also promote to King. Castling is not allowed.
If a side can capture then they must make a capture move.

**The side whose King is captured wins.** A side that cannot move wins by stalemate.
 
Rules: see D. Pritchard: The Classified Encyclopedia of Chess Variants, chapter 10.9.

This implementation has been tested with [Fairy-Stockfish](https://github.com/ianfab/Fairy-Stockfish).
However, Fairy-Stockfish has castling.

I hope this is useful.
 