### PR TITLE
Fix output for CLOP script

### DIFF
--- a/tools/clop-cutechess-cli.py
+++ b/tools/clop-cutechess-cli.py
@@ -115,15 +115,22 @@ def main(argv = None):
     for line in output.decode("utf-8").splitlines():
         if line.startswith('Finished game'):
             if line.find(": 1-0") != -1:
-                result = clop_seed % 2
-            elif line.find(": 0-1") != -1:
                 result = (clop_seed % 2) ^ 1
+            elif line.find(": 0-1") != -1:
+                result = clop_seed % 2
             elif line.find(": 1/2-1/2") != -1:
                 result = 2
             else:
                 sys.stderr.write('the game did not terminate properly\n')
                 return 2
             break
+
+    if result == 0:
+        sys.stdout.write('L\n')
+    elif result == 1:
+        sys.stdout.write('W\n')
+    elif result == 2:
+        sys.stdout.write('D\n')
 
     if result == 0:
         sys.stdout.write('L\n')

--- a/tools/clop-cutechess-cli.py
+++ b/tools/clop-cutechess-cli.py
@@ -126,9 +126,9 @@ def main(argv = None):
             break
 
     if result == 0:
-        sys.stdout.write('W\n')
-    elif result == 1:
         sys.stdout.write('L\n')
+    elif result == 1:
+        sys.stdout.write('W\n')
     elif result == 2:
         sys.stdout.write('D\n')
 


### PR DESCRIPTION
It seems that there is a *severe* error in the current CLOP script. Wins and losses are swapped, meaning that the script is optimizing for losing games and avoiding wins(!). This pull request fixes that.


This is a documented issue. See here for more details: https://groups.google.com/d/msg/fishcooking/0uRw0Zila0M/s2siUjVzFFwJ 