### PR TITLE
Introduce policies when to pick the next opening in tournaments

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -1,4 +1,4 @@
-.Dd October 25, 2018
+.Dd April 29, 2019
 .Dt CUTECHESS-CLI 6
 .Os
 .Sh NAME
@@ -271,7 +271,7 @@ Set the interval for printing the ratings to
 games.
 .It Fl debug
 Display all engine input and output.
-.It Fl openings Cm file Ns = Ns Ar file Cm format Ns = Ns [ Cm epd | Cm pgn Ns ] Cm order Ns = Ns [ Cm random | Cm sequential Ns ] Cm plies Ns = Ns Ar plies Cm start Ns = Ns Ar start
+.It Fl openings Cm file Ns = Ns Ar file Cm format Ns = Ns [ Cm epd | Cm pgn Ns ] Cm order Ns = Ns [ Cm random | Cm sequential Ns ] Cm plies Ns = Ns Ar plies Cm start Ns = Ns Ar start Cm policy Ns = Ns [ Cm default | Cm encounter | Cm round ]
 Pick game openings from
 .Ar file .
 The file can be either in
@@ -298,6 +298,17 @@ is the number of the first opening that will be played.
 The minimum value for
 .Ar start
 is 1 (default).
+.Pp
+The value of
+.Ar policy
+rules when to shift to a new opening. If set to
+.Cm encounter
+a new opening is used for any new pair of players,
+.Cm round
+shifts when a new round begins. The
+.Cm default
+shifts for any new pair of players and also when the
+specified number of opening repetitions is reached.
 .It Fl bookmode Ar mode
 Set Polyglot book access mode, where
 .Ar mode
@@ -307,7 +318,7 @@ is either
 .Cm disk
 (the book is accessed directly on disk).
 The default mode is
-.Cm ram .
+.Cm ram.
 .It Fl pgnout Ar file Bq Cm min Cm Bq fi
 Save the games to
 .Ar file

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -127,7 +127,7 @@ Options:
 			games set by '-rounds' and/or '-games' is reached.
   -ratinginterval N	Set the interval for printing the ratings to N games
   -debug		Display all engine input and output
-  -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START
+  -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START policy=POLICY
 			Pick game openings from FILE. The file's format is
 			FORMAT, which can be either 'epd' or 'pgn' (default).
 			Openings will be picked in the order specified by ORDER,
@@ -136,6 +136,12 @@ Options:
 			not set the opening depth is unlimited. In sequential
 			mode START is the number of the first opening that will
 			be played. The minimum value for START is 1 (default).
+			The POLICY rules when to shift to a new opening.
+			It can be one of 'encounter'- which uses a new
+			opening for any new pair of players, 'round'- which
+			shifts only for a new round, or 'default'- which shifts
+			for any new pair of players and also when the number of
+			opening repetitions is reached.
   -bookmode MODE	Set Polyglot book mode to MODE, which can be one of:
 			'ram': The whole book is loaded into RAM (default)
 			'disk': The book is accessed directly on disk.

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -433,7 +433,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		else if (name == "-openings")
 		{
 			QMap<QString, QString> params =
-				option.toMap("file|format=pgn|order=sequential|plies=1024|start=1");
+				option.toMap("file|format=pgn|order=sequential|plies=1024|start=1|policy=default");
 			ok = !params.isEmpty();
 
 			OpeningSuite::Format format = OpeningSuite::EpdFormat;
@@ -460,6 +460,21 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 				ok = false;
 			}
 
+			using OpeningPolicy = Tournament::OpeningPolicy;
+			OpeningPolicy policy = OpeningPolicy::DefaultPolicy;
+			if (params["policy"] == "default")
+				policy = OpeningPolicy::DefaultPolicy;
+			else if (params["policy"] == "encounter")
+				policy = OpeningPolicy::EncounterPolicy;
+			else if (params["policy"] == "round")
+				policy = OpeningPolicy::RoundPolicy;
+			else if (ok)
+			{
+				qWarning("Invalid opening shift policy: \"%s\"",
+					 qUtf8Printable(params["policy"]));
+				ok = false;
+			}
+
 			int plies = params["plies"].toInt();
 			int start = params["start"].toInt();
 
@@ -467,6 +482,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 			if (ok)
 			{
 				tournament->setOpeningDepth(plies);
+				tournament->setOpeningPolicy(policy);
 
 				OpeningSuite* suite = new OpeningSuite(params["file"],
 								       format,

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -46,6 +46,14 @@ class LIB_EXPORT Tournament : public QObject
 	Q_OBJECT
 
 	public:
+		/*! The policy for using a fresh opening. */
+		enum OpeningPolicy
+		{
+			DefaultPolicy,     //!< Shift on repetition count and on new encounter
+			EncounterPolicy,   //!< Shift on new encounter
+			RoundPolicy        //!< Shift on new round
+		};
+
 		/*!
 		 * Creates a new tournament that uses \a gameManager
 		 * to manage the games.
@@ -211,6 +219,19 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setOpeningRepetitions(int count);
 		/*!
+		 * The value of \a policy rules when to switch to the next opening.
+		 *
+		 * Given the default value \ref DefaultPolicy a new opening is selected
+		 * when the number of opening repetitions played reaches the specified
+		 * number of repetitions (\ref setOpeningRepetitions) or a new encounter
+		 * is started.
+		 *
+		 * If \ref EncounterPolicy is used then a new opening will be selected
+		 * only for any new encounter. \ref RoundPolicy shifts to a new opening
+		 * only when a new round starts.
+		 */
+		void setOpeningPolicy(OpeningPolicy policy = DefaultPolicy);
+		/*!
 		 * Sets the side swap flag to \a enabled.
 		 *
 		 * If \a enabled is true then paired engines will
@@ -218,7 +239,7 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setSwapSides(bool enabled);
 		/*!
-		 * Sets opening book ownerhip to \a enabled.
+		 * Sets opening book ownership to \a enabled.
 		 *
 		 * By default the \a Tournament object doesn't take ownership of
 		 * its opening books.
@@ -427,6 +448,7 @@ class LIB_EXPORT Tournament : public QObject
 		QString m_site;
 		QString m_variant;
 		int m_round;
+		int m_oldRound;
 		int m_nextGameNumber;
 		int m_finishedGameCount;
 		int m_savedGameCount;
@@ -438,6 +460,7 @@ class LIB_EXPORT Tournament : public QObject
 		int m_seedCount;
 		bool m_stopping;
 		int m_openingRepetitions;
+		OpeningPolicy m_openingPolicy;
 		bool m_recover;
 		bool m_pgnCleanup;
 		bool m_pgnWriteUnfinishedGames;


### PR DESCRIPTION
Resolves #501
(library and CLI).

Alternative 2 - "More general solution"

This patch adds a parameter _policy_ to the CLI option `-openings`,e.g. `policy=default`.
It can have one of three values:

_default_: Use a new opening when a new encounter (pair of players) starts or the specified number of repetitions is reached. Cutechess behaves as before - except for some cases of incommensurable combinations n,m of -repeat n and -games m.

_encounter_  uses a new opening only for a new encounter.

_round_ shifts to a new opening only when a new round starts.

The _RoundPolicy_ currently depends on the (tag) round counters of the tournament types. These are not in sync with the schedule repetition counters controlled by the -round n option of the CLI or the corresponding `m_roundsSpin` SpinBox of the GUI.

Reference: PR #502