### PR TITLE
Fix issue where UCI_Variant is sent without a value.

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -54,7 +54,7 @@ QString variantFromUci(QString str, bool uciPrefix = true)
 
 QString variantToUci(const QString& str, bool uciPrefix = true)
 {
-	if (str.isEmpty())
+	if (str.isEmpty() || (str == "standard" && uciPrefix == true))
 		return QString();
 
 	if (str == "fischerandom")

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -54,7 +54,7 @@ QString variantFromUci(QString str, bool uciPrefix = true)
 
 QString variantToUci(const QString& str, bool uciPrefix = true)
 {
-	if (str.isEmpty() || str == "standard")
+	if (str.isEmpty())
 		return QString();
 
 	if (str == "fischerandom")


### PR DESCRIPTION
This PR is a bugfix for UCI code specific to the `UCI_Variant` option. The bug happens with any engine that supports `UCI_Variant` combo option with the `standard` value. When playing standard chess matches through cutechess-cli, cutechess will send `setoption name UCI_Variant` to the engine without an actual value. However, in the UCI specification, only button-type options can be set without a value. Doing it for combo-type options is a bug, and causes some engines to crash.