### PR TITLE
Added link to wiki-page for build instructions and simpler build instructions for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ If you are using the Visual C++ compiler replace `make` with `nmake`.
 Documentation is available as Unix manual pages in the `docs/` directory. API
 documentation can be built by issuing `make doc-api` (requires [Doxygen](http://www.doxygen.org/)).
 
+For detailed build instruction on various operating systems please visit:
+* [Making a release](https://github.com/cutechess/cutechess/wiki/Making-a-release)
+
 Running
 -------
 


### PR DESCRIPTION
Hello,
thank you for this cool GUI which also supports the main chess variants.

A friend of mine had trouble building  cutechess for mac and because there's no official release for mac,
I thought it could be useful to update the build instructions for mac on your wiki-page.

Unfortunately there's no proper way to create a pull request for wiki pages right now:
* https://stackoverflow.com/questions/10642928/how-to-pull-request-a-wiki-page-on-github

That's why I post the instructions which worked on his system here so you can include this in your wiki:
I also added a link to the wiki page in the main readme.

### Compile cutechess on mac

* https://github.com/glinscott/fishtest/issues/13

Install Homebrew:

```
$ ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
``` 

Install Qt:

```
$ brew install qt
```

Get Cute Chess source code:

```
$ git clone https://github.com/cutechess/cutechess.git
```

Build Cute Chess:

```
$ qmake -spec macx-g++ -config static
$ make
```

If you receive an error like:

`project ERROR: failed to parse default search paths from compiler output
no targets specifed and no makefile found. stop.`

You can try adding the line `export LD_PATH="$LD_PATH:$HOME/.local/lib"` in `~/.profile` then restart the terminal and try building Cute Chess again:
* https://forum.qt.io/topic/91156/qmake-error-project-error-failed-to-parse-default-search-paths-from-compiler-output-on-macos-high-sierra
