### PR TITLE
Support Jeson Mor

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -109,6 +109,8 @@ Hoppel-Poppel (has N/B hybrids)
 Horde Chess (v2)
 .It janus
 Janus Chess
+.It jesonmor
+Jeson Mör
 .It karouk
 Kar Ouk (One-check Ouk)
 .It kinglet

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -47,6 +47,7 @@ Options:
 			'hoppelpoppel': Hoppel-Poppel (has N/B hybrids)
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
+			'jesonmor': Jeson Mör
 			'karouk': Kar Ouk (One-check Ouk)
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -14,6 +14,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/extinctionboard.cpp \
     $$PWD/gryphonboard.cpp \
     $$PWD/threekingsboard.cpp \
+    $$PWD/jesonmorboard.cpp \
     $$PWD/kingofthehillboard.cpp \
     $$PWD/hordeboard.cpp \
     $$PWD/embassyboard.cpp \
@@ -77,6 +78,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/extinctionboard.h \
     $$PWD/gryphonboard.h \
     $$PWD/threekingsboard.h \
+    $$PWD/jesonmorboard.h \
     $$PWD/kingofthehillboard.h \
     $$PWD/hordeboard.h \
     $$PWD/embassyboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -46,6 +46,7 @@
 #include "hoppelpoppelboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
+#include "jesonmorboard.h"
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
 #include "loopboard.h"
@@ -107,6 +108,7 @@ REGISTER_BOARD(GryphonBoard, "gryphon")
 REGISTER_BOARD(HoppelPoppelBoard, "hoppelpoppel")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
+REGISTER_BOARD(JesonMorBoard, "jesonmor")
 REGISTER_BOARD(KarOukBoard,"karouk")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")

--- a/projects/lib/src/board/jesonmorboard.cpp
+++ b/projects/lib/src/board/jesonmorboard.cpp
@@ -1,0 +1,96 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "jesonmorboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+JesonMorBoard::JesonMorBoard()
+	: WesternBoard(new WesternZobrist()),
+	m_centralSquare(71) // e5
+{
+}
+
+Board* JesonMorBoard::copy() const
+{
+	return new JesonMorBoard(*this);
+}
+
+QString JesonMorBoard::variant() const
+{
+	return "jesonmor";
+}
+
+int JesonMorBoard::width() const
+{
+	return 9;
+}
+
+int JesonMorBoard::height() const
+{
+	return 9;
+}
+
+QString JesonMorBoard::defaultFenString() const
+{
+	return "nnnnnnnnn/9/9/9/9/9/9/9/NNNNNNNNN w - - 0 1";
+}
+
+bool JesonMorBoard::kingsCountAssertion(int, int) const
+{
+	return true;
+}
+
+bool JesonMorBoard::inCheck(Side side, int square) const
+{
+	if (square == 0)
+		return false;
+
+	return WesternBoard::inCheck(side, square);
+}
+
+Result JesonMorBoard::result()
+{
+	QString str;
+	Side side = sideToMove();
+	Side opp = side.opposite();
+
+	if (!canMove())
+	{
+		str = tr("%1 cannot move").arg(side.toString());
+		return Result(Result::Win, opp, str);
+	}
+
+	Piece piece = pieceAt(m_centralSquare);
+	Side centralSide = piece.side();
+
+	/*
+	 * The game is won if the side on the central square can move
+	 * immediately or else cannot be captured by the opponent.
+	 */
+	if (centralSide == side
+	|| (centralSide == opp && !inCheck(opp, m_centralSquare)))
+	{
+		str = tr("%1 wins").arg(centralSide.toString());
+		return Result(Result::Win, centralSide, str);
+	}
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/jesonmorboard.h
+++ b/projects/lib/src/board/jesonmorboard.h
@@ -1,0 +1,59 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef JESONMORBOARD_H
+#define JESONMORBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Jeson Mor
+ *
+ * Jeson Mor is a board game from Mongolia. There are nine knights per
+ * side and no other pieces. Initially all knights are lined up on their
+ * sides' first rank of a 9x9 board.
+ *
+ * Leaving the central square e5 or capturing all opponent pieces wins.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Jeson_Mor
+ */
+class LIB_EXPORT JesonMorBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new JesonMorBoard object. */
+		JesonMorBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int width() const;
+		virtual int height() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+	protected:
+		// Inherited from WesternBoard
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool inCheck(Side side, int square = 0) const;
+	private:
+		const int m_centralSquare;
+};
+
+} // namespace Chess
+#endif // JESONMORBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -929,6 +929,29 @@ void tst_Board::results_data() const
 		<< "8/8/8/2sp2k1/8/3P4/4K1a1/7r w - - 0 1"
 		<< "0-1";
 
+	variant = "jesonmor";
+
+	QTest::newRow("jesonmor continue")
+		<< variant
+		<< "9/9/9/2n6/4N4/9/9/9/9 b - - 0 1"
+		<< "*";
+	QTest::newRow("jesonmor white win 1")
+		<< variant
+		<< "9/9/9/2n6/4N4/9/9/9/9 w - - 0 1"
+		<< "1-0";
+	QTest::newRow("jesonmor white win 2")
+		<< variant
+		<< "1nnn1n1nn/9/9/3n1n3/4N4/5N3/1N7/9/1N1N1NNN1 b - - 0 7"
+		<< "1-0";
+	QTest::newRow("jesonmor black win")
+		<< variant
+		<< "9/9/Nn7/9/4n4/9/9/9/9 w - - 0 25"
+		<< "0-1";
+	QTest::newRow("jesonmor no white pieces")
+		<< variant
+		<< "9/9/1n7/9/9/9/3n5/9/9 w - - 0 24"
+		<< "0-1";
+
 	variant = "almost";
 
 	QTest::newRow("almost fool's mate")
@@ -1407,6 +1430,13 @@ void tst_Board::perft_data() const
 		<< "8/8/8/2sp2k1/7p/3P4/6K1/7r w - - 0 1"
 		<< 5 // 4 plies: 6855, 5 plies: 30055, 6 plies: 631293
 		<< Q_UINT64_C(30055);
+
+	variant = "jesonmor";
+	QTest::newRow("jeson mor startpos")
+		<< variant
+		<< "nnnnnnnnn/9/9/9/9/9/9/9/NNNNNNNNN w - - 0 1"
+		<< 4 // 3 plies: 27960, 4 plies: 868624, 5 plies: 27756588/27882796
+		<< Q_UINT64_C(868624);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
 Jeson Mor is a board game from Mongolia. There are nine knights per side and no other pieces. Initially all knights are lined up on their sides' first rank of a 9x9 board.  Leaving the central square e5 or capturing all opponent pieces wins.

Note: `JesonMorBoard` adjudicates early when a side occupies the cental square and has the move or the central piece cannot be captured by the opponent.

This implementation has been tested by manual play and with the [Fairy-Stockfish](https://github.com/ianfab/Fairy-Stockfish) engine.

I hope ths is useful.
