### PR TITLE
Ouk Chatrang: Correction of rule implementation

### DIFF
--- a/projects/lib/src/board/oukboard.cpp
+++ b/projects/lib/src/board/oukboard.cpp
@@ -163,9 +163,10 @@ void OukBoard::generateMovesForPiece(QVarLengthArray< Move >& moves,
 			continue;
 
 		int target = square - i.offset * sign;
-		const Piece& piece = pieceAt(target);
+		const Piece& tgtPiece = pieceAt(target);
 
-		if  (piece.isEmpty())
+		if  (tgtPiece.isEmpty()
+		||   (pieceType == Maiden && tgtPiece.side() == side.opposite()))
 			moves.append(Move(square, target));
 	}
 }
@@ -188,8 +189,8 @@ bool OukBoard::inCheck(Side side, int square) const
 
 	if (!m_moveCount[opSide][King] && attacked)
 	{
-		if (square == kingSquare(side)
-		|| !inCheck(opSide))
+		if (pieceAt(square).isEmpty()
+		&&  !inCheck(opSide))
 			return true;
 	}
 	return MakrukBoard::inCheck(side, square);

--- a/projects/lib/src/board/oukboard.h
+++ b/projects/lib/src/board/oukboard.h
@@ -34,9 +34,9 @@ namespace Chess {
  *
  * Ouk has additional moves, which have been abandoned in Makruk:
  *
- * The King has the option to make an initial leap sideways like a Horse
- * (Knight), but only if not in check. The Advisor (Maiden, Neang) may leap
- * straight forward two squares on its initial move. These moves cannot capture.
+ * The King has the option to make an initial leap sideways to an empty square
+ * like a Horse (Knight), but only if not in check. The Advisor (Maiden, Neang)
+ * may leap straight forward two squares on its initial move.
  *
  * \note Rules: http://history.chess.free.fr/cambodian/Cambodian%20Chess%20Games.htm
  *              http://www.khmerinstitute.com/culture/ok.html

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1414,7 +1414,7 @@ void tst_Board::perft_data() const
 	QTest::newRow("cambodian startpos")
 		<< variant
 		<< "rnsmksnr/8/pppppppp/8/8/PPPPPPPP/8/RNSKMSNR w DEde 0 0 1"
-		<< 4 // 4 plies: 361793, 5 plies: 8601434, 6 plies: 204755574
+		<< 4 // 4 plies: 361793, 5 plies: 8601434, 6 plies: 204757579
 		<< Q_UINT64_C(361793);
 	QTest::newRow("cambodian check1")
 		<< variant


### PR DESCRIPTION
A King must not capture with the initial leap.
An Advisor (Queen) may capture with its initial leap.

Also, an inconsistency between move generation and check detection has been fixed.

Thanks to @ianfab for bringing this up.
