### PR TITLE
Sittuyin: Prevent discovered check by Pawn promotion.

### DIFF
--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -253,6 +253,10 @@ bool SittuyinBoard::isLegalPosition()
 	||  pieceCount(side, General) > 1)
 		return false;
 
+	// Do not allow (discovered) checks by a promotion move
+	if (lastMove().promotion() != 0 && inCheck(side))
+		return false;
+
 	return true;
 }
 
@@ -292,8 +296,9 @@ Result SittuyinBoard::result()
 		}
 		else
 		{
-			str = tr("%1 forfeits by stalemating").arg(opp.toString());
-			return Result(Result::Adjudication, side, str);
+			// Federation rule 5.2a: stalemate is draw
+			str = tr("Draw by stalemate");
+			return Result(Result::Draw, Side::NoSide, str);
 		}
 	}
 

--- a/projects/lib/src/board/sittuyinboard.h
+++ b/projects/lib/src/board/sittuyinboard.h
@@ -49,11 +49,11 @@ namespace Chess {
  * a square that is part of a main diagonal. Promotion counts as a move of
  * its own. When promoting the Pawn either remains on its current square or
  * makes a General's move. The promotion move must not give check or capture
- * an opponent piece. Pawn promotion is optional, not oligatory: The Pawn can
- * also make a normal move or capture.
+ * an opponent piece. Pawn promotion is optional, not oligatory: The Pawn
+ * can also make a normal move or capture.
  *
- * Checkmating the opponent King wins. Stalemating is not allowed. A draw can
- * be claimed if no pawns have been moved and no captures have been made for
+ * Checkmating the opponent King wins. Stalemate is a draw. A draw can be
+ * claimed if no pawns have been moved and no captures have been made for
  * fifty consecutive moves. A game will be drawn if it is impossible for
  * the remaining pieces to give mate. There is no 3-fold repetition rule.
  *
@@ -64,7 +64,6 @@ namespace Chess {
  * \note Rules: The Official Rules by the Myanmar Chess Federation
  * (as described by Maung Maung Lwin).
  * \note: Set-up phase with alternating red and black piece drops.
- * \note: Board will adjudicate against side giving stalemate.
  *
  * \sa MakrukBoard
  * \sa ShatranjBoard

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1395,6 +1395,16 @@ void tst_Board::perft_data() const
 		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
 		<< 4 // 1 ply: 35, 2 plies: 825, 3 plies: 26791, 4 plies: 657824
 		<< Q_UINT64_C(657824);
+	QTest::newRow("sittuyin promotion1")
+		<< variant
+		<< "8/8/S2P1k2/8/8/8/8/4K3[-] w - - 0 9"
+		<< 1 // 1 ply: 12, 2 plies: 86
+		<< Q_UINT64_C(12);
+	QTest::newRow("sittuyin promotion2")
+		<< variant
+		<< "8/8/R2P1k2/8/8/8/8/4K3[-] w - - 0 9"
+		<< 1 // 1 ply: 16, 2 plies: 105
+		<< Q_UINT64_C(16);
 
 	variant = "ai-wok";
 	QTest::newRow("ai-wok startpos")


### PR DESCRIPTION
Such a move is not legal (rule 3.9 c.5).
Resolves #448

Adjudicate stalemate as draw (rule 5.2 a)
Resolves #449

Thanks to @gbtami