### PR TITLE
Rounding Elo to one decimal place.

### DIFF
--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -736,7 +736,7 @@ QString Tournament::results() const
 		if (playerCount() == 2)
 		{
 			ret += QString("Elo difference: %1 +/- %2, LOS: %3 %")
-				.arg(elo.diff(), 0, 'f', 2)
+				.arg(elo.diff(), 0, 'f', 1)
 				.arg(elo.errorMargin(), 0, 'f', 2)
 				.arg(elo.LOS(), 0, 'f', 2);
 			break;

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -738,7 +738,7 @@ QString Tournament::results() const
 			ret += QString("Elo difference: %1 +/- %2, LOS: %3 %, DrawRatio: %4 %")
 				.arg(elo.diff(), 0, 'f', 1)
 				.arg(elo.errorMargin(), 0, 'f', 1)
-				.arg(elo.LOS(), 0, 'f', 2)
+				.arg(elo.LOS(), 0, 'f', 1)
 				.arg(elo.drawRatio() * 100, 0, 'f', 1);
 			break;
 		}

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -737,7 +737,7 @@ QString Tournament::results() const
 		{
 			ret += QString("Elo difference: %1 +/- %2, LOS: %3 %, DrawRatio: %4 %")
 				.arg(elo.diff(), 0, 'f', 1)
-				.arg(elo.errorMargin(), 0, 'f', 2)
+				.arg(elo.errorMargin(), 0, 'f', 1)
 				.arg(elo.LOS(), 0, 'f', 2)
 				.arg(elo.drawRatio() * 100, 0, 'f', 1);
 			break;


### PR DESCRIPTION
Reason for this suggestion is that it's very rare that Elo estimations have error bars low enough to justify a precision of two decimal places.