### PR TITLE
Add id number of engine issuing an illegal PV move, and print PV line

### DIFF
--- a/projects/lib/src/chessengine.cpp
+++ b/projects/lib/src/chessengine.cpp
@@ -303,6 +303,11 @@ bool ChessEngine::supportsVariant(const QString& variant) const
 	return m_variants.contains(variant);
 }
 
+int ChessEngine::id() const
+{
+	return m_id;
+}
+
 bool ChessEngine::stopThinking()
 {
 	if (state() == Thinking || isPondering())

--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -226,6 +226,10 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		 * the engine does not support pondering.
 		 */
 		bool pondering() const;
+		/*!
+		 * Gives id number of the engine
+		 */
+		int id() const;
 
 	protected slots:
 		// Inherited from ChessPlayer

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -826,9 +826,14 @@ QString UciEngine::sanPv(const QVarLengthArray<QStringRef>& tokens)
 		auto move = board->moveFromString(token.toString());
 		if (move.isNull())
 		{
-			qWarning("Illegal PV move %s from %s",
-				 qUtf8Printable(token.toString()),
-				 qUtf8Printable(name()));
+			QString tokenString(token.toString());
+			qWarning("Illegal PV move %s from %s (%d)",
+				 qUtf8Printable(tokenString),
+				 qUtf8Printable(name()),
+				 id());
+			qWarning("PV: %s %s",
+				 qUtf8Printable(pv),
+				 qUtf8Printable(tokenString));
 			break;
 		}
 		if (!pv.isEmpty())


### PR DESCRIPTION
This small patch causes output of some more information in case of illegal PV moves.
Resolves #471