### PR TITLE
Fix CECP mate scores for winning side

### DIFF
--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -577,7 +577,7 @@ int XboardEngine::adaptScore(int score) const
 	&&  absScore < newCECPMateScore + 100)
 	{
 		absScore = 2 * newCECPMateScore - 2 * absScore + m_eval.MATE_SCORE;
-		if (score >= absScore)
+		if (score >= 0)
 			absScore++;
 	}
 


### PR DESCRIPTION
This patch fixes a bug I introduced last year into the CECP (xboard) mate score calculation. Only _new style_ mate scores for the winning side are affected. Currently the transformation of the mate scores for the winning side is off one ply e.g. 999998 (+M2) instead of 999999 (+M1).