### PR TITLE
Option to use two-sided scores for resign adjudication

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -1,4 +1,4 @@
-.Dd July 26, 2018
+.Dd October 25, 2018
 .Dt CUTECHESS-CLI 6
 .Os
 .Sh NAME
@@ -175,12 +175,20 @@ centipawns from zero for at least
 consecutive moves, and at least
 .Ar number
 full moves have been played. Captures and pawn moves will reset the counters.
-.It Fl resign Cm movecount Ns = Ns Ar count Cm score Ns = Ns Ar score
+.It Fl resign Cm movecount Ns = Ns Ar count Cm score Ns = Ns Ar score Bq Cm twosided Ns = Ns Ar value
 Adjudicate the game as a loss if an engine's score is at least
 .Ar score
 centipawns below zero for at least
 .Ar count
 consecutive moves.
+If
+.Ar value
+is true (default: false) then activate two-sided resign adjudication. The winning side's
+scores must be at least
+.Ar score
+centipawns above zero for at least
+.Ar count
+consecutive moves
 .It Fl maxmoves Ar n
 Adjudicate the game as a draw if at least
 .Ar n

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -81,10 +81,14 @@ Options:
 			least COUNT consecutive moves, and at least NUMBER full
 			moves have been played. Captures and pawn moves will
 			reset the counters.
-  -resign movecount=COUNT score=SCORE
+  -resign movecount=COUNT score=SCORE [twosided=VALUE]
 			Adjudicate the game as a loss if an engine's score is
 			at least SCORE centipawns below zero for at least COUNT
 			consecutive moves.
+			If VALUE is true (default: false) then activate
+			two-sided resign adjudication: The scores of the winning
+			side must be at least SCORE centipawns above zero for at
+			least COUNT consecutive moves.
   -maxmoves N		Adjudicate the game as a draw if the game is still
 			ongoing after N or more full moves have been played.
 			This limit is not in action if set to zero.

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -338,15 +338,16 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		// Threshold for resign adjudication
 		else if (name == "-resign")
 		{
-			QMap<QString, QString> params = option.toMap("movecount|score");
+			QMap<QString, QString> params = option.toMap("movecount|score|twosided=false");
 			bool countOk = false;
 			bool scoreOk = false;
 			int moveCount = params["movecount"].toInt(&countOk);
 			int score = params["score"].toInt(&scoreOk);
+			bool twoSided = params["twosided"] == "true";
 
 			ok = (countOk && scoreOk);
 			if (ok)
-				adjudicator.setResignThreshold(moveCount, -score);
+				adjudicator.setResignThreshold(moveCount, -score, twoSided);
 		}
 		// Maximum game length before draw adjudication
 		else if (name == "-maxmoves")

--- a/projects/gui/ui/gamesettingswidget.ui
+++ b/projects/gui/ui/gamesettingswidget.ui
@@ -417,7 +417,7 @@
         <property name="fieldGrowthPolicy">
          <enum>QFormLayout::ExpandingFieldsGrow</enum>
         </property>
-        <item row="0" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="m_resignMoveCountLabel">
           <property name="text">
            <string>Move count:</string>
@@ -427,7 +427,7 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="1" column="1">
          <widget class="QSpinBox" name="m_resignMoveCountSpin">
           <property name="toolTip">
            <string>Resign adjudication is used if an engine's score is below the threshold for at least this many consecutive moves.</string>
@@ -440,7 +440,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="m_resignScoreLabel">
           <property name="text">
            <string>Score:</string>
@@ -450,7 +450,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QSpinBox" name="m_resignScoreSpin">
           <property name="enabled">
            <bool>false</bool>
@@ -466,6 +466,35 @@
           </property>
           <property name="maximum">
            <number>9999</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QRadioButton" name="m_resignNormalRadio">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Resignation is only based on losing side's scores.</string>
+          </property>
+          <property name="text">
+           <string>Normal</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QRadioButton" name="m_resignTwoSidedRadio">
+          <property name="toolTip">
+           <string>Both sides are needed to indicate decisive scores.</string>
+          </property>
+          <property name="text">
+           <string>Two-Sided</string>
           </property>
          </widget>
         </item>

--- a/projects/lib/src/gameadjudicator.h
+++ b/projects/lib/src/gameadjudicator.h
@@ -54,9 +54,13 @@ class LIB_EXPORT GameAdjudicator
 		 * A game will be adjudicated as a loss for the player that
 		 * made the last move if it reports a score that's at least
 		 * \a score centipawns below zero for at least \a moveCount
-		 * consecutive moves.
+		 * consecutive moves. Beyond that the score of the winning
+		 * side must be at least \a score centipawns above zero if
+		 * \a twoSided is true (default: false).
 		 */
-		void setResignThreshold(int moveCount, int score);
+		void setResignThreshold(int moveCount,
+					int score,
+					bool twoSided = false);
 		/*!
 		 * Limits the number of moves playable in a game.
 		 *
@@ -101,6 +105,8 @@ class LIB_EXPORT GameAdjudicator
 		int m_resignMoveCount;
 		int m_resignScore;
 		int m_resignScoreCount[2];
+		int m_winScoreCount[2];
+		bool m_twoSided;
 		int m_maxGameLength;
 		bool m_tbEnabled;
 		Chess::Result m_result;


### PR DESCRIPTION
This PR resolves #385.

The CLI option `-resign` now has a new optional parameter `twosided`. When set to _true_ it activates two-sided resign adjudication: In addition to the conditions of the normal (single-sided) resign adjudication the winning side's scores must be at least _SCORE_ centipawns above zero for at least _COUNT_ consecutive moves.

So the proposed usage for two-sided adjudication is

`cutechess-cli ... -resign movecount=4  score=650 twosided=true  ...`.

Normal, single-sided resignation works as before.

In the GUI there is a new group of radio buttons to select either normal (single-sided) or two-sided resignation score adjudication.



----
Original text:

The option `-resign2`  is added to the CLI. The new option activates two-sided resign adjudication. It has no parameters of its own. It only has an effect when the `-resign `option is in action: In addition to the conditions of the normal (single-sided) resign adjudication the winning side's scores must be at least _SCORE_ centipawns above zero for at least _COUNT_ consecutive moves.

So the proposed usage is 
`cutechess-cli ... -resign movecount=4  score=650 -resign2 ...`

rather than
`cutechess-cli ... -resign movecount=4  score=650 twosided=true  ...`.

In the GUI there is a new group of radio buttons to select either normal (single-sided) or two-sided resignation score adjudication.