### PR TITLE
Extend gauntlet tournaments to multiple seeded players

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -217,7 +217,7 @@ is one of:
 .It round-robin
 Round-robin tournament (default)
 .It gauntlet
-First engine plays against the rest
+First engine(s) against the rest
 .It knockout
 Single-elimination tournament
 .It pyramid

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -102,7 +102,7 @@ Options:
   -tbignore50		Disable the fifty move rule for tablebase adjudication.
   -tournament TYPE	Set the tournament type to TYPE, which can be one of:
 			'round-robin': Round-robin tournament (default)
-			'gauntlet': First engine plays against the rest
+			'gauntlet': First engine(s) against the rest
 			'knockout': Single-elimination tournament.
 			'pyramid': Every engine plays against all predecessors
   -event EVENT		Set the event/tournament name to EVENT

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -31,6 +31,10 @@ TournamentSettingsWidget::TournamentSettingsWidget(QWidget *parent)
 		ui->m_roundsSpin->setEnabled(!checked);
 		ui->m_seedsSpin->setEnabled(checked);
 	});
+	connect(ui->m_gauntletRadio, &QRadioButton::toggled, [=](bool checked)
+	{
+		ui->m_seedsSpin->setEnabled(checked);
+	});
 
 	readSettings();
 }

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -50,7 +50,7 @@
         <item>
          <widget class="QRadioButton" name="m_gauntletRadio">
           <property name="toolTip">
-           <string>First engine plays against the rest</string>
+           <string>First engine (or group of seeded engines) plays against the rest</string>
           </property>
           <property name="text">
            <string>Gauntlet</string>

--- a/projects/lib/src/gauntlettournament.cpp
+++ b/projects/lib/src/gauntlettournament.cpp
@@ -45,12 +45,16 @@ void GauntletTournament::onGameAboutToStart(ChessGame* game,
 
 void GauntletTournament::initializePairing()
 {
-	m_opponent = 1;
+	int gauntletPlayers = qBound(1, seedCount(), playerCount() - 1);
+	setSeedCount(gauntletPlayers);
+
+	m_opponent = seedCount();
+	m_currentPlayer = 0;
 }
 
 int GauntletTournament::gamesPerCycle() const
 {
-	return playerCount() - 1;
+	return (playerCount() - seedCount()) * seedCount();
 }
 
 TournamentPair* GauntletTournament::nextPair(int gameNumber)
@@ -62,11 +66,15 @@ TournamentPair* GauntletTournament::nextPair(int gameNumber)
 
 	if (m_opponent >= playerCount())
 	{
-		m_opponent = 1;
-		setCurrentRound(currentRound() + 1);
+		m_opponent = seedCount();
+		if (++m_currentPlayer >= seedCount())
+		{
+			m_currentPlayer = 0;
+			setCurrentRound(currentRound() + 1);
+		}
 	}
 
-	int white = 0;
+	int white = m_currentPlayer;
 	int black = m_opponent++;
 
 	return pair(white, black);

--- a/projects/lib/src/gauntlettournament.h
+++ b/projects/lib/src/gauntlettournament.h
@@ -49,6 +49,7 @@ class LIB_EXPORT GauntletTournament : public Tournament
 		virtual bool hasGauntletRatingsOrder() const;
 
 	private:
+		int m_currentPlayer;
 		int m_opponent;
 };
 

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -769,7 +769,7 @@ QString Tournament::results() const
 		// 2. Players with finished games, sorted by point ratio
 		// 3. Players without finished games
 		qreal key = -1.0;
-		if (i > 0 || !hasGauntletRatingsOrder())
+		if ((i > 0 && i >= seedCount()) || !hasGauntletRatingsOrder())
 		{
 			if (data.games)
 				key = 1.0 - data.score;


### PR DESCRIPTION
Library, CLI and GUI

Resolves #488

In the CLI, the `-seeds n` option specifies the number of seeded (first) players who play gauntlet against the rest. Only the first player plays against the rest if the option is omitted (the default)  and also for `-seeds 0`, and `-seeds 1`.

In the GUI the seeds spinbox is used to specify the number of gauntlet players.  Standard gauntlet tournaments with the first player against the rest result from both values 0 and 1.

The number of gauntlet players is bounded by 1 and the total count of tournament players minus 1.