### PR TITLE
Use 64-bit node limits

### DIFF
--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -208,12 +208,12 @@ bool parseEngine(const QStringList& args, EngineData& data)
 		}
 		else if (name == "nodes")
 		{
-			if (val.toInt() <= 0)
+			if (val.toLongLong() <= 0)
 			{
 				qWarning() << "Invalid node limit:" << val;
 				return false;
 			}
-			data.tc.setNodeLimit(val.toInt());
+			data.tc.setNodeLimit(val.toLongLong());
 		}
 		else if (name == "ponder")
 		{

--- a/projects/gui/ui/timecontroldlg.ui
+++ b/projects/gui/ui/timecontroldlg.ui
@@ -203,7 +203,7 @@
         <string>Maximum number of nodes to search (engines only)</string>
        </property>
        <property name="maximum">
-        <number>99999999</number>
+        <number>2147483647</number>
        </property>
       </widget>
      </item>

--- a/projects/lib/src/timecontrol.cpp
+++ b/projects/lib/src/timecontrol.cpp
@@ -31,7 +31,7 @@ QString s_timeString(int ms)
 	return TimeControl::tr("%1 h").arg(ms / 3600000);
 }
 
-QString s_nodeString(int nodes)
+QString s_nodeString(qint64 nodes)
 {
 	if (nodes == 0 || nodes % 1000 != 0)
 		return QString::number(nodes);
@@ -249,7 +249,7 @@ int TimeControl::plyLimit() const
 	return m_plyLimit;
 }
 
-int TimeControl::nodeLimit() const
+qint64 TimeControl::nodeLimit() const
 {
 	return m_nodeLimit;
 }
@@ -305,7 +305,7 @@ void TimeControl::setPlyLimit(int plies)
 	m_plyLimit = plies;
 }
 
-void TimeControl::setNodeLimit(int nodes)
+void TimeControl::setNodeLimit(qint64 nodes)
 {
 	Q_ASSERT(nodes >= 0);
 	m_nodeLimit = nodes;
@@ -385,7 +385,7 @@ void TimeControl::readSettings(QSettings* settings)
 	m_timePerMove = settings->value("time_per_move", m_timePerMove).toInt();
 	m_increment = settings->value("increment", m_increment).toInt();
 	m_plyLimit = settings->value("ply_limit", m_plyLimit).toInt();
-	m_nodeLimit = settings->value("node_limit", m_nodeLimit).toInt();
+	m_nodeLimit = settings->value("node_limit", m_nodeLimit).toLongLong();
 	m_expiryMargin = settings->value("expiry_margin", m_expiryMargin).toInt();
 	m_infinite = settings->value("infinite", m_infinite).toBool();
 

--- a/projects/lib/src/timecontrol.h
+++ b/projects/lib/src/timecontrol.h
@@ -125,7 +125,7 @@ class LIB_EXPORT TimeControl
 		int plyLimit() const;
 
 		/*! Returns the node limit for each move. */
-		int nodeLimit() const;
+		qint64 nodeLimit() const;
 
 		/*!
 		 * Returns the expiry margin.
@@ -165,7 +165,7 @@ class LIB_EXPORT TimeControl
 		void setPlyLimit(int plies);
 
 		/*! Sets the node limit. */
-		void setNodeLimit(int nodes);
+		void setNodeLimit(qint64 nodes);
 
 		/*! Sets the expiry margin. */
 		void setExpiryMargin(int expiryMargin);
@@ -212,7 +212,7 @@ class LIB_EXPORT TimeControl
 		int m_timeLeft;
 		int m_movesLeft;
 		int m_plyLimit;
-		int m_nodeLimit;
+		qint64 m_nodeLimit;
 		int m_lastMoveTime;
 		int m_expiryMargin;
 		bool m_expired;


### PR DESCRIPTION
This PR is intended to fix problem #433.

The node limit property of time control now is of type `qint64` instead of `int`. So the upper limit of 2^31 - 1 nodes for lib and CLI is lifted to 2^63 - 1 nodes and practically out of reach.

The node limit in the GUI however, has only been increased twenty-fold from 99999999 to 2 ** 31 - 1.

HTH
