### PR TITLE
GUI: option to enable automatic flipping of board for human vs human games

### DIFF
--- a/projects/gui/src/gameviewer.h
+++ b/projects/gui/src/gameviewer.h
@@ -74,6 +74,7 @@ class GameViewer : public QWidget
 		void viewNextMove();
 		void viewLastMove();
 		void viewPosition(int index);
+		void autoFlip();
 
 		BoardScene* m_boardScene;
 		BoardView* m_boardView;
@@ -88,6 +89,7 @@ class GameViewer : public QWidget
 		QPointer<ChessGame> m_game;
 		QVector<Chess::GenericMove> m_moves;
 		int m_moveIndex;
+		bool m_humanGame;
 };
 
 #endif // GAMEVIEWER_H

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -56,6 +56,11 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/display_players_sides_on_clocks", checked);
 	});
 
+	connect(ui->m_autoFlipBoardForHumanGamesCheck, &QCheckBox::toggled,
+		[=](bool checked)
+	{
+		QSettings().setValue("ui/auto_flip_board_for_human_games", checked);
+	});
 
 	connect(ui->m_humanCanPlayAfterTimeoutCheck, &QCheckBox::toggled,
 		[=](bool checked)
@@ -205,6 +210,8 @@ void SettingsDialog::readSettings()
 		s.value("use_full_user_name", true).toBool());
 	ui->m_playersSidesOnClocksCheck->setChecked(
 		s.value("display_players_sides_on_clocks", false).toBool());
+	ui->m_autoFlipBoardForHumanGamesCheck->setChecked(
+		s.value("auto_flip_board_for_human_games", false).toBool());
 	ui->m_tbPathEdit->setText(s.value("tb_path").toString());
 	s.endGroup();
 

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -32,7 +32,7 @@
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
         <layout class="QFormLayout" name="formLayout_6">
-         <item row="6" column="0">
+         <item row="7" column="0">
           <widget class="QCheckBox" name="m_humanCanPlayAfterTimeoutCheck">
            <property name="text">
             <string>Human player can play after timeout</string>
@@ -76,6 +76,13 @@
            </property>
            <property name="checked">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QCheckBox" name="m_autoFlipBoardForHumanGamesCheck">
+           <property name="text">
+            <string>Auto flip board for human vs human</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This patch adds a checkbox to the General section of Settings. It enables or disables auto flipping the board after each move in human vs human games.

Discussed in #387