### PR TITLE
Wdl not dtz should be the minimum required for adjudication.

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -201,7 +201,7 @@ equals zero (default).
 Adjudicate games using Syzygy tablebases.
 .Ar Paths
 should be semicolon-delimited list of paths to the compressed tablebase files.
-Only the DTZ tablebase files are required.
+Only the WDL tablebase files are required.
 .It Fl tbpieces Ar N
 Only use tablebase adjudication for positions with
 .Ar N

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -95,7 +95,7 @@ Options:
 			This limit is not in action if set to zero.
   -tb PATHS		Adjudicate games using Syzygy tablebases. PATHS should
 			be semicolon-delimited list of paths to the compressed
-			tablebase files. Only the DTZ tablebase files are
+			tablebase files. Only the WDL tablebase files are
 			required.
   -tbpieces N		Only use tablebase adjudication for positions with
 			N pieces or less.


### PR DESCRIPTION
While in fathom source code probe_root calls probe_dtz, probe_dtz actually ends up calling probe_ab, which calls probe_wdl_table.
Without WDL tables this fails, which cascades upwards to probe_root failing.

WDL files should be the expected minimum - dtz files for syzygy are technically not complete without the corresponding WDL files.