### PR TITLE
Enable file selector for string type options if name ends with "file"or "path"

### DIFF
--- a/projects/lib/src/engineoptionfactory.cpp
+++ b/projects/lib/src/engineoptionfactory.cpp
@@ -75,9 +75,9 @@ EngineOption* EngineOptionFactory::create(const QVariantMap& map)
 	else if (type == "text" || type == "file" || type == "folder")
 	{
 		EngineTextOption::EditorType editorType;
-		if (type == "file")
+		if (type == "file" || name.toLower().endsWith("file"))
 			editorType = EngineTextOption::FileDialog;
-		else if (type == "folder")
+		else if (type == "folder" || name.toLower().endsWith("path"))
 			editorType = EngineTextOption::FolderDialog;
 		else
 			editorType = EngineTextOption::LineEdit;


### PR DESCRIPTION
Enable file selector for string type options if their name ends with "file".
Enable directory selector for string type options if their name ends with "path".

This is a convenience patch.
Resolves feature request #478