### PR TITLE
Test whether declined promotion move exists

### DIFF
--- a/projects/gui/src/boardview/boardscene.cpp
+++ b/projects/gui/src/boardview/boardscene.cpp
@@ -338,7 +338,7 @@ void BoardScene::onTransitionFinished()
 void BoardScene::onPromotionChosen(const Chess::Piece& promotion)
 {
 	m_chooser = nullptr;
-	if (!promotion.isValid() && !m_board->variantHasOptionalPromotions())
+	if (!promotion.isValid() && !m_moves.contains(m_promotionMove))
 	{
 		GraphicsPiece* piece = m_squares->pieceAt(m_promotionMove.sourceSquare());
 		m_anim = pieceAnimation(piece, m_sourcePos);


### PR DESCRIPTION
resolves #491 

One might possibly want to retire Board::variantHasOptionalPromotions() later.