### PR TITLE
End the SettingsGroup in TimeControl::writeSettings

### DIFF
--- a/projects/lib/src/timecontrol.cpp
+++ b/projects/lib/src/timecontrol.cpp
@@ -404,4 +404,6 @@ void TimeControl::writeSettings(QSettings* settings)
 	settings->setValue("node_limit", m_nodeLimit);
 	settings->setValue("expiry_margin", m_expiryMargin);
 	settings->setValue("infinite", m_infinite);
+
+	settings->endGroup();
 }


### PR DESCRIPTION
This is a small fix. The SettingsGroup in writeSettings has no termination. 