### PR TITLE
Extend repetition settings in the GUI

### DIFF
--- a/projects/gui/src/gamerepetitionspinbox.cpp
+++ b/projects/gui/src/gamerepetitionspinbox.cpp
@@ -49,11 +49,11 @@ void GameRepetitionSpinBox::setTournamentType(const QString& tournamentType)
 // Returns the highest matching number of games
 int GameRepetitionSpinBox::limit() const
 {
-	int games = m_gamesPerEncounter;
+	int games = qMax(m_gamesPerEncounter, 1);
 	if (m_tournamentType != "gauntlet")
 		return games;
 
-	int factor = m_rounds;
+	int factor = qMin(m_rounds, 10000000 / games);
 	while (m_rounds % factor)
 	{
 		factor--;

--- a/projects/gui/src/gamerepetitionspinbox.h
+++ b/projects/gui/src/gamerepetitionspinbox.h
@@ -63,7 +63,6 @@ class GameRepetitionSpinBox : public QSpinBox
 		int limit() const;
 		QValidator::State examine(int value) const;
 
-		int m_maxGames;
 		int m_gamesPerEncounter;
 		int m_rounds;
 		QString m_tournamentType;


### PR DESCRIPTION
Up to now in the GUI each opening (from a repertoire of PGNs or EPDs ) was only played either once or twice in a tournament, then the next opening was selected. This PR extends the choice. This has already been available in the CLI (request #188, PR #269). 

In the `TournamentSettingsWidget` the checkbox _"Play each opening twice"_ is replaced by a spinbox _"Play each opening n times"_. For the number `n` it offers all choices that match (are factors of) the number of games per encounter. For _gauntlet tournaments_ there are additional choices (multiples of the number of games per encounter that also match the number of rounds to be played).

I hope this is useful.

![rep1](https://user-images.githubusercontent.com/6425738/57973182-5a61f280-7994-11e9-8707-1a47a31b5d15.png)

![tourn1](https://user-images.githubusercontent.com/6425738/58287393-7274b000-7da0-11e9-8a3e-52341855352f.png)
