### PR TITLE
Add application debug log

### DIFF
--- a/projects/gui/src/cutechessapp.cpp
+++ b/projects/gui/src/cutechessapp.cpp
@@ -301,3 +301,30 @@ void CuteChessApplication::closeDialogs()
 	if (m_gameWall)
 		m_gameWall->close();
 }
+
+void CuteChessApplication::messageHandler(QtMsgType type, const QMessageLogContext &context, const QString& msg)
+{
+	emit applicationMessage(type, context, msg);
+	emit applicationStringMessage(qPrintable(qFormatLogMessage(type, context, msg)));
+}
+
+void CuteChessApplication::printApplicationMessage(QtMsgType type, const QMessageLogContext &context, const QString& msg)
+{
+	static QTextStream out(stdout);
+	static QTextStream err(stderr);
+
+	switch (type)
+	{
+	case QtDebugMsg:
+	case QtInfoMsg:
+		out << qPrintable(qFormatLogMessage(type, context, msg)) << endl;
+		break;
+	case QtWarningMsg:
+	case QtCriticalMsg:
+		err << qPrintable(qFormatLogMessage(type, context, msg)) << endl;
+		break;
+	case QtFatalMsg:
+		err << qPrintable(qFormatLogMessage(type, context, msg)) << endl;
+		abort();
+	}
+}

--- a/projects/gui/src/cutechessapp.h
+++ b/projects/gui/src/cutechessapp.h
@@ -48,6 +48,7 @@ class CuteChessApplication : public QApplication
 		QList<MainWindow*> gameWindows();
 		void showGameWindow(int index);
 		TournamentResultsDialog* tournamentResultsDialog();
+		void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString& msg);
 
 		static CuteChessApplication* instance();
 		static QString userName();
@@ -61,6 +62,11 @@ class CuteChessApplication : public QApplication
 		void showGameWall();
 		void closeDialogs();
 		void onQuitAction();
+		void printApplicationMessage(QtMsgType type, const QMessageLogContext &context, const QString& msg);
+
+	signals:
+		void applicationMessage(QtMsgType type, const QMessageLogContext &context, const QString& msg);
+		void applicationStringMessage(const QString& msg);
 
 	private:
 		void showDialog(QWidget* dlg);

--- a/projects/gui/src/main.cpp
+++ b/projects/gui/src/main.cpp
@@ -30,6 +30,11 @@
 #include <board/result.h>
 #include <moveevaluation.h>
 
+void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString& msg)
+{
+	CuteChessApplication::instance()->messageHandler(type, context, msg);
+}
+
 int main(int argc, char* argv[])
 {
 	// Register types for signal / slot connections
@@ -38,10 +43,19 @@ int main(int argc, char* argv[])
 	qRegisterMetaType<Chess::Side>("Chess::Side");
 	qRegisterMetaType<Chess::Result>("Chess::Result");
 	qRegisterMetaType<MoveEvaluation>("MoveEvaluation");
+	qRegisterMetaType<QtMsgType>("QtMsgType");
 
 	QLoggingCategory::defaultCategory()->setEnabled(QtDebugMsg, true);
 
+	qSetMessagePattern("%{time yyyy-MM-dd h:mm:ss.zzz} %{if-debug}D%{endif}%{if-info}I%{endif}%{if-warning}W%{endif}%{if-critical}C%{endif}%{if-fatal}F%{endif} %{message}");
+
 	CuteChessApplication app(argc, argv);
+
+	// Setup message handler for console output
+	QObject::connect(&app, &CuteChessApplication::applicationMessage,
+	    &app, &CuteChessApplication::printApplicationMessage);
+
+	qInstallMessageHandler(messageHandler);
 
 	QTranslator translator;
 	translator.load(QLocale(), "cutechess", "_", "translations", ".qm");
@@ -76,3 +90,4 @@ int main(int argc, char* argv[])
 	app.newDefaultGame();
 	return app.exec();
 }
+

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -352,6 +352,16 @@ void MainWindow::createDockWindows()
 	engineDebugDock->close();
 	addDockWidget(Qt::BottomDockWidgetArea, engineDebugDock);
 
+	// Applicatino debug
+	auto appDebugDock = new QDockWidget(tr("Application Debug"), this);
+	appDebugDock->setObjectName("ApplicationDebugDock");
+	m_appDebugLog = new PlainTextLog(appDebugDock);
+	connect(CuteChessApplication::instance(),
+	    &CuteChessApplication::applicationStringMessage, m_appDebugLog,
+	    &PlainTextLog::appendPlainText);
+	appDebugDock->setWidget(m_appDebugLog);
+	addDockWidget(Qt::BottomDockWidgetArea, appDebugDock);
+
 	// Evaluation history
 	auto evalHistoryDock = new QDockWidget(tr("Evaluation history"), this);
 	evalHistoryDock->setObjectName("EvalHistoryDock");
@@ -394,6 +404,7 @@ void MainWindow::createDockWindows()
 	m_viewMenu->addAction(moveListDock->toggleViewAction());
 	m_viewMenu->addAction(tagsDock->toggleViewAction());
 	m_viewMenu->addAction(engineDebugDock->toggleViewAction());
+	m_viewMenu->addAction(appDebugDock->toggleViewAction());
 	m_viewMenu->addAction(evalHistoryDock->toggleViewAction());
 	m_viewMenu->addAction(whiteEvalDock->toggleViewAction());
 	m_viewMenu->addAction(blackEvalDock->toggleViewAction());

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -160,6 +160,7 @@ class MainWindow : public QMainWindow
 		QAction* m_showSettingsAct;
 
 		PlainTextLog* m_engineDebugLog;
+		PlainTextLog* m_appDebugLog;
 
 		EvalHistory* m_evalHistory;
 		EvalWidget* m_evalWidgets[2];


### PR DESCRIPTION
This PR adds debug log to the main window. At the beginning of the application startup, a custom message handler is installed which is responsible for emitting signals when messages (such as qDebug) are sent.

There are two signals: plain QString and more structured with type, context and message itself delivered separately.

The messages are always sent to stdout / stderr. When the application window appears, the messages are then sent to the UI as well. The messages are not cached, which results in only messages that have happened *after* the UI widget initialization to be shown in the UI.