### PR TITLE
Introduce flag to reverse schedule for sides in CLI

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -342,7 +342,9 @@ sides after each game. So they get to play the
 opening on both sides. Please note that a new encounter will use
 a new opening.
 .It Fl noswap
-Do not swap sides of paired engines
+Do not swap sides of paired engines.
+.It Fl reverse
+Use schedule with reverse sides.
 .It Fl seeds Ar n
 Set the first
 .Ar n

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -155,7 +155,8 @@ Options:
 			option is used, the players swap sides after each game.
 			So they get to play the opening on both sides. Please
 			note that a new encounter will use a new opening.
-  -noswap		Do not swap sides of paired engines
+  -noswap		Do not swap sides of paired engines.
+  -reverse		Use schedule with reverse sides.
   -seeds N		Set the first N engines as seeds in the tournament
   -site SITE		Set the site/location to SITE
   -srand N		Set the seed for the random number generator to N

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -261,6 +261,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-epdout", QVariant::String, 1, 1);
 	parser.addOption("-repeat", QVariant::Int, 0, 1);
 	parser.addOption("-noswap", QVariant::Bool, 0, 0);
+	parser.addOption("-reverse", QVariant::Bool, 0, 0);
 	parser.addOption("-recover", QVariant::Bool, 0, 0);
 	parser.addOption("-site", QVariant::String, 1, 1);
 	parser.addOption("-wait", QVariant::Int, 1, 1);
@@ -556,6 +557,9 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		// Do not swap sides between paired engines
 		else if (name == "-noswap")
 			tournament->setSwapSides(false);
+		// Use tournament schedule but with reverse sides
+		else if (name == "-reverse")
+			tournament->setReverseSides(true);
 		// Recover crashed/stalled engines
 		else if (name == "-recover")
 			tournament->setRecoveryMode(true);

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -59,6 +59,7 @@ Tournament::Tournament(GameManager* gameManager, QObject *parent)
 	  m_sprt(new Sprt),
 	  m_repetitionCounter(0),
 	  m_swapSides(true),
+	  m_reverseSides(false),
 	  m_pgnOutMode(PgnGame::Verbose),
 	  m_pair(nullptr)
 {
@@ -289,6 +290,11 @@ void Tournament::setSwapSides(bool enabled)
 	m_swapSides = enabled;
 }
 
+void Tournament::setReverseSides(bool enabled)
+{
+	m_reverseSides = enabled;
+}
+
 void Tournament::setOpeningBookOwnership(bool enabled)
 {
 	m_bookOwnership = enabled;
@@ -456,7 +462,11 @@ void Tournament::startNextGame()
 	if (!pair || !pair->isValid())
 		return;
 
-	if ((!pair->hasSamePlayers(m_pair) && m_players.size() > 2
+	bool samePlayers = pair->hasSamePlayers(m_pair);
+	if (!samePlayers && m_reverseSides)
+		pair->swapPlayers();
+
+	if ((!samePlayers && m_players.size() > 2
 	     && m_openingPolicy != OpeningPolicy::RoundPolicy)
 	|| (m_round > m_oldRound
 	     && m_openingPolicy == OpeningPolicy::RoundPolicy))

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -239,6 +239,13 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setSwapSides(bool enabled);
 		/*!
+		 * Sets the reverse colors flag to \a enabled.
+		 *
+		 * If \a enabled is true then the players will play reverse
+		 * sides /wrt to the normal schedule. The default is false.
+		 */
+		void setReverseSides(bool enabled);
+		/*!
 		 * Sets opening book ownership to \a enabled.
 		 *
 		 * By default the \a Tournament object doesn't take ownership of
@@ -476,6 +483,7 @@ class LIB_EXPORT Tournament : public QObject
 		QString m_startFen;
 		int m_repetitionCounter;
 		int m_swapSides;
+		bool m_reverseSides;
 		PgnGame::PgnMode m_pgnOutMode;
 		TournamentPair* m_pair;
 		QMap< QPair<int, int>, TournamentPair* > m_pairs;


### PR DESCRIPTION
This patch introduces an option `-reverse` to the CLI, which reverses the colour assignment in a tournament.

E.g. the sequence
`Player A -  Player B, Player C - Player D`
would become
`Player B - Player A, Player D - Player C`. 

For gauntlet tournaments, `-reverse` together with the options `-noswap` and  `-games m` has the gauntlet player play `m` games per round all with Black (instead of White) against any opponent in the list.

Thus resolves #520.