### PR TITLE
Give search speed in nps for values below 10000, else in knps.

### DIFF
--- a/projects/gui/src/evalwidget.cpp
+++ b/projects/gui/src/evalwidget.cpp
@@ -98,7 +98,8 @@ void EvalWidget::onEval(const MoveEvaluation& eval)
 	auto nps = eval.nps();
 	if (nps)
 	{
-		QString npsStr = QString("%1k").arg(nps / 1000);
+		QString npsStr = nps < 10000 ? QString("%1").arg(nps)
+					     : QString("%1k").arg(nps / 1000);
 		auto item = m_statsTable->itemPrototype()->clone();
 		item->setText(npsStr);
 		m_statsTable->setItem(0, NpsHeader, item);


### PR DESCRIPTION
This small patch shows search speed in (unity) nps instead of knps when speed is below 10000 nodes per second.

Resolves request #481.