### PR TITLE
Extended output of tournament results

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -356,6 +356,18 @@ Set the random seed for the book move selector.
 Wait
 .Ar n
 milliseconds between games. The default is 0.
+.It Fl resultformat Ar format
+Specify the
+.Ar format
+of result lists.
+.Ar Format
+can either be a comma separated
+list of fields or a format name. Format
+.Cm help
+shows available named formats. The
+.Cm default
+format lists rank, name, elo, elo error, number of games,
+score percentage, and draw percentage of every player.
 .It Fl version
 Display the version information.
 .It Fl help

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -160,6 +160,13 @@ Options:
   -site SITE		Set the site/location to SITE
   -srand N		Set the seed for the random number generator to N
   -wait N		Wait N milliseconds between games. The default is 0.
+  -resultformat FORMAT  Specify the format of result lists. FORMAT can either be
+			a comma separated list of fields or a format name.
+			Format 'help' shows available named formats. The
+			'default' format lists rank, name, elo, elo error,
+			number of games, score percentage, and draw percentage
+			of every player.
+
 
 Engine options:
 

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -254,6 +254,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-rounds", QVariant::Int, 1, 1);
 	parser.addOption("-sprt", QVariant::StringList);
 	parser.addOption("-ratinginterval", QVariant::Int, 1, 1);
+	parser.addOption("-resultformat", QVariant::String, 1, 1);
 	parser.addOption("-debug", QVariant::Bool, 0, 0);
 	parser.addOption("-openings", QVariant::StringList);
 	parser.addOption("-bookmode", QVariant::String);
@@ -423,6 +424,28 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		// Interval for rating list updates
 		else if (name == "-ratinginterval")
 			match->setRatingInterval(value.toInt());
+		// Interval for rating list updates
+		else if (name == "-resultformat")
+		{
+			if (value == "help")
+			{
+				qInfo() << "\nOption -resultformat accepts a comma separated list of fields or one of following format names:\n";
+				const auto& map = tournament->namedResultFormats();
+				for (const QString& key: map.keys() )
+					qInfo() << qUtf8Printable(key) << "\n  "
+						<< qUtf8Printable(map[key]);
+				qInfo() <<"\nField tokens:";
+				QString s;
+				for (const QString& token: tournament->resultFieldTokens())
+				{
+					 s.append(qUtf8Printable(token));
+					 s.append(" ");
+				}
+				qInfo() << "  " << qUtf8Printable(s);
+				return 0;
+			}
+			tournament->setResultFormat(value.toString().left(256).trimmed());
+		}
 		// Debugging mode. Prints all engine input and output.
 		else if (name == "-debug")
 		{

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -297,6 +297,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	t->setOpeningRepetitions(ts->openingRepetition()? 2: 1);
 	t->setRecoveryMode(ts->engineRecovery());
 	t->setPgnWriteUnfinishedGames(ts->savingOfUnfinishedGames());
+	t->setResultFormat(ts->resultFormat());
 
 	const auto engines = m_addedEnginesManager->engines();
 	for (EngineConfiguration config : engines)

--- a/projects/gui/src/tournamentresultsdlg.cpp
+++ b/projects/gui/src/tournamentresultsdlg.cpp
@@ -44,7 +44,7 @@ TournamentResultsDialog::TournamentResultsDialog(QWidget* parent)
 	layout->setContentsMargins(0, 0, 0, 0);
 
 	setLayout(layout);
-	resize(700, 400);
+	resize(1080, 400);
 }
 
 TournamentResultsDialog::~TournamentResultsDialog()
@@ -82,7 +82,7 @@ void TournamentResultsDialog::update()
 	}
 
 	text += tournament->results();
-	text += tr("\n\n%1 of %2 games finished.")
+	text += tr("\n%1 of %2 games finished.")
 		.arg(tournament->finishedGameCount())
 		.arg(tournament->finalGameCount());
 	m_resultsEdit->setPlainText(text);

--- a/projects/gui/src/tournamentresultsdlg.cpp
+++ b/projects/gui/src/tournamentresultsdlg.cpp
@@ -44,7 +44,7 @@ TournamentResultsDialog::TournamentResultsDialog(QWidget* parent)
 	layout->setContentsMargins(0, 0, 0, 0);
 
 	setLayout(layout);
-	resize(1080, 400);
+	resize(1100, 400);
 }
 
 TournamentResultsDialog::~TournamentResultsDialog()

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -19,6 +19,8 @@
 #include "tournamentsettingswidget.h"
 #include "ui_tournamentsettingswidget.h"
 #include <QSettings>
+#include "gamemanager.h"
+#include "roundrobintournament.h"
 
 TournamentSettingsWidget::TournamentSettingsWidget(QWidget *parent)
 	: QWidget(parent),
@@ -30,6 +32,21 @@ TournamentSettingsWidget::TournamentSettingsWidget(QWidget *parent)
 	{
 		ui->m_roundsSpin->setEnabled(!checked);
 		ui->m_seedsSpin->setEnabled(checked);
+	});
+
+	GameManager gameManager;
+	RoundRobinTournament tournament(&gameManager);
+	const QMap<QString, QString> map = tournament.namedResultFormats();
+	for (const QString& value: map)
+		ui->m_resultFormatCombo->addItem(map.key(value), value);
+	ui->m_resultFormatCombo->setCurrentIndex(-1);
+
+	connect(ui->m_resultFormatCombo,
+		static_cast<void(QComboBox::*)(const QString &)>(&QComboBox::currentIndexChanged),
+		this, [=](const QString&)
+	{
+		const QVariant value = ui->m_resultFormatCombo->currentData();
+		ui->m_resultFormatEdit->setText(value.toString());
 	});
 
 	readSettings();
@@ -90,6 +107,11 @@ bool TournamentSettingsWidget::savingOfUnfinishedGames() const
 	return ui->m_saveUnfinishedGamesCheck->isChecked();
 }
 
+QString TournamentSettingsWidget::resultFormat() const
+{
+	return ui->m_resultFormatEdit->text();
+}
+
 void TournamentSettingsWidget::readSettings()
 {
 	QSettings s;
@@ -114,6 +136,19 @@ void TournamentSettingsWidget::readSettings()
 	ui->m_recoverCheck->setChecked(s.value("recover").toBool());
 	ui->m_saveUnfinishedGamesCheck->setChecked(
 		s.value("save_unfinished_games", true).toBool());
+
+	QString format = s.value("result_format").toString();
+	if (format.isEmpty())
+	{
+		int defaultIdx = ui->m_resultFormatCombo->findText("default");
+		ui->m_resultFormatCombo->setCurrentIndex(defaultIdx);
+	}
+	else
+	{
+		ui->m_resultFormatCombo->addItem("setting", QVariant(format));
+		int index = ui->m_resultFormatCombo->findData(format);
+		ui->m_resultFormatCombo->setCurrentIndex(index);
+	}
 
 	s.endGroup();
 }
@@ -173,5 +208,10 @@ void TournamentSettingsWidget::enableSettingsUpdates()
 	connect(ui->m_saveUnfinishedGamesCheck, &QCheckBox::toggled, [=](bool checked)
 	{
 		QSettings().setValue("tournament/save_unfinished_games", checked);
+	});
+
+	connect(ui->m_resultFormatEdit, &QLineEdit::textChanged, [=](const QString &text)
+	{
+		QSettings().setValue("tournament/result_format", text);
 	});
 }

--- a/projects/gui/src/tournamentsettingswidget.h
+++ b/projects/gui/src/tournamentsettingswidget.h
@@ -41,6 +41,7 @@ class TournamentSettingsWidget : public QWidget
 		bool openingRepetition() const;
 		bool engineRecovery() const;
 		bool savingOfUnfinishedGames() const;
+		QString resultFormat() const;
 
 		void enableSettingsUpdates();
 

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>314</height>
+    <width>419</width>
+    <height>436</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,7 +40,7 @@
            <string>Round-robin tournament</string>
           </property>
           <property name="text">
-           <string>Round Robin</string>
+           <string>Ro&amp;und Robin</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -53,7 +53,7 @@
            <string>First engine plays against the rest</string>
           </property>
           <property name="text">
-           <string>Gauntlet</string>
+           <string>Gaunt&amp;let</string>
           </property>
          </widget>
         </item>
@@ -63,7 +63,7 @@
            <string>Single-elimination tournament</string>
           </property>
           <property name="text">
-           <string>Knockout</string>
+           <string>Kno&amp;ckout</string>
           </property>
          </widget>
         </item>
@@ -73,7 +73,7 @@
            <string>Every engine plays against all of its predecessors</string>
           </property>
           <property name="text">
-           <string>Pyramid</string>
+           <string>&amp;Pyramid</string>
           </property>
          </widget>
         </item>
@@ -134,7 +134,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Games per encounter:</string>
+         <string>&amp;Games per encounter:</string>
         </property>
         <property name="buddy">
          <cstring>m_gamesPerEncounterSpin</cstring>
@@ -216,6 +216,72 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>100</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Results</string>
+     </property>
+     <widget class="QWidget" name="horizontalLayoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>29</y>
+        <width>401</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <widget class="QLabel" name="m_resultFormatLabel">
+         <property name="text">
+          <string>Format</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="m_resultFormatCombo"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QLineEdit" name="m_resultFormatEdit">
+      <property name="geometry">
+       <rect>
+        <x>12</x>
+        <y>70</y>
+        <width>400</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="autoFillBackground">
+       <bool>false</bool>
+      </property>
+      <property name="maxLength">
+       <number>256</number>
+      </property>
+      <property name="placeholderText">
+       <string>Result Format</string>
+      </property>
+      <property name="clearButtonEnabled">
+       <bool>false</bool>
+      </property>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/projects/lib/src/knockouttournament.cpp
+++ b/projects/lib/src/knockouttournament.cpp
@@ -130,7 +130,7 @@ int KnockoutTournament::gamesPerCycle() const
 	return total;
 }
 
-void KnockoutTournament::addScore(int player, int score)
+void KnockoutTournament::addScore(int player, Chess::Side side, int score)
 {
 	for (TournamentPair* pair : m_rounds.last())
 	{
@@ -146,7 +146,7 @@ void KnockoutTournament::addScore(int player, int score)
 		}
 	}
 
-	Tournament::addScore(player, score);
+	Tournament::addScore(player, side, score);
 }
 
 QList<int> KnockoutTournament::lastRoundWinners() const

--- a/projects/lib/src/knockouttournament.h
+++ b/projects/lib/src/knockouttournament.h
@@ -47,7 +47,7 @@ class LIB_EXPORT KnockoutTournament : public Tournament
 		virtual void initializePairing();
 		virtual int gamesPerCycle() const;
 		virtual TournamentPair* nextPair(int gameNumber);
-		virtual void addScore(int player, int score);
+		virtual void addScore(int player, Chess::Side side, int score);
 		virtual bool areAllGamesFinished() const;
 
 	private:

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -54,6 +54,9 @@ class LIB_EXPORT Tournament : public QObject
 			RoundPolicy        //!< Shift on new round
 		};
 
+		constexpr static auto c_defaultFormat 
+			= "Rank,Name,Elo,Error,Games,Score,DScore";
+
 		/*!
 		 * Creates a new tournament that uses \a gameManager
 		 * to manage the games.
@@ -232,13 +235,6 @@ class LIB_EXPORT Tournament : public QObject
 		 */
 		void setOpeningPolicy(OpeningPolicy policy = DefaultPolicy);
 		/*!
-		 * Sets the side swap flag to \a enabled.
-		 *
-		 * If \a enabled is true then paired engines will
-		 * swap sides for the following game.
-		 */
-		void setSwapSides(bool enabled);
-		/*!
 		 * Sets opening book ownership to \a enabled.
 		 *
 		 * By default the \a Tournament object doesn't take ownership of
@@ -250,6 +246,32 @@ class LIB_EXPORT Tournament : public QObject
 		 * the tournament.
 		 */
 		void setSeedCount(int seedCount);
+		/*!
+		 * Sets the side swap flag to \a enabled.
+		 *
+		 * If \a enabled is true then paired engines will
+		 * swap sides for the following game.
+		 */
+		void setSwapSides(bool enabled);
+		/*!
+		 * The \a format specifies which information are listed in the
+		 * table of tournament results. Available tokens are given by
+		 * \p fieldMap.
+		 */
+		void setResultFormat(const QString &format);
+		/*!
+		 * Returns the format of the result table.
+		 * The format uses tokens given by \p fieldMap.
+		 */
+		QString resultFormat() const;
+		/*!
+		 * Lists the result formats associated with a name.
+		 */
+		const QMap<QString, QString>& namedResultFormats() const;
+		/*!
+		 * Lists the format tokens for results
+		 */
+		const QList<QString> resultFieldTokens() const;
 		/*!
 		 * Adds player \a builder to the tournament.
 		 *
@@ -400,7 +422,7 @@ class LIB_EXPORT Tournament : public QObject
 		 * 1-0, 0-1 or 1/2-1/2 result. Subclasses can reimplement this
 		 * to do their own score tracking.
 		 */
-		virtual void addScore(int player, int score);
+		virtual void addScore(int player, Chess::Side side, int score);
 		/*!
 		 * Returns true if all games in the tournament have finished;
 		 * otherwise returns false.
@@ -425,6 +447,86 @@ class LIB_EXPORT Tournament : public QObject
 		void onGameStartFailed(ChessGame* game);
 
 	private:
+		/*! Output field identifier */
+		enum OutputField
+		{
+			Rank,
+			Name,
+			Games,
+			Wins,
+			Losses,
+			Draws,
+			WhiteWins,
+			WhiteLosses,
+			WhiteDraws,
+			BlackWins,
+			BlackLosses,
+			BlackDraws,
+			Points,
+			Score,
+			DrawScore,
+			EloDiff,
+			ErrorMargin,
+			LOS,
+			WhiteScore,
+			WhiteDrawScore,
+			WhiteEloDiff,
+			WhiteErrorMargin,
+			WhiteLOS,
+			BlackScore,
+			BlackDrawScore,
+			BlackEloDiff,
+			BlackErrorMargin,
+			BlackLOS
+		};
+
+		const QMap<int, QString> m_tokenMap = {
+			{Rank,             "Rank"},
+			{Name,             "Name"},
+			{Games,            "Games"},
+			{Wins,             "W"},
+			{Losses,           "L"},
+			{Draws,            "D"},
+			{WhiteWins,        "wW"},
+			{WhiteLosses,      "wL"},
+			{WhiteDraws,       "wD"},
+			{BlackWins,        "bW"},
+			{BlackLosses,      "bL"},
+			{BlackDraws,       "bD"},
+			{Points,           "Points"},
+			{Score,            "Score"},
+			{DrawScore,        "DScore"},
+			{EloDiff,          "Elo"},
+			{ErrorMargin,      "Error"},
+			{LOS,              "LOS"},
+			{WhiteScore,       "wScore"},
+			{WhiteDrawScore,   "wDScore"},
+			{WhiteEloDiff,     "wElo"},
+			{WhiteErrorMargin, "wError"},
+			{WhiteLOS,         "wLOS"},
+			{BlackScore,       "bScore"},
+			{BlackDrawScore,   "bDScore"},
+			{BlackEloDiff,     "bElo"},
+			{BlackErrorMargin, "bError"},
+			{BlackLOS,         "bLOS"}
+		};
+
+		const QMap<QString, QString> m_namedFormats =
+		{
+			{"minimal",	"Rank,Name"},
+			{"small",	"Rank,Name,Games,Points"},
+			{"short",	"Rank,Name,Elo,Games"},
+			{"concise",	"Rank,Name,Elo,Error,Games"},
+			{"default",	QString(c_defaultFormat)},
+			{"with-points",	"Rank,Name,Elo,Error,Games,Points,Score,DScore"},
+			{"wide",	"Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore"},
+			{"wide2",	"Rank,Name,Elo,Error,Games,W,L,D,Points,"
+					"Score,DScore,wScore,bScore"},
+			{"per-color",	"Rank,Name,Elo,Error,Games,W,L,D,Points,"
+					"wW,wL,wD,wPoints,bW,bL,bD,bPoints"},
+			{"ordo",	"Rank,Name,Elo,Points,Games,Score"}
+		};
+
 		struct GameData
 		{
 			int number;
@@ -435,11 +537,34 @@ class LIB_EXPORT Tournament : public QObject
 		{
 			QString name;
 			int games;
+			int wins;
+			int losses;
+			int draws;
+			int whiteWins;
+			int whiteLosses;
+			int whiteDraws;
+			int blackWins;
+			int blackLosses;
+			int blackDraws;
+			qreal points;
 			qreal score;
-			qreal draws;
-			qreal errorMargin;
+			qreal drawScore;
 			qreal eloDiff;
+			qreal errorMargin;
+			qreal LOS;
+			qreal whiteScore;
+			qreal whiteDrawScore;
+			qreal whiteEloDiff;
+			qreal whiteErrorMargin;
+			qreal whiteLOS;
+			qreal blackScore;
+			qreal blackDrawScore;
+			qreal blackEloDiff;
+			qreal blackErrorMargin;
+			qreal blackLOS;
 		};
+
+		QString resultsForSides(int index) const;
 
 		GameManager* m_gameManager;
 		ChessGame* m_lastGame;
@@ -476,6 +601,7 @@ class LIB_EXPORT Tournament : public QObject
 		QString m_startFen;
 		int m_repetitionCounter;
 		int m_swapSides;
+		QString m_resultFormat;
 		PgnGame::PgnMode m_pgnOutMode;
 		TournamentPair* m_pair;
 		QMap< QPair<int, int>, TournamentPair* > m_pairs;
@@ -483,6 +609,36 @@ class LIB_EXPORT Tournament : public QObject
 		QMap<int, PgnGame> m_pgnGames;
 		QMap<ChessGame*, GameData*> m_gameData;
 		QVector<Chess::Move> m_openingMoves;
+};
+
+/*!
+ * \brief Formatter for chess tournament results
+ */
+class LIB_EXPORT ResultFormatter : public QObject
+{
+	Q_OBJECT
+
+	public:
+		/*!
+		 * The ResultFormatter uses a reference to a map of available
+		 * tokens \a tokenMap to generate a tournament result list.
+		 */
+		ResultFormatter(const QMap<int, QString>& tokenMap,
+				const QString& format = QString(),
+				QObject* parent = nullptr);
+		/*!
+		 * Sets the output \a format of an entry in a tournament
+		 * result list.
+		 */
+		void setEntryFormat(const QString& format);
+		/*! Returns format for a line of tournament results */
+		QString entryFormat() const;
+		/*! Returns a line of tournament results */
+		QString entry(const QMap<int, QString>& data) const;
+	private:
+		QString m_entryFormat;
+		QMap<int, QString> m_tokenMap;
+		QStringList m_tokenList;
 };
 
 #endif // TOURNAMENT_H

--- a/projects/lib/src/tournamentplayer.cpp
+++ b/projects/lib/src/tournamentplayer.cpp
@@ -29,7 +29,10 @@ TournamentPlayer::TournamentPlayer(PlayerBuilder* builder,
 	  m_bookDepth(bookDepth),
 	  m_wins(0),
 	  m_draws(0),
-	  m_losses(0)
+	  m_losses(0),
+	  m_whiteWins(0),
+	  m_whiteDraws(0),
+	  m_whiteLosses(0)
 {
 	Q_ASSERT(builder != nullptr);
 }
@@ -80,23 +83,65 @@ int TournamentPlayer::losses() const
 	return m_losses;
 }
 
+int TournamentPlayer::whiteWins() const
+{
+	return m_whiteWins;
+}
+
+int TournamentPlayer::whiteDraws() const
+{
+	return m_whiteDraws;
+}
+
+int TournamentPlayer::whiteLosses() const
+{
+	return m_whiteLosses;
+}
+
+int TournamentPlayer::blackWins() const
+{
+	return m_wins - m_whiteWins;
+}
+
+int TournamentPlayer::blackDraws() const
+{
+	return m_draws - m_whiteDraws;
+}
+
+int TournamentPlayer::blackLosses() const
+{
+	return m_losses - m_whiteLosses;
+}
+
 int TournamentPlayer::score() const
 {
 	return m_wins * 2 + m_draws;
 }
 
-void TournamentPlayer::addScore(int score)
+void TournamentPlayer::addScore(Chess::Side side, int score)
 {
+	if (side == Chess::Side::NoSide)
+		Q_UNREACHABLE();
+
 	switch (score)
 	{
 	case 0:
 		m_losses++;
+
+		if (side == Chess::Side::White)
+			m_whiteLosses++;
 		break;
 	case 1:
 		m_draws++;
+
+		if (side == Chess::Side::White)
+			m_whiteDraws++;
 		break;
 	case 2:
 		m_wins++;
+
+		if (side == Chess::Side::White)
+			m_whiteWins++;
 		break;
 	default:
 		Q_UNREACHABLE();

--- a/projects/lib/src/tournamentplayer.h
+++ b/projects/lib/src/tournamentplayer.h
@@ -21,6 +21,7 @@
 
 #include "playerbuilder.h"
 #include "timecontrol.h"
+#include "board/side.h"
 
 class OpeningBook;
 
@@ -61,10 +62,40 @@ class LIB_EXPORT TournamentPlayer
 		 * tournament.
 		 */
 		int losses() const;
+		/*!
+		 * Returns the total number of wins of the player when
+		 * playing with White.
+		 */
+		int whiteWins() const;
+		/*!
+		 * Returns the total number of draws of the player when
+		 * playing with White.
+		 */
+		int whiteDraws() const;
+		/*!
+		 * Returns the total number of losses of the player when
+		 * playing with White.
+		 */
+		int whiteLosses() const;
+		/*!
+		 * Returns the total number of wins of the player when
+		 * playing with Black.
+		 */
+		int blackWins() const;
+		/*!
+		 * Returns the total number of draws of the player when
+		 * playing with Black.
+		 */
+		int blackDraws() const;
+		/*!
+		 * Returns the total number of losses of the player when
+		 * playing with Black.
+		 */
+		int blackLosses() const;
 		/*! Returns the player's total score in the tournament. */
 		int score() const;
 		/*! Adds \a score to the player's score in the tournament. */
-		void addScore(int score);
+		void addScore(Chess::Side side, int score);
 		/*!
 		 * Returns the total number of games the player has finished
 		 * in the tournament.
@@ -79,6 +110,9 @@ class LIB_EXPORT TournamentPlayer
 		int m_wins;
 		int m_draws;
 		int m_losses;
+		int m_whiteWins;
+		int m_whiteDraws;
+		int m_whiteLosses;
 };
 
 #endif // TOURNAMENTPLAYER_H

--- a/projects/lib/tests/tournamentplayer/tst_tournamentplayer.cpp
+++ b/projects/lib/tests/tournamentplayer/tst_tournamentplayer.cpp
@@ -99,6 +99,12 @@ void tst_TournamentPlayer::initialValues()
 	QCOMPARE(m_player->draws(), 0);
 	QCOMPARE(m_player->losses(), 0);
 	QCOMPARE(m_player->gamesFinished(), 0);
+	QCOMPARE(m_player->whiteWins(), 0);
+	QCOMPARE(m_player->whiteDraws(), 0);
+	QCOMPARE(m_player->whiteLosses(), 0);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackDraws(), 0);
+	QCOMPARE(m_player->blackLosses(), 0);
 }
 
 void tst_TournamentPlayer::setName()
@@ -111,26 +117,84 @@ void tst_TournamentPlayer::addScore()
 {
 	QCOMPARE(m_player->gamesFinished(), 0);
 
-	m_player->addScore(0);
+	m_player->addScore(Chess::Side::White, 0);
 	QCOMPARE(m_player->gamesFinished(), 1);
 	QCOMPARE(m_player->score(), 0);
 	QCOMPARE(m_player->draws(), 0);
 	QCOMPARE(m_player->wins(), 0);
 	QCOMPARE(m_player->losses(), 1);
+	QCOMPARE(m_player->draws(), 0);
+	QCOMPARE(m_player->whiteWins(), 0);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 0);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackLosses(), 0);
+	QCOMPARE(m_player->blackDraws(), 0);
 
-	m_player->addScore(1);
+	m_player->addScore(Chess::Side::White, 1);
 	QCOMPARE(m_player->gamesFinished(), 2);
 	QCOMPARE(m_player->score(), 1);
 	QCOMPARE(m_player->draws(), 1);
 	QCOMPARE(m_player->wins(), 0);
 	QCOMPARE(m_player->losses(), 1);
+	QCOMPARE(m_player->whiteWins(), 0);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 1);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackLosses(), 0);
+	QCOMPARE(m_player->blackDraws(), 0);
 
-	m_player->addScore(2);
+	m_player->addScore(Chess::Side::White, 2);
 	QCOMPARE(m_player->gamesFinished(), 3);
 	QCOMPARE(m_player->score(), 3);
 	QCOMPARE(m_player->draws(), 1);
 	QCOMPARE(m_player->wins(), 1);
 	QCOMPARE(m_player->losses(), 1);
+	QCOMPARE(m_player->whiteWins(), 1);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 1);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackLosses(), 0);
+	QCOMPARE(m_player->blackDraws(), 0);
+
+	m_player->addScore(Chess::Side::Black, 0);
+	QCOMPARE(m_player->gamesFinished(), 4);
+	QCOMPARE(m_player->score(), 3);
+	QCOMPARE(m_player->draws(), 1);
+	QCOMPARE(m_player->wins(), 1);
+	QCOMPARE(m_player->losses(), 2);
+	QCOMPARE(m_player->whiteWins(), 1);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 1);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackLosses(), 1);
+	QCOMPARE(m_player->blackDraws(), 0);
+
+	m_player->addScore(Chess::Side::Black, 1);
+	QCOMPARE(m_player->gamesFinished(), 5);
+	QCOMPARE(m_player->score(), 4);
+	QCOMPARE(m_player->draws(), 2);
+	QCOMPARE(m_player->wins(), 1);
+	QCOMPARE(m_player->losses(), 2);
+	QCOMPARE(m_player->whiteWins(), 1);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 1);
+	QCOMPARE(m_player->blackWins(), 0);
+	QCOMPARE(m_player->blackLosses(), 1);
+	QCOMPARE(m_player->blackDraws(), 1);
+
+	m_player->addScore(Chess::Side::Black, 2);
+	QCOMPARE(m_player->gamesFinished(), 6);
+	QCOMPARE(m_player->score(), 6);
+	QCOMPARE(m_player->draws(), 2);
+	QCOMPARE(m_player->wins(), 2);
+	QCOMPARE(m_player->losses(), 2);
+	QCOMPARE(m_player->whiteWins(), 1);
+	QCOMPARE(m_player->whiteLosses(), 1);
+	QCOMPARE(m_player->whiteDraws(), 1);
+	QCOMPARE(m_player->blackWins(), 1);
+	QCOMPARE(m_player->blackLosses(), 1);
+	QCOMPARE(m_player->blackDraws(), 1);
 }
 
 QTEST_MAIN(tst_TournamentPlayer)


### PR DESCRIPTION
,This PR extends the format choices for tournament results.

- For every player not only the total scores are calculated but also separate scores for White and Black.
- The CLI now provides the new option `-resultformat` to specify the format of result lists. It takes exactly one argument, the _format_. This can either be a comma separated list of fields or a format name. Format **'help'** shows available named formats and fields. The 'default' format is the same as before. It lists rank, name, elo, elo error, number of games, score percentage, and draw percentage of every player.
- The GUI now provides a `ComboBox` and a `LineEdit` in the "Tournament Settings" tab and in the "New Tournament" dialog to specify the format of result lists (see below). The text of the `LineEdit` is used as format description.
The results of matches between two engines now also list the White and Black scores of the first player and also the general score White vs Black.
- The CLI also prints out this additional per side information for two-engine matches, but only once per `ratinginterval`, and also at the end of the match.

These format names are defined:
```
concise 
   Rank,Name,Elo,Error,Games
default 
   Rank,Name,Elo,Error,Games,Score,DScore
minimal 
   Rank,Name
ordo 
   Rank,Name,Elo,Points,Games,Score
per-color 
   Rank,Name,Elo,Error,Games,W,L,D,Points,wW,wL,wD,wPoints,bW,bL,bD,bPoints
short 
   Rank,Name,Elo,Games
small 
   Rank,Name,Games,Points
wide 
   Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore
wide2 
   Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore,wScore,bScore
with-points 
   Rank,Name,Elo,Error,Games,Points,Score,DScore
```

These tokens are used to select the output fields:
```
Rank Name Games W L D wW wL wD bW bL bD Points Score DScore Elo Error LOS wScore
wDScore wElo wError wLOS bScore bDScore bElo bError bLOS
```

---
Example of a two-engine match with the CLI:
```
Started game 200 of 200 (Stockfish 6 64 BMI2 vs Fairy-Stockfish 230519 64 BMI2)
Finished game 200 (Stockfish 6 64 BMI2 vs Fairy-Stockfish 230519 64 BMI2): 1/2-1/2 {Draw
by 3-fold repetition}
Score of Fairy-Stockfish 230519 64 BMI2 vs Stockfish 6 64 BMI2: 75 - 56 - 69  [0.547] 200
...      Fairy-Stockfish 230519 64 BMI2 playing White: 44 - 23 - 33  [0.605] 100
...      Fairy-Stockfish 230519 64 BMI2 playing Black: 31 - 33 - 36  [0.490] 100
...      White vs Black: 77 - 54 - 69  [0.557] 200
Elo difference: 33.1 +/- 39.2, LOS: 95.2 %, DrawRatio: 34.5 %
Finished match
```
Example: result list of a three-engine tournament with the CLI using `-resultformat ordo`:
```
cutechess-cli -engine cmd=stockfish-5 proto=uci -engine cmd=stockfish-7 proto=uci
-engine cmd=stockfish-10 proto=uci -each tc=30+0.3 -games 2 -rounds 6 -recover
-repeat -openings file=data/8moves_v3.pgn format=pgn -concurrency 2 -pgnout sf1.pgn
-epdout sf1.epd -resultformat ordo

...
Finished game 36 (Stockfish 7 64 BMI2 vs Stockfish 5 64 BMI2): 1-0 {White mates}
Rank Name                          Elo   Points   Games   Score 
   1 Stockfish 10 64 BMI2          307     20.5      24   85.4% 
   2 Stockfish 7 64 BMI2           -29     11.0      24   45.8% 
   3 Stockfish 5 64 BMI2          -255      4.5      24   18.8% 

Finished match

```
Using `-resultformat with-points`:
```
Rank Name                          Elo     +/-   Games   Points   Score    Draw 
   1 Stockfish 10 64 BMI2          154     113      24     17.0   70.8%   41.7% 
   2 Stockfish 7 64 BMI2            29      92      24     13.0   54.2%   58.3% 
   3 Stockfish 5 64 BMI2          -191     114      24      6.0   25.0%   41.7% 

```
Using `-resultformat per-side` (a wide format - please use the scrollbar):
```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   WWins  WLoss.  WDraws   BWins  BLoss.  BDraws 
   1 Stockfish 10 64 BMI2          172     121      24      13       2       9     17.5       7       2       3       6       0       6 
   2 Stockfish 7 64 BMI2            73     115      24      10       5       9     14.5       5       3       4       5       2       5 
   3 Stockfish 5 64 BMI2          -280     131      24       0      16       8      4.0       0       6       6       0      10       2 
```
Finally, using `-resultformat Rank,Name,Elo` (no format name, but a comma separated list of fields):

```
Rank Name                          Elo 
   1 Stockfish 10 64 BMI2          172 
   2 Stockfish 7 64 BMI2            73 
   3 Stockfish 5 64 BMI2          -280  

```

Resolves #516,  #354.

I hope this is useful.

`
