### PR TITLE
Introduce policies when to pick the next opening in tournaments

### DIFF
--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -433,7 +433,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		else if (name == "-openings")
 		{
 			QMap<QString, QString> params =
-				option.toMap("file|format=pgn|order=sequential|plies=1024|start=1");
+				option.toMap("file|format=pgn|order=sequential|plies=1024|start=1|policy=default");
 			ok = !params.isEmpty();
 
 			OpeningSuite::Format format = OpeningSuite::EpdFormat;
@@ -460,6 +460,21 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 				ok = false;
 			}
 
+			using OpeningPolicy = Tournament::OpeningPolicy;
+			OpeningPolicy policy = OpeningPolicy::DefaultPolicy;
+			if (params["policy"] == "default")
+				policy = OpeningPolicy::DefaultPolicy;
+			else if (params["policy"] == "encounter")
+				policy = OpeningPolicy::EncounterPolicy;
+			else if (params["policy"] == "round")
+				policy = OpeningPolicy::RoundPolicy;
+			else if (ok)
+			{
+				qWarning("Invalid opening shift policy: \"%s\"",
+					 qUtf8Printable(params["policy"]));
+				ok = false;
+			}
+
 			int plies = params["plies"].toInt();
 			int start = params["start"].toInt();
 
@@ -467,6 +482,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 			if (ok)
 			{
 				tournament->setOpeningDepth(plies);
+				tournament->setOpeningPolicy(policy);
 
 				OpeningSuite* suite = new OpeningSuite(params["file"],
 								       format,

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -46,6 +46,14 @@ class LIB_EXPORT Tournament : public QObject
 	Q_OBJECT
 
 	public:
+		/*! The policy for using a fresh opening. */
+		enum OpeningPolicy
+		{
+			DefaultPolicy,     //!< Shift on repetition count and on new encounter
+			EncounterPolicy,   //!< Shift on new encounter
+			RoundPolicy        //!< Shift on new round
+		};
+
 		/*!
 		 * Creates a new tournament that uses \a gameManager
 		 * to manage the games.
@@ -211,6 +219,19 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setOpeningRepetitions(int count);
 		/*!
+		 * The value of \a policy rules when to switch to the next opening.
+		 *
+		 * Given the default value \ref DefaultPolicy a new opening is selected
+		 * when the number of opening repetitions played reaches the specified
+		 * number of repetitions (\ref setOpeningRepetitions) or a new encounter
+		 * is started.
+		 *
+		 * If \ref EncounterPolicy is used then a new opening will be selected
+		 * only for any new encounter. \ref RoundPolicy shifts to a new opening
+		 * only when a new round starts.
+		 */
+		void setOpeningPolicy(OpeningPolicy policy = DefaultPolicy);
+		/*!
 		 * Sets the side swap flag to \a enabled.
 		 *
 		 * If \a enabled is true then paired engines will
@@ -218,7 +239,7 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setSwapSides(bool enabled);
 		/*!
-		 * Sets opening book ownerhip to \a enabled.
+		 * Sets opening book ownership to \a enabled.
 		 *
 		 * By default the \a Tournament object doesn't take ownership of
 		 * its opening books.
@@ -427,6 +448,7 @@ class LIB_EXPORT Tournament : public QObject
 		QString m_site;
 		QString m_variant;
 		int m_round;
+		int m_oldRound;
 		int m_nextGameNumber;
 		int m_finishedGameCount;
 		int m_savedGameCount;
@@ -438,6 +460,7 @@ class LIB_EXPORT Tournament : public QObject
 		int m_seedCount;
 		bool m_stopping;
 		int m_openingRepetitions;
+		OpeningPolicy m_openingPolicy;
 		bool m_recover;
 		bool m_pgnCleanup;
 		bool m_pgnWriteUnfinishedGames;


### PR DESCRIPTION
Resolves #501
(library and CLI).

Alternative 2 - "More general solution"

_DefaultPolicy_: Use a new opening when a new encounter  (pair of players) starts or the specified number of repetitions is reached. Cutechess behaves as before - except for some cases of strange combinations n,m of -repeat n and -games m.

_EncounterPolicy_ uses a new opening only for a new encounter.

_RoundPolicy_ shifts to a new opening only when a new round starts. 

The _RoundPolicy_ currently depends on the (tag) round counters of the tournament types. These are not in sync with the schedule repetition counters controlled by the `-round n` option of the CLI or the corresponding `m_roundsSpin` SpinBox of the GUI.

Reference: PR #502
