### PR TITLE
Support Gustav III's Chess

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -103,6 +103,8 @@ Grid Chess
 Berolina Grid Chess
 .It gryphon
 Gryphon Chess
+.It gustav3
+Gustav III's Chess
 .It hoppelpoppel
 Hoppel-Poppel (has N/B hybrids)
 .It horde

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -44,6 +44,7 @@ Options:
 			'grid': Grid Chess
 			'gridolina': Berolina Grid Chess
 			'gryphon': Gryphon Chess
+			'gustav3': Gustav III's Chess
 			'hoppelpoppel': Hoppel-Poppel (has N/B hybrids)
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess

--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -87,6 +87,11 @@ bool Board::variantHasOptionalPromotions() const
 	return false;
 }
 
+bool Board::variantHasWallSquares() const
+{
+	return false;
+}
+
 QList<Piece> Board::reservePieceTypes() const
 {
 	return QList<Piece>();
@@ -473,6 +478,9 @@ QString Board::fenString(FenNotation notation) const
 
 			if (pc.isValid())
 				fen += pieceSymbol(pc);
+			else if (pc.isWall())
+				fen += "*";
+
 			i++;
 		}
 		i++;
@@ -553,6 +561,15 @@ bool Board::setFenString(const QString& fen)
 				return false;
 			handPieceIndex = i + 1;
 			break;
+		}
+		// Wall square
+		if (c == '*' && variantHasWallSquares())
+		{
+			if (!pieceStr.isEmpty())
+				return false;
+			square++;
+			k++;
+			continue;
 		}
 		// Add empty squares
 		if (c.isDigit())

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -138,6 +138,11 @@ class LIB_EXPORT Board
 		 */
 		virtual bool variantHasOptionalPromotions() const;
 		/*!
+		 * Returns true if the board accepts wall squares, else false.
+		 * The default value is false.
+		 */
+		virtual bool variantHasWallSquares() const;
+		/*!
 		 * Returns a list of piece types that can be in the reserve,
 		 * ie. captured pieces that can be dropped on the board.
 		 *

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -58,6 +58,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/chigorinboard.cpp \
     $$PWD/hoppelpoppelboard.cpp \
     $$PWD/placementboard.cpp \
+    $$PWD/gustavboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -122,6 +123,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/chigorinboard.h \
     $$PWD/hoppelpoppelboard.h \
     $$PWD/placementboard.h \
+    $$PWD/gustavboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -43,6 +43,7 @@
 #include "grandboard.h"
 #include "gridboard.h"
 #include "gryphonboard.h"
+#include "gustavboard.h"
 #include "hoppelpoppelboard.h"
 #include "hordeboard.h"
 #include "janusboard.h"
@@ -105,6 +106,7 @@ REGISTER_BOARD(GrandBoard, "grand")
 REGISTER_BOARD(GridBoard, "grid")
 REGISTER_BOARD(BerolinaGridBoard, "gridolina")
 REGISTER_BOARD(GryphonBoard, "gryphon")
+REGISTER_BOARD(GustavBoard, "gustav3")
 REGISTER_BOARD(HoppelPoppelBoard, "hoppelpoppel")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")

--- a/projects/lib/src/board/gustavboard.cpp
+++ b/projects/lib/src/board/gustavboard.cpp
@@ -1,0 +1,75 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "gustavboard.h"
+#include "westernzobrist.h"
+
+
+namespace Chess {
+
+GustavBoard::GustavBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Adjutant, tr("adjutant-general"), "A",
+		     KnightMovement | BishopMovement | RookMovement, "Q~");
+}
+
+Board* GustavBoard::copy() const
+{
+	return new GustavBoard(*this);
+}
+
+QString GustavBoard::variant() const
+{
+	return "gustav3";
+}
+
+QString GustavBoard::defaultFenString() const
+{
+	return "arnbqkbnra/*pppppppp*/*8*/*8*/*8*/*8*/*PPPPPPPP*/ARNBQKBNRA w KQkq - 0 1";
+}
+
+int GustavBoard::width() const
+{
+	return 10;
+}
+
+int GustavBoard::height() const
+{
+	return 8;
+}
+
+bool GustavBoard::variantHasWallSquares() const
+{
+	return true;
+}
+
+int GustavBoard::castlingFile(WesternBoard::CastlingSide castlingSide) const
+{
+	Q_ASSERT(castlingSide != NoCastlingSide);
+	// QueenSide denotes lower file side, towards a-rook
+	return castlingSide == QueenSide ? 3 : 7; // d-file and h-file
+}
+
+void GustavBoard::addPromotions(int sourceSquare, int targetSquare, QVarLengthArray< Move >& moves) const
+{
+	WesternBoard::addPromotions(sourceSquare, targetSquare, moves);
+	moves.append(Move(sourceSquare, targetSquare, Adjutant));
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/gustavboard.h
+++ b/projects/lib/src/board/gustavboard.h
@@ -1,0 +1,68 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GUSTAVBOARD_H
+#define GUSTAVBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Gustav III's Chess
+ *
+ * This variant of chess on a 10x8 board was attributed to King Gustav III
+ * of Sweden. In addition to the standard chess arrangement each side has
+ * two additional Adjutant-Generals (Amazon, Q+N). They start from extra
+ * corner squares outside of the Rooks. The outermost files of the board only
+ * consist of these corner squares, so there are 64 plus 4 squares in total.
+ *
+ * Standard chess rules apply. A Pawn can promote to Adjutant-General.
+ *
+ * \note Rules: http://mlwi.magix.net/bg/gustaviii.htm
+ *
+ * \sa AmazonBoard
+ */
+class LIB_EXPORT GustavBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new GustavBoard object. */
+		GustavBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual int width() const;
+		virtual int height() const;
+		virtual bool variantHasWallSquares() const;
+	protected:
+		/*! Piece types for Gustav Chess */
+		enum GustavPieceType
+		{
+			Adjutant = 7 //!< Adjutant-General (Queen + Knight)
+		};
+		// Inherited from WesternBoard
+		virtual int castlingFile(CastlingSide castlingSide) const;
+		virtual void addPromotions(int sourceSquare,
+					   int targetSquare,
+					   QVarLengthArray< Move >& moves) const;
+};
+
+} // namespace Chess
+#endif // GUSTAVBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -548,6 +548,16 @@ void tst_Board::moveStrings_data() const
 		<< "N@e1 N@e8 N@f1 B@h8"
 		<< "8/pppppppp/8/8/8/8/PPPPPPPP/8[KQRRBBNNkqrrbbnn] w - - 0 1"
 		<< "4n2b/pppppppp/8/8/8/8/PPPPPPPP/4NN2[KQRRBBkqrrbn] w - - 0 3";
+	QTest::newRow("gustav3 san1")
+		<< "gustav3"
+		<< "Ab3 Ai6 Ng3"
+		<< "arnbqkbnra/*pppppppp*/*8*/*8*/*8*/*8*/*PPPPPPPP*/ARNBQKBNRA w KQkq - 0 1"
+		<< "arnbqkbnr1/*pppppppp*/*7a*/*8*/*8*/*A4N2*/*PPPPPPPP*/1RNBQKB1RA b KQkq - 3 2";
+	QTest::newRow("gustav3 san2 promotion")
+		<< "gustav3"
+		<< "c8=A"
+		<< "4k5/*KP6*/*8*/*8*/*8*/*8*/*8*/10 w - - 0 1"
+		<< "2A1k5/*K7*/*8*/*8*/*8*/*8*/*8*/10 b - - 0 1";
 	QTest::newRow("shoot san1")
 		<< "shoot"
 		<< "e4 e5 Bb5 c6 Bxc6 Nc6 Bxc6 Nf6 Bxd7+ Nd7 Bxd7+ Bd7 Bxd7+ Qd7 Bxd7+"
@@ -1563,6 +1573,13 @@ void tst_Board::perft_data() const
 		<< "1n1r1q2/pppppppp/8/8/8/8/PPPPPPPP/1N1B1R1N[KQRBkrbbn] b - - 0 4"
 		<< 5 // 5 plies: 145152, 6 plies:580608, 7,8,9 plies: 1658880
 		<< Q_UINT64_C(145152);
+
+	variant = "gustav3";
+	QTest::newRow("gustav3 startpos")
+		<< variant
+		<< "arnbqkbnra/*pppppppp*/*8*/*8*/*8*/*8*/*PPPPPPPP*/ARNBQKBNRA w KQkq - 0 1"
+		<< 4 // 4 plies: 331659, 5 plies: 9988369, 6 plies: 294561801
+		<< Q_UINT64_C(331659);
 
 	variant = "rifle";
 	QTest::newRow("rifle startpos")


### PR DESCRIPTION
This is a suggestion to support the chess game of Gustav III's of Sweden, resolving feature request #467.

In this chess variant there are four new squares attached to sides of the chess board outside of the Rooks. At the start of the game each of these squares is occupied by a powerful Adjutant-General (Amazon, with Queen and Knight movements). Squares a2-a7 and j2-j7 are occupied by wall  pieces so they cannot be used by the regular pieces. Standard chess rules apply. A Pawn can promote to Adjutant-General.

Wall squares are each denoted by an asterisk '*' in FEN (maintaining xboard-compatibility).  
It was necessary to extend `Board::fenString` and `Board::setFenString` for this.

The starting position is given by 
`arnbqkbnra/*pppppppp*/*8*/*8*/*8*/*8*/*PPPPPPPP*/ARNBQKBNRA w KQkq - 0 1`.

Adjutant-Generals are represented graphically by the Promoted Queen symbol Q~.
Currently CuteChess GUI _cannot display wall pieces_.

![amazon2](https://user-images.githubusercontent.com/6425738/50490182-f43bf980-0a0b-11e9-9794-0b1829eb725e.png)


I hope this is useful.
 