### PR TITLE
Improvements of SittuyinBoard

### DIFF
--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -195,6 +195,17 @@ bool SittuyinBoard::vSetFenString(const QStringList& fen)
 	return ret;
 }
 
+Move SittuyinBoard::moveFromSanString(const QString& str)
+{
+	Move move = MakrukBoard::moveFromSanString(str);
+
+	// Avoid problems with promotion moves in LAN(!) format
+	if (move.sourceSquare() != 0
+	&&  move.promotion() != Piece::NoPiece && !str.contains("=") )
+		return Move();
+
+	return move;
+}
 
 void SittuyinBoard::vMakeMove(const Move& move, BoardTransition* transition)
 {

--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -280,6 +280,22 @@ int SittuyinBoard::countingLimit() const
 	return 1000; // intentional limit
 }
 
+
+/*! Returns true if the side to move can make any non-promotion moves. */
+bool SittuyinBoard::canMakeNormalMove()
+{
+	QVarLengthArray<Move> moves;
+	generateMoves(moves);
+
+	for (int i = 0; i < moves.size(); i++)
+	{
+		if (vIsLegalMove(moves[i]) && moves[i].promotion() == Piece::NoPiece)
+			return true;
+	}
+
+	return false;
+}
+
 Result SittuyinBoard::result()
 {
 	QString str;
@@ -300,6 +316,12 @@ Result SittuyinBoard::result()
 			str = tr("Draw by stalemate");
 			return Result(Result::Draw, Side::NoSide, str);
 		}
+	}
+	if (!m_inSetUp && pieceCount(side, Pawn) == 1 && !canMakeNormalMove())
+	{
+		// Federation rule 3.9c7: promotion cannot be forced
+		str = tr("Draw by promotion stalemate");
+		return Result(Result::Draw, Side::NoSide, str);
 	}
 
 	// 50 move rule

--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -265,7 +265,7 @@ bool SittuyinBoard::isLegalPosition()
 		return false;
 
 	// Do not allow (discovered) checks by a promotion move
-	if (lastMove().promotion() != 0 && inCheck(side))
+	if (plyCount() > 0 && lastMove().promotion() != 0 && inCheck(side))
 		return false;
 
 	return true;

--- a/projects/lib/src/board/sittuyinboard.h
+++ b/projects/lib/src/board/sittuyinboard.h
@@ -106,6 +106,7 @@ class LIB_EXPORT SittuyinBoard : public MakrukBoard
 					   int targetSquare,
 					   QVarLengthArray< Move >& moves) const;
 		virtual bool vSetFenString(const QStringList& fen);
+		virtual Move moveFromSanString(const QString & str);
 		virtual void vMakeMove(const Move& move,
 				       BoardTransition* transition);
 		virtual void vUndoMove(const Move& move);

--- a/projects/lib/src/board/sittuyinboard.h
+++ b/projects/lib/src/board/sittuyinboard.h
@@ -119,6 +119,7 @@ class LIB_EXPORT SittuyinBoard : public MakrukBoard
 	private:
 		bool m_inSetUp;
 		bool inSetup() const;
+		bool canMakeNormalMove();
 };
 
 } // namespace Chess

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -932,6 +932,13 @@ void tst_Board::results_data() const
 		<< "8/8/8/5K2/1q6/8/8/k7 w - - 0 71"
 		<< "1/2-1/2";
 
+	variant = "sittuyin";
+
+	QTest::newRow("sittuyin draw by promotion stalemate, rule 3.9c7")
+		<< variant
+		<< "1k4PK/3r4/8/8/8/8/8/8[-] w - 0 0 1"
+		<< "1/2-1/2";
+
 	variant = "ai-wok";
 
 	QTest::newRow("ai-wok black win")

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -518,6 +518,11 @@ void tst_Board::moveStrings_data() const
 		<< "g3g3f"
 		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
 		<< "8/8/6R1/s3r3/P5R1/1KP3f1/1F2kr2/8[-] w - 0 0 73";
+	QTest::newRow("sittuyin lan2 promotion by general's move")
+		<< "sittuyin"
+		<< "g3f4f"
+		<< "3k4/6R1/3s4/4r3/S2KF3/P2P2p1/8/8[-] b - 0 0 52"
+		<< "3k4/6R1/3s4/4r3/S2KFf2/P2P4/8/8[-] w - 0 0 53";
 	QTest::newRow("sittuyin san1 promotion staying on square")
 		<< "sittuyin"
 		<< "g3=F"


### PR DESCRIPTION
This PR only affects SittuyinBoard and consists of three patches:

1. Implementation of Sittuyin rule 3.9c.7 (Maung Maung Lwin: How to play Myanmar Traditional Chess, p. 8): If promotion moves are the only legal moves to avoid a stalemate then the weaker side may claim a draw. So cutechess will adjudicate a draw with this software patch.

![sittuyin1](https://user-images.githubusercontent.com/6425738/55659652-15259f00-57f2-11e9-9fbe-e151e527f1d1.png)
In this situation white to move may claim a draw. FEN: 1k4PK/3r4/8/8/8/8/8/8[-] w - 0 0 1

2. There is a problem with pawn promotions in engine play. This patch avoids wrong decoding of promotion moves in LAN format (by then throwing away the result of moveFromSanString for promotion moves in SittuyinBoard!).

3. A problem in `SittuyinBoard::isLegalPosition` gets obvious when using a debug compile and running the chessboard test suite: The move history must not be empty when using `Board::lastMove()`.