### PR TITLE
Add checkbox to Tournament Settings to enable/disable side swap

### DIFF
--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -297,6 +297,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	t->setOpeningRepetitions(ts->openingRepetition()? 2: 1);
 	t->setRecoveryMode(ts->engineRecovery());
 	t->setPgnWriteUnfinishedGames(ts->savingOfUnfinishedGames());
+	t->setSwapSides(ts->swappingSides());
 
 	const auto engines = m_addedEnginesManager->engines();
 	for (EngineConfiguration config : engines)

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -90,6 +90,11 @@ bool TournamentSettingsWidget::savingOfUnfinishedGames() const
 	return ui->m_saveUnfinishedGamesCheck->isChecked();
 }
 
+bool TournamentSettingsWidget::swappingSides() const
+{
+	return ui->m_swapCheck->isChecked();
+}
+
 void TournamentSettingsWidget::readSettings()
 {
 	QSettings s;
@@ -114,6 +119,7 @@ void TournamentSettingsWidget::readSettings()
 	ui->m_recoverCheck->setChecked(s.value("recover").toBool());
 	ui->m_saveUnfinishedGamesCheck->setChecked(
 		s.value("save_unfinished_games", true).toBool());
+	ui->m_swapCheck->setChecked(s.value("swap_sides", true).toBool());
 
 	s.endGroup();
 }
@@ -173,5 +179,9 @@ void TournamentSettingsWidget::enableSettingsUpdates()
 	connect(ui->m_saveUnfinishedGamesCheck, &QCheckBox::toggled, [=](bool checked)
 	{
 		QSettings().setValue("tournament/save_unfinished_games", checked);
+	});
+	connect(ui->m_swapCheck, &QCheckBox::toggled, [=](bool checked)
+	{
+		QSettings().setValue("tournament/swap_sides", checked);
 	});
 }

--- a/projects/gui/src/tournamentsettingswidget.h
+++ b/projects/gui/src/tournamentsettingswidget.h
@@ -41,6 +41,7 @@ class TournamentSettingsWidget : public QWidget
 		bool openingRepetition() const;
 		bool engineRecovery() const;
 		bool savingOfUnfinishedGames() const;
+		bool swappingSides() const;
 
 		void enableSettingsUpdates();
 

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>314</height>
+    <height>337</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -209,6 +209,19 @@
        <widget class="QCheckBox" name="m_saveUnfinishedGamesCheck">
         <property name="text">
          <string>Save unfinished games</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QCheckBox" name="m_swapCheck">
+        <property name="toolTip">
+         <string>Swap colors after each game within an encounter (default: true)</string>
+        </property>
+        <property name="text">
+         <string>Swap sides</string>
         </property>
         <property name="checked">
          <bool>true</bool>


### PR DESCRIPTION
This change in the GUI corresponds to CLI's -noswap option (CLI feature request #95).

This resolves #321 for gauntlet tournaments (i. e. player 0) and also for the first player of a round-robin tournament (given the current tournament game sequence).

![s1](https://user-images.githubusercontent.com/6425738/66230784-7280a700-e6d4-11e9-8c72-34b530cca8bf.png)
