### PR TITLE
For gauntlet tournaments keep same openings within rounds

### DIFF
--- a/projects/lib/src/gauntlettournament.cpp
+++ b/projects/lib/src/gauntlettournament.cpp
@@ -24,7 +24,8 @@
 GauntletTournament::GauntletTournament(GameManager* gameManager,
 				       QObject *parent)
 	: Tournament(gameManager, parent),
-	  m_opponent(-1)
+	  m_opponent(-1),
+	  m_newRound(true)
 {
 }
 
@@ -60,7 +61,8 @@ TournamentPair* GauntletTournament::nextPair(int gameNumber)
 	if (gameNumber % gamesPerEncounter() != 0)
 		return currentPair();
 
-	if (m_opponent >= playerCount())
+	m_newRound = (m_opponent >= playerCount());
+	if (m_newRound)
 	{
 		m_opponent = 1;
 		setCurrentRound(currentRound() + 1);
@@ -75,4 +77,9 @@ TournamentPair* GauntletTournament::nextPair(int gameNumber)
 bool GauntletTournament::hasGauntletRatingsOrder() const
 {
 	return true;
+}
+
+bool GauntletTournament::newOpeningForNewEncounter() const
+{
+	return m_newRound;
 }

--- a/projects/lib/src/gauntlettournament.h
+++ b/projects/lib/src/gauntlettournament.h
@@ -47,9 +47,11 @@ class LIB_EXPORT GauntletTournament : public Tournament
 		virtual int gamesPerCycle() const;
 		virtual TournamentPair* nextPair(int gameNumber);
 		virtual bool hasGauntletRatingsOrder() const;
+		virtual bool newOpeningForNewEncounter() const;
 
 	private:
 		int m_opponent;
+		bool m_newRound;
 };
 
 #endif // GAUNTLETTOURNAMENT_H

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -440,6 +440,11 @@ int Tournament::playerIndex(ChessGame* game, Chess::Side side) const
 	return side == Chess::Side::White ? gd->whiteIndex : gd->blackIndex;
 }
 
+bool Tournament::newOpeningForNewEncounter() const
+{
+	return true;
+}
+
 void Tournament::startNextGame()
 {
 	if (m_stopping)
@@ -449,7 +454,8 @@ void Tournament::startNextGame()
 	if (!pair || !pair->isValid())
 		return;
 
-	if (!pair->hasSamePlayers(m_pair) && m_players.size() > 2)
+	if (!pair->hasSamePlayers(m_pair) && m_players.size() > 2
+	&&  newOpeningForNewEncounter())
 	{
 		m_startFen.clear();
 		m_openingMoves.clear();

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -393,6 +393,11 @@ class LIB_EXPORT Tournament : public QObject
 		 * The default implementation always returns false.
 		 */
 		virtual bool hasGauntletRatingsOrder() const;
+		/*!
+		 * Returns true (default) if the next encounter of players will
+		 * start with a different set-up; otherwise returns false.
+		 */
+		virtual bool newOpeningForNewEncounter() const;
 
 	private slots:
 		void startNextGame();


### PR DESCRIPTION
Resolves #501

Alternative 1 - "Small Solution"

This PR introduces a new flag `m_newRound` to `GauntletTournament`. The `Tournament` class is amended by a virtual method which indicates whether a new opening should be used for the next pair of players. This affects the behaviour of CuteChess only for gauntlet tournaments.

Note: A new opening will still be used when the number of repetitions played reaches the number of specified repetitions (equals 1 if option `-repeat` is not used, 2 for `-repeat` without parameter). So it is necessary to use `-repeat n` with a **sufficiently large n** to play an entire round with the same opening.

Example: A gauntlet of Engine1 against Engine2 and Engine3 with 4 games per encounter requires at least `-repeat 8`: 4 games per encounter * 2 encounters (1 vs 2, 1 vs 3).