### PR TITLE
Fix display of evaluation history for games with Black starting positions

### DIFF
--- a/projects/gui/src/evalhistory.cpp
+++ b/projects/gui/src/evalhistory.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "evalhistory.h"
+#include "board/board.h"
 #include <QVBoxLayout>
 #include <QtGlobal>
 #include <qcustomplot.h>
@@ -26,7 +27,8 @@
 EvalHistory::EvalHistory(QWidget *parent)
 	: QWidget(parent),
 	  m_plot(new QCustomPlot(this)),
-	  m_game(nullptr)
+	  m_game(nullptr),
+	  m_invertSides(false)
 {
 	auto x = m_plot->xAxis;
 	auto y = m_plot->yAxis;
@@ -74,6 +76,7 @@ void EvalHistory::setGame(ChessGame* game)
 	connect(m_game, SIGNAL(scoreChanged(int,int)),
 		this, SLOT(onScore(int,int)));
 
+	m_invertSides = (m_game->board()->startingSide() == Chess::Side::Black);
 	setScores(game->scores());
 }
 
@@ -82,6 +85,7 @@ void EvalHistory::setPgnGame(PgnGame* pgn)
 	if (pgn == nullptr || pgn->isNull())
 		return;
 
+	m_invertSides = (pgn->startingSide() == Chess::Side::Black);
 	setScores(pgn->extractScores());
 }
 
@@ -119,7 +123,8 @@ void EvalHistory::addData(int ply, int score)
 	if (score == MoveEvaluation::NULL_SCORE)
 		return;
 
-	int side = (ply % 2 == 0) ? 0 : 1;
+	int base = m_invertSides ? 1 : 0;
+	int side = (ply % 2 == base) ? 0 : 1;
 	double x = double(ply + 2) / 2;
 	double y = qBound(-15.0, double(score) / 100.0, 15.0);
 	if (side == 1)

--- a/projects/gui/src/evalhistory.h
+++ b/projects/gui/src/evalhistory.h
@@ -57,6 +57,7 @@ class EvalHistory : public QWidget
 
 		QCustomPlot* m_plot;
 		QPointer<ChessGame> m_game;
+		bool m_invertSides;
 };
 
 #endif // EVALHISTORY_H


### PR DESCRIPTION
The score graph for games set-up from Black starting positions currently is inverted (Fig. 1). This patch fixes the assignment of odd and even plies  (Fig. 2).


![a1](https://user-images.githubusercontent.com/6425738/67150812-d2b64200-f2ab-11e9-8b53-e3416b25697d.png)
_Figure 1: Black wins. The game started with a set-up position and Black having the move. The score graph suggests a win for White_

![a2](https://user-images.githubusercontent.com/6425738/67150764-65a2ac80-f2ab-11e9-9d58-2734cd64731e.png)
_Figure 2: Black wins. The game started with a set-up position and Black having the move. With the fix the score graph is consistent with game scores._
