### PR TITLE
Support Placement Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -123,6 +123,8 @@ Loser's Chess
 Makruk (Thai Chess)
 .It modern
 Modern Chess (9x9)
+.It placement
+Placement Chess
 .It pocketknight
 Pocket Knight Chess
 .It racingkings

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -54,6 +54,7 @@ Options:
 			'losers': Loser's Chess
 			'makruk': Makruk (Thai Chess)
 			'modern': Modern Chess (9x9)
+			'placement': Placement Chess
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess
 			'seirawan': S-Chess (Seirawan Chess)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -53,6 +53,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/almostboard.cpp \
     $$PWD/amazonboard.cpp \
     $$PWD/chigorinboard.cpp \
+    $$PWD/placementboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -112,6 +113,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/almostboard.h \
     $$PWD/amazonboard.h \
     $$PWD/chigorinboard.h \
+    $$PWD/placementboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -53,6 +53,7 @@
 #include "makrukboard.h"
 #include "modernboard.h"
 #include "oukboard.h"
+#include "placementboard.h"
 #include "pocketknightboard.h"
 #include "racingkingsboard.h"
 #include "seirawanboard.h"
@@ -109,6 +110,7 @@ REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(ModernBoard, "modern")
+REGISTER_BOARD(PlacementBoard, "placement")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(SeirawanBoard, "seirawan")

--- a/projects/lib/src/board/placementboard.cpp
+++ b/projects/lib/src/board/placementboard.cpp
@@ -1,0 +1,215 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "placementboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+PlacementBoard::PlacementBoard()
+	: WesternBoard(new WesternZobrist()),
+	  m_inSetUp(true),
+	  m_previouslyInSetUp(true)
+{
+}
+
+Board* PlacementBoard::copy() const
+{
+	return new PlacementBoard(*this);
+}
+
+QString PlacementBoard::variant() const
+{
+	return "placement";
+}
+
+QString PlacementBoard::defaultFenString() const
+{
+	return "8/pppppppp/8/8/8/8/PPPPPPPP/8[KQRRBBNNkqrrbbnn] w - - 0 1";
+}
+
+bool PlacementBoard::variantHasDrops() const
+{
+	return true;
+}
+
+QList< Piece > PlacementBoard::reservePieceTypes() const
+{
+	QList< Piece > types;
+	for (Side side: { Side::White, Side::Black} )
+	{
+		for (int type = Knight; type <= King; type++)
+			types << Piece(side, type);
+	}
+	return types;
+}
+
+bool PlacementBoard::kingsCountAssertion(int whiteKings, int blackKings) const
+{
+	Piece whiteKing(Side::White, King);
+	Piece blackKing(Side::Black, King);
+	return whiteKings + reserveCount(whiteKing) == 1 && blackKings + reserveCount(blackKing) == 1;
+}
+
+void PlacementBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					  int pieceType,
+					  int square) const
+{
+	// Normal game moves
+	if (!m_inSetUp)
+	{
+		// No drops after set up
+		if (square == 0)
+			return;
+
+		return WesternBoard::generateMovesForPiece(moves, pieceType, square);
+	}
+
+	// Set-up: generate drops onto own half
+	if (square != 0)
+		return;
+
+	Side side = sideToMove();
+	const int size = arraySize();
+	const bool isBlack = (side == Side::Black);
+	const int arwidth = width() + 2;
+	const int start = 2 * arwidth + 1;
+	const int end = start + width();
+
+	// loop index i will have Black side perspective
+	for (int i = start; i < end; i++)
+	{
+		bool ok = true;
+		int index = isBlack ? i : size - 1 - i;
+		Piece tmp = pieceAt(index);
+		if (!tmp.isEmpty())
+			continue;
+
+		// Square on a-file
+		int a = 1 + index / arwidth * arwidth;
+
+		// Bishops must not be placed on same coloured squares
+		if(pieceType == Bishop)
+		{
+			for (int s = a; s < a + width(); s++)
+			{
+				if (s % 2 != index % 2)
+					continue;
+				if (pieceAt(s).type() == Bishop)
+					ok = false;
+			}
+		}
+		else if (reserveCount(Piece(side, Bishop)) > 0)
+		{
+			bool colorOk[2] {false, false};
+
+			for (int s = a; s < a + width(); s++)
+			{
+				if (s == index)
+					continue;
+				tmp = pieceAt(s);
+				if (tmp.isEmpty() || tmp.type() == Bishop)
+					colorOk[s % 2] = true;
+			}
+			ok = colorOk[0] && colorOk[1];
+		}
+
+		if (ok)
+			moves.append(Move(0, index, pieceType));
+	}
+}
+
+bool PlacementBoard::inSetup() const
+{
+	// Set-up phase ends when no pieces are left in reserve
+	const QList<Piece> reserveTypes = reservePieceTypes();
+	for (const Piece piece: reserveTypes)
+	{
+		if (reserveCount(piece) > 0)
+			return true;
+	}
+	return false;
+}
+
+bool PlacementBoard::vSetFenString(const QStringList& fen)
+{
+	int ret = WesternBoard::vSetFenString(fen);
+	m_inSetUp = inSetup();
+
+	return ret;
+}
+
+
+void PlacementBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	WesternBoard::vMakeMove(move, transition);
+
+	if (move.sourceSquare() == 0)
+		removeFromReserve(Piece(sideToMove(), move.promotion()));
+
+	m_inSetUp = inSetup();
+}
+
+void PlacementBoard::vUndoMove(const Move& move)
+{
+	WesternBoard::vUndoMove(move);
+
+	if (move.sourceSquare() == 0)
+		addToReserve(Piece(sideToMove(), move.promotion()));
+
+	m_inSetUp = inSetup();
+}
+
+bool PlacementBoard::isLegalPosition()
+{
+	if (!m_inSetUp)
+		return WesternBoard::isLegalPosition();
+
+	return true;
+}
+
+void PlacementBoard::setCastlingRights()
+{
+	for (const QChar c: "AHah")
+		parseCastlingRights(c);
+
+	// only support orthodox castling
+	const Side sides[2]{Side::White, Side::Black};
+	for (const Side side: sides)
+	{
+		int ksq = kingSquare(side);
+		if (chessSquare(ksq).file() != width()/2)
+			removeCastlingRights(side);
+	}
+}
+
+Result PlacementBoard::result()
+{
+	if (m_previouslyInSetUp && !m_inSetUp)
+		setCastlingRights();
+
+	if (m_inSetUp && !m_previouslyInSetUp)
+	{
+	      removeCastlingRights(Side::White);
+	      removeCastlingRights(Side::Black);
+	}
+	m_previouslyInSetUp = m_inSetUp;
+	return WesternBoard::result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/placementboard.h
+++ b/projects/lib/src/board/placementboard.h
@@ -1,0 +1,85 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PLACEMENTBOARD_H
+#define PLACEMENTBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Placement Chess, a Shuffle-Chess variant
+ * (a.k.a. Pre-Chess, Meta-Chess, Bronstein Chess, Benko Chess)
+ * 
+ * This game was proposed by several authors like David Bronstein,
+ * USSR ~1948, and Pal Benkö, USA 1978.
+ * 
+ * Placement Chess follows the rules of standard chess but each side begins
+ * only with their Pawns on their second rank. Then the players take turns
+ * to place their pieces freely on the base rank. There is one restriction:
+ * any side must place their Bishops on squares with different colours.
+ * 
+ * After all pieces have been placed White makes the first move.
+ * There are 2880*2880 opening positions.
+ * 
+ * Castling rights are established only for Kings on the e-file and for
+ * Rooks on corner squares.
+ * 
+ * \note: Set-up phase with alternating white and black piece drops.
+ *
+ * \sa StandardBoard
+ * \sa FrcBoard
+ *
+ */
+class LIB_EXPORT PlacementBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new PlacementBoard object. */
+		PlacementBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual bool variantHasDrops() const;
+		virtual Result result();
+
+	protected:
+		virtual void setCastlingRights();
+
+		// Inherited from WstermBoard
+		virtual QList< Piece > reservePieceTypes() const;
+		virtual bool kingsCountAssertion(int whiteKings, int blackKings) const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual bool isLegalPosition();
+
+	private:
+		bool m_inSetUp;
+		bool m_previouslyInSetUp;
+		bool inSetup() const;
+};
+
+} // namespace Chess
+#endif // PLACEMENTBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -543,6 +543,11 @@ void tst_Board::moveStrings_data() const
 		<< "Cc3 g6 Cxc7#"
 		<< "rnbckbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBCKBNR w KQkq - 0 1"
 		<< "rnbckbnr/ppCppp1p/6p1/8/8/8/PPPPPPPP/RNB1KBNR b KQkq - 0 2";
+	QTest::newRow("placement san1")
+		<< "placement"
+		<< "N@e1 N@e8 N@f1 B@h8"
+		<< "8/pppppppp/8/8/8/8/PPPPPPPP/8[KQRRBBNNkqrrbbnn] w - - 0 1"
+		<< "4n2b/pppppppp/8/8/8/8/PPPPPPPP/4NN2[KQRRBBkqrrbn] w - - 0 3";
 
 }
 
@@ -1467,6 +1472,18 @@ void tst_Board::perft_data() const
 		<< "8/KP6/8/4k3/8/8/6p1/8 w - - 0 1"
 		<< 5 // 4 plies: 8133, 5 plies: 104326
 		<< Q_UINT64_C(104326);
+
+	variant = "placement";
+	QTest::newRow("placement startpos")
+		<< variant
+		<< "8/pppppppp/8/8/8/8/PPPPPPPP/8[KQRRBBNNkqrrbbnn] w - - 0 1"
+		<< 4 // 3 plies: 50560, 4 plies: 1597696, 5 plies: 38587392
+		<< Q_UINT64_C(1597696);
+	QTest::newRow("placement2")
+		<< variant
+		<< "1n1r1q2/pppppppp/8/8/8/8/PPPPPPPP/1N1B1R1N[KQRBkrbbn] b - - 0 4"
+		<< 5 // 5 plies: 145152, 6 plies:580608, 7,8,9 plies: 1658880
+		<< Q_UINT64_C(145152);
 
 }
 


### PR DESCRIPTION
This patch supports Placement Chess a.k.a. Pre-Chess, Bronstein Chess, Benko Chess.
Resolves #419 (feature request). 