### PR TITLE
Update engine count label when adding or removing engines

### DIFF
--- a/projects/gui/src/enginemanagementwidget.cpp
+++ b/projects/gui/src/enginemanagementwidget.cpp
@@ -130,6 +130,7 @@ void EngineManagementWidget::addEngine()
 	{
 		m_engineManager->addEngine(dlg->engineConfiguration());
 		m_hasChanged = true;
+		updateEngineCount();
 	});
 	dlg->open();
 }
@@ -181,6 +182,7 @@ void EngineManagementWidget::removeEngine()
 		for (const QModelIndex& index : qAsConst(selected))
 			m_engineManager->removeEngineAt(index.row());
 		m_hasChanged = true;
+		updateEngineCount();
 	}
 }
 


### PR DESCRIPTION
This is a small patch to update the engine count shown in the engine management widget.