### PR TITLE
Support Hoppel-Poppel and New Zealand Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -103,6 +103,8 @@ Grid Chess
 Berolina Grid Chess
 .It gryphon
 Gryphon Chess
+.It hoppelpoppel
+Hoppel-Poppel (has N/B hybrids)
 .It horde
 Horde Chess (v2)
 .It janus
@@ -125,6 +127,8 @@ Loser's Chess
 Makruk (Thai Chess)
 .It modern
 Modern Chess (9x9)
+.It newzealand
+New Zealand Chess  (has N/R hybrids)
 .It placement
 Placement Chess
 .It pocketknight

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -44,6 +44,7 @@ Options:
 			'grid': Grid Chess
 			'gridolina': Berolina Grid Chess
 			'gryphon': Gryphon Chess
+			'hoppelpoppel': Hoppel-Poppel (has N/B hybrids)
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
 			'karouk': Kar Ouk (One-check Ouk)
@@ -55,6 +56,7 @@ Options:
 			'losers': Loser's Chess
 			'makruk': Makruk (Thai Chess)
 			'modern': Modern Chess (9x9)
+			'newzealand': New Zealand Chess (has N/R hybrids)
 			'placement': Placement Chess
 			'pocketknight': Pocket Knight Chess
 			'racingkings': Racing Kings Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -55,6 +55,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/almostboard.cpp \
     $$PWD/amazonboard.cpp \
     $$PWD/chigorinboard.cpp \
+    $$PWD/hoppelpoppelboard.cpp \
     $$PWD/placementboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
@@ -117,6 +118,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/almostboard.h \
     $$PWD/amazonboard.h \
     $$PWD/chigorinboard.h \
+    $$PWD/hoppelpoppelboard.h \
     $$PWD/placementboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -43,6 +43,7 @@
 #include "grandboard.h"
 #include "gridboard.h"
 #include "gryphonboard.h"
+#include "hoppelpoppelboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
 #include "kingofthehillboard.h"
@@ -103,6 +104,7 @@ REGISTER_BOARD(GrandBoard, "grand")
 REGISTER_BOARD(GridBoard, "grid")
 REGISTER_BOARD(BerolinaGridBoard, "gridolina")
 REGISTER_BOARD(GryphonBoard, "gryphon")
+REGISTER_BOARD(HoppelPoppelBoard, "hoppelpoppel")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(KarOukBoard,"karouk")
@@ -113,6 +115,7 @@ REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(ModernBoard, "modern")
+REGISTER_BOARD(NewZealandBoard, "newzealand")
 REGISTER_BOARD(PlacementBoard, "placement")
 REGISTER_BOARD(PocketKnightBoard, "pocketknight")
 REGISTER_BOARD(RacingKingsBoard, "racingkings")

--- a/projects/lib/src/board/hoppelpoppelboard.cpp
+++ b/projects/lib/src/board/hoppelpoppelboard.cpp
@@ -1,0 +1,125 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hoppelpoppelboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+HoppelPoppelBoard::HoppelPoppelBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	// cross-over definitions used for checks and capturing moves
+	setPieceType(Knight, "Knibis", "N", BishopMovement);
+	setPieceType(Bishop, "Biskni", "B", KnightMovement);
+}
+
+Board* HoppelPoppelBoard::copy() const
+{
+	return new HoppelPoppelBoard(*this);
+}
+
+QString HoppelPoppelBoard::variant() const
+{
+	return "hoppelpoppel";
+}
+
+QString HoppelPoppelBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+void HoppelPoppelBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
+					      int pieceType,
+					      int square) const
+{
+	if (pieceType != Knight && pieceType != Bishop)
+		return WesternBoard::generateMovesForPiece(moves, pieceType, square);
+
+	// Knight and Bishop: sort moves obtained from cross-over definitions
+	QVarLengthArray< Move > testmoves;
+	WesternBoard::generateMovesForPiece(testmoves, Knight, square);
+	for (const auto m: testmoves)
+	{
+		const bool isCapture = captureType(m) != Piece::NoPiece;
+		if ((isCapture && pieceType == Knight)
+		|| (!isCapture && pieceType == Bishop))
+			moves.append(m);  // diagonal
+	}
+	testmoves.clear();
+	WesternBoard::generateMovesForPiece(testmoves, Bishop, square);
+	for (const auto m: testmoves)
+	{
+		const bool isCapture = captureType(m) != Piece::NoPiece;
+		if ((isCapture && pieceType == Bishop)
+		|| (!isCapture && pieceType == Knight))
+			moves.append(m);  // orthodox knight leaps
+	}
+} //TODO: insufficient material?
+
+
+NewZealandBoard::NewZealandBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	// cross-over definitions used for checks and capturing moves
+	setPieceType(Knight, "Kniroo", "N", RookMovement);
+	setPieceType(Rook, "Rookni", "R", KnightMovement);
+}
+
+Board* NewZealandBoard::copy() const
+{
+	return new NewZealandBoard(*this);
+}
+
+QString NewZealandBoard::variant() const
+{
+	return "newzealand";
+}
+
+QString NewZealandBoard::defaultFenString() const
+{
+	return "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+}
+
+void NewZealandBoard::generateMovesForPiece(QVarLengthArray< Move >& moves, int pieceType, int square) const
+{
+	if (pieceType != Knight && pieceType != Rook)
+		return WesternBoard::generateMovesForPiece(moves, pieceType, square);
+
+	// Knight and Rook: sort moves obtained from cross-over definitions
+	QVarLengthArray< Move > testmoves;
+	WesternBoard::generateMovesForPiece(testmoves, Knight, square);
+	for (const auto m: testmoves)
+	{
+		const bool isCapture = captureType(m) != Piece::NoPiece;
+		if ((isCapture && pieceType == Knight)
+		|| (!isCapture && pieceType == Rook))
+			moves.append(m);  // rook move: file or rank
+	}
+	testmoves.clear();
+	WesternBoard::generateMovesForPiece(testmoves, Rook, square);
+	for (const auto m: testmoves)
+	{
+		const bool isCapture = captureType(m) != Piece::NoPiece;
+		if ((isCapture && pieceType == Rook)
+		|| (!isCapture && pieceType == Knight))
+			moves.append(m);  // orthodox knight leaps
+	}
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/hoppelpoppelboard.h
+++ b/projects/lib/src/board/hoppelpoppelboard.h
@@ -1,0 +1,89 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HOPPELPOPPELBOARD_H
+#define HOPPELPOPPELBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Hoppel-Poppel Chess
+ *
+ * Hoppel-Poppel follows the rules of standard chess, but
+ * the Bishop moves like a Knight when capturing and the
+ * Knight makes captures diagonally like a Bishop.
+ *
+ * This variant originates from Germany.
+ *
+ * \note Rules: https://www.chessvariants.com/diffmove.dir/hoppel-poppel.html
+ */
+
+
+class LIB_EXPORT HoppelPoppelBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new HoppelPoppelBoard object. */
+		HoppelPoppelBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+};
+
+/*!
+ * \brief A borad for New Zealand Chess
+ *
+ * New Zealand Chess follows the rules of standard chess, but
+ * has Rooks that move like Knights when capturing. The Knights
+ * capture like Rooks in standard chess.
+ *
+ * This variant was published in the British Chess Magazine,
+ * September 1903.
+ *
+ * \note Rules: D. B. Pritchard, The Classified Encyclopedia of
+ *              Chess Variants, ed. John Beasley, 2007, ch. 14.4
+ */
+class LIB_EXPORT NewZealandBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new HoppelPoppelBoard object. */
+		NewZealandBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from WesternBoard
+		virtual void generateMovesForPiece(QVarLengthArray< Move >& moves,
+						   int pieceType,
+						   int square) const;
+};
+
+} // namespace Chess
+#endif // HOPPELPOPPELBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1498,6 +1498,20 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 8133, 5 plies: 104326
 		<< Q_UINT64_C(104326);
 
+	variant = "hoppelpoppel";
+	QTest::newRow("hoppelpoppel startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 5 // 4 plies: 202459, 5 plies: 5056643, 6 plies: 125120759
+		<< Q_UINT64_C(5056643);
+
+	variant = "newzealand";
+	QTest::newRow("newzealand startpos")
+		<< variant
+		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+		<< 4 // 4 plies: 200310, 5 plies: 4987426, 6 plies: 123099631
+		<< Q_UINT64_C(200310);
+
 	variant = "placement";
 	QTest::newRow("placement startpos")
 		<< variant


### PR DESCRIPTION
This patch adds support for two leightweight chess variants with hybrid piece movement. These variants are known at least since the 1920s.

Hoppel-Poppel Chess is standard chess but with modified Bishops and Knights. The Bishop captures like a standard Knight but else moves as usual. This piece configuration is called `Biskni`. The Knight captures like a standard Bishop but makes their usual hops when not capturing. This piece is called`Knibis`. In the endgame these hybrid pieces seem to be weaker than Bishop or Knight.

New Zealand Chess is similar. The Bishops are normal Bishops, but here the Rooks and the Knights are hybrids called `Rookni` (R moves and N captures) and `Kniroo` (N moves and R captures). The Rooknis can participate in castling. In the endgame these hybrid pieces are clearly weaker than a Rook and perhaps as useful as a Knight.

`HoppelPoppelBoard` has been tested with [Fairy-Stockfish](https://github.com/ianfab/Fairy-Stockfish/). Starting position perft 6 match.

I hope this is useful.
