### PR TITLE
Fix problem reading EPD openings

### DIFF
--- a/projects/gui/src/gamesettingswidget.cpp
+++ b/projects/gui/src/gamesettingswidget.cpp
@@ -161,7 +161,7 @@ OpeningSuite* GameSettingsWidget::openingSuite() const
 		return nullptr;
 
 	OpeningSuite::Format format = OpeningSuite::PgnFormat;
-	if (file.endsWith(".epd"), Qt::CaseInsensitive)
+	if (file.endsWith(".epd", Qt::CaseInsensitive))
 		format = OpeningSuite::EpdFormat;
 
 	OpeningSuite::Order order = OpeningSuite::SequentialOrder;


### PR DESCRIPTION
Small fix because EPD opening books do not work anymore in the GUI. 

(Qt::CaseInsensitive has value 0.)