### PR TITLE
Support Minishogi, Dobutsu Shogi, EuroShogi, and Judkins Shogi

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -129,6 +129,8 @@ Los Alamos Chess
 Loser's Chess
 .It makruk
 Makruk (Thai Chess)
+.It minishogi
+Minishogi (5x5)
 .It modern
 Modern Chess (9x9)
 .It newzealand

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -85,6 +85,8 @@ Courier Chess (Medieval)
 Crazyhouse (Drop Chess Variant)
 .It displacedgrid
 Displaced Grid Chess
+.It dobutsu
+Dobutsu Shogi (3x4)
 .It embassy
 Embassy Chess
 .It extinction

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -89,6 +89,8 @@ Displaced Grid Chess
 Dobutsu Shogi (3x4)
 .It embassy
 Embassy Chess
+.It euroshogi
+EuroShogi (8x8)
 .It extinction
 Extinction Chess
 .It fischerandom

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -145,6 +145,8 @@ Rifle Chess
 S-Chess (Seirawan Chess)
 .It shatranj
 Shatranj
+.It shogi
+Shogi
 .It shoot
 Shoot Chess
 .It simplifiedgryphon

--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -117,6 +117,8 @@ Horde Chess (v2)
 Janus Chess
 .It jesonmor
 Jeson Mör
+.It judkins
+Judkins Shogi (6x6)
 .It karouk
 Kar Ouk (One-check Ouk)
 .It kinglet

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -57,6 +57,7 @@ Options:
 			'losalamos': Los Alamos Chess
 			'losers': Loser's Chess
 			'makruk': Makruk (Thai Chess)
+			'minishogi': Minishogi (5x5)
 			'modern': Modern Chess (9x9)
 			'newzealand': New Zealand Chess (has N/R hybrids)
 			'placement': Placement Chess

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -35,6 +35,7 @@ Options:
 			'courier': Courier Chess
 			'crazyhouse': Crazyhouse (Drop Chess)
 			'discplacedgrid': Displaced Grid Chess
+			'dobutsu': Dobutsu Shogi (3x4)
 			'embassy': Embassy Chess
 			'extinction': Extinction Chess
 			'fischerandom': Fischer Random Chess/Chess 960

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -37,6 +37,7 @@ Options:
 			'discplacedgrid': Displaced Grid Chess
 			'dobutsu': Dobutsu Shogi (3x4)
 			'embassy': Embassy Chess
+			'euroshogi': EuroShogi (8x8)
 			'extinction': Extinction Chess
 			'fischerandom': Fischer Random Chess/Chess 960
 			'giveaway': Giveaway Chess (Losing Chess)

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -65,6 +65,7 @@ Options:
 			'rifle': Rifle Chess
 			'seirawan': S-Chess (Seirawan Chess)
 			'shatranj': Shatranj
+			'shogi' : Shogi
 			'shoot': Shoot Chess
 			'slippedgrid': Slipped Grid Chess
 			'simplifiedgryphon': Simplified Gryphon Chess

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -51,6 +51,7 @@ Options:
 			'horde': Horde Chess (v2)
 			'janus': Janus Chess
 			'jesonmor': Jeson Mör
+			'judkins': Judkins Shogi (6x6)
 			'karouk': Kar Ouk (One-check Ouk)
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -52,6 +52,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/aiwokboard.cpp \
     $$PWD/sittuyinboard.cpp \
     $$PWD/shogiboard.cpp \
+    $$PWD/minishogiboard.cpp \
     $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
@@ -118,6 +119,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/aiwokboard.h \
     $$PWD/sittuyinboard.h \
     $$PWD/shogiboard.h \
+    $$PWD/minishogiboard.h \
     $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -51,6 +51,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/aseanboard.cpp \
     $$PWD/aiwokboard.cpp \
     $$PWD/sittuyinboard.cpp \
+    $$PWD/shogiboard.cpp \
     $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
@@ -116,6 +117,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/aseanboard.h \
     $$PWD/aiwokboard.h \
     $$PWD/sittuyinboard.h \
+    $$PWD/shogiboard.h \
     $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -53,6 +53,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/sittuyinboard.cpp \
     $$PWD/shogiboard.cpp \
     $$PWD/minishogiboard.cpp \
+    $$PWD/dobutsushogiboard.cpp \
     $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
@@ -120,6 +121,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/sittuyinboard.h \
     $$PWD/shogiboard.h \
     $$PWD/minishogiboard.h \
+    $$PWD/dobutsushogiboard.h \
     $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -54,6 +54,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/shogiboard.cpp \
     $$PWD/minishogiboard.cpp \
     $$PWD/dobutsushogiboard.cpp \
+    $$PWD/euroshogiboard.cpp \
     $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
@@ -122,6 +123,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/shogiboard.h \
     $$PWD/minishogiboard.h \
     $$PWD/dobutsushogiboard.h \
+    $$PWD/euroshogiboard.h \
     $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -55,6 +55,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/minishogiboard.cpp \
     $$PWD/dobutsushogiboard.cpp \
     $$PWD/euroshogiboard.cpp \
+    $$PWD/judkinsshogiboard.cpp \
     $$PWD/rifleboard.cpp \
     $$PWD/losalamosboard.cpp \
     $$PWD/almostboard.cpp \
@@ -124,6 +125,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/minishogiboard.h \
     $$PWD/dobutsushogiboard.h \
     $$PWD/euroshogiboard.h \
+    $$PWD/judkinsshogiboard.h \
     $$PWD/rifleboard.h \
     $$PWD/losalamosboard.h \
     $$PWD/almostboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -55,6 +55,7 @@
 #include "losersboard.h"
 #include "ncheckboard.h"
 #include "makrukboard.h"
+#include "minishogiboard.h"
 #include "modernboard.h"
 #include "oukboard.h"
 #include "placementboard.h"
@@ -119,6 +120,7 @@ REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")
 REGISTER_BOARD(MakrukBoard, "makruk")
+REGISTER_BOARD(MiniShogiBoard, "minishogi")
 REGISTER_BOARD(ModernBoard, "modern")
 REGISTER_BOARD(NewZealandBoard, "newzealand")
 REGISTER_BOARD(PlacementBoard, "placement")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -63,6 +63,7 @@
 #include "rifleboard.h"
 #include "seirawanboard.h"
 #include "shatranjboard.h"
+#include "shogiboard.h"
 #include "sittuyinboard.h"
 #include "standardboard.h"
 #include "suicideboard.h"
@@ -126,6 +127,7 @@ REGISTER_BOARD(RacingKingsBoard, "racingkings")
 REGISTER_BOARD(RifleBoard, "rifle")
 REGISTER_BOARD(SeirawanBoard, "seirawan")
 REGISTER_BOARD(ShatranjBoard, "shatranj")
+REGISTER_BOARD(ShogiBoard, "shogi")
 REGISTER_BOARD(ShootBoard, "shoot")
 REGISTER_BOARD(SimplifiedGryphonBoard, "simplifiedgryphon")
 REGISTER_BOARD(SittuyinBoard, "sittuyin")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -37,6 +37,7 @@
 #include "crazyhouseboard.h"
 #include "dobutsushogiboard.h"
 #include "embassyboard.h"
+#include "euroshogiboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
 #include "giveawayboard.h"
@@ -101,6 +102,7 @@ REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
 REGISTER_BOARD(DobutsuShogiBoard, "dobutsu")
 REGISTER_BOARD(EmbassyBoard, "embassy")
+REGISTER_BOARD(EuroShogiBoard, "euroshogi")
 REGISTER_BOARD(ExtinctionBoard, "extinction")
 REGISTER_BOARD(KingletBoard, "kinglet")
 REGISTER_BOARD(FrcBoard, "fischerandom")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -35,6 +35,7 @@
 #include "coregalboard.h"
 #include "courierboard.h"
 #include "crazyhouseboard.h"
+#include "dobutsushogiboard.h"
 #include "embassyboard.h"
 #include "extinctionboard.h"
 #include "frcboard.h"
@@ -98,6 +99,7 @@ REGISTER_BOARD(CoRegalBoard, "coregal")
 REGISTER_BOARD(CourierBoard, "courier")
 REGISTER_BOARD(CrazyhouseBoard, "crazyhouse")
 REGISTER_BOARD(DisplacedGridBoard, "displacedgrid")
+REGISTER_BOARD(DobutsuShogiBoard, "dobutsu")
 REGISTER_BOARD(EmbassyBoard, "embassy")
 REGISTER_BOARD(ExtinctionBoard, "extinction")
 REGISTER_BOARD(KingletBoard, "kinglet")

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -50,6 +50,7 @@
 #include "hordeboard.h"
 #include "janusboard.h"
 #include "jesonmorboard.h"
+#include "judkinsshogiboard.h"
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
 #include "loopboard.h"
@@ -117,6 +118,7 @@ REGISTER_BOARD(HoppelPoppelBoard, "hoppelpoppel")
 REGISTER_BOARD(HordeBoard, "horde")
 REGISTER_BOARD(JanusBoard, "janus")
 REGISTER_BOARD(JesonMorBoard, "jesonmor")
+REGISTER_BOARD(JudkinsShogiBoard, "judkins")
 REGISTER_BOARD(KarOukBoard,"karouk")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")

--- a/projects/lib/src/board/dobutsushogiboard.cpp
+++ b/projects/lib/src/board/dobutsushogiboard.cpp
@@ -1,0 +1,135 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dobutsushogiboard.h"
+
+namespace Chess {
+
+DobutsuShogiBoard::DobutsuShogiBoard()
+	: ShogiBoard()
+{
+	for (int type = Pawn; type < PromotedRook; type++)
+		setPieceType(type, tr("no-piece"), "", 0);
+
+	setPieceType(Pawn, tr("chick"), "C", 0, "P");
+	setPieceType(Bishop, tr("elephant"), "E", FerzMovement, "F");
+	setPieceType(Rook, tr("giraffe"), "G", WazirMovement, "R");
+	setPieceType(King, tr("lion"), "L", 0, "K");
+
+	setPieceType(PromotedPawn, tr("tokin"), "+P", GoldMovement, "W");
+
+}
+
+Board* DobutsuShogiBoard::copy() const
+{
+	return new DobutsuShogiBoard(*this);
+}
+
+QString DobutsuShogiBoard::variant() const
+{
+	return "dobutsu";
+}
+
+int DobutsuShogiBoard::height() const
+{
+	return 4;
+}
+
+int DobutsuShogiBoard::width() const
+{
+	return 3;
+}
+
+QString DobutsuShogiBoard::defaultFenString() const
+{
+	return "gle/1c1/1C1/ELG[-] w - 1";
+}
+
+int DobutsuShogiBoard::promotedPieceType(int type) const
+{
+	switch (type)
+	{
+		case Pawn:
+			return PromotedPawn;
+		default:
+			return type;
+	}
+}
+
+bool DobutsuShogiBoard::isLegalPosition()
+{
+	return true;
+}
+
+
+Result DobutsuShogiBoard::result()
+{
+	Side side = sideToMove();
+	Side opp = side.opposite();
+	QString str;
+
+	bool foundKing = false;
+	int kingSquare = 0;
+
+	// find Lion (King)
+	for (int i = 0; i < arraySize(); i++)
+	{
+		if (pieceAt(i) == Piece(side, King))
+		{
+			foundKing = true;
+			break;
+		}
+	}
+
+	// Lion (King) got captured
+	if (!foundKing)
+	{
+		str = tr("Lion captured - %1 wins").arg(opp);
+		return Result(Result::Win, opp, str);
+	}
+
+	// find opponent's Lion
+	for (int i = 0; i < arraySize(); i++)
+	{
+		if (pieceAt(i) == Piece(opp, King))
+		{
+			kingSquare = i;
+			break;
+		}
+	}
+
+	// test whether opponent's Lion reached farthest rank
+	int arwidth = width() + 2;
+	int rank = kingSquare / arwidth - 2;
+	int flag = (opp == Side::White) ? 0 : height() - 1;
+	if (rank == flag && !inCheck(opp))
+	{
+		str = tr("Lion reached farthest rank");
+		return Result(Result::Win, opp, str);
+	}
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+	{
+		str = tr("Draw by 3-fold repetition");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/dobutsushogiboard.h
+++ b/projects/lib/src/board/dobutsushogiboard.h
@@ -1,0 +1,78 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DOBUTSUSHOGIBOARD_H
+#define DOBUTSUSHOGIBOARD_H
+
+#include "shogiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Dōbutsu shōgi (どうぶつしょうぎ, Animal Chess)
+ *
+ * Dōbutsu shōgi is a simplified variant of shōgi for young children which
+ * is played on a board with 3 files and 4 ranks. Many shōgi rules apply in
+ * this variant. The pieces move like in standard shōgi but moves are limited
+ * to the range of one square. There are captures by displacement but no
+ * concepts of check nor mate. Captured pieces switch sides and can be dropped
+ * onto empty squares.
+ *
+ * Either side begins with one Lion (King) in the center of their base rank,
+ * one Giraffe (Rook) to its right, one Elephant (Bishop) to its left,
+ * and one Chick (Pawn) in front if it.
+ *
+ * The Chick promotes to a Hen (Tokin) after moving forward to highest rank.
+ * The Hen moves like a Gold General in shōgi. A captured Hen can only be
+ * dropped as a Chick but without further restrictions.
+ *
+ * The game is drawn if the players play the same position three turns in a
+ * row. Perpetual checks are allowed.
+ *
+ * Capturing the opponent's Lion wins. The Lion reaching the opponent's base
+ * rank wins if the Lion cannot be captured immediately.
+ *
+ * Dōbutsu shōgi was introduced in 2009 by Madoka Kitao, Japan
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Dōbutsu_shōgi
+ *
+ * \sa ShogiBoard
+ */
+class LIB_EXPORT DobutsuShogiBoard : public ShogiBoard
+{
+	public:
+		/*! Creates a new DobutsuShogiBoard object. */
+		DobutsuShogiBoard();
+
+		// Inherited from ShogiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		virtual int promotedPieceType(int type) const;
+		virtual bool isLegalPosition();
+
+
+};
+
+} // namespace Chess
+#endif // DOBUTSUSHOGIBOARD_H

--- a/projects/lib/src/board/euroshogiboard.cpp
+++ b/projects/lib/src/board/euroshogiboard.cpp
@@ -1,0 +1,148 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "euroshogiboard.h"
+
+namespace Chess {
+
+EuroShogiBoard::EuroShogiBoard()
+	: ShogiBoard()
+{
+	setPieceType(Lance, tr("no-lance"), "", 0);
+	setPieceType(SilverGeneral, tr("no-silver"), "", 0);
+	setPieceType(PromotedLance, tr("no-promoted-lance"), "", 0);
+	setPieceType(PromotedSilver, tr("no-promoted-silver"), "", 0);
+	setPieceType(Knight, tr("knight"), "N");
+}
+
+Board* EuroShogiBoard::copy() const
+{
+	return new EuroShogiBoard(*this);
+}
+
+QString EuroShogiBoard::variant() const
+{
+	return "euroshogi";
+}
+
+int EuroShogiBoard::height() const
+{
+	return 8;
+}
+
+int EuroShogiBoard::width() const
+{
+	return 8;
+}
+
+QString EuroShogiBoard::defaultFenString() const
+{
+	return "1nbgkgn1/1r4b1/pppppppp/8/8/PPPPPPPP/1B4R1/1NGKGBN1[-] w - 1";
+}
+
+int EuroShogiBoard::promotionRank() const
+{
+	return height() - 3;
+}
+
+void EuroShogiBoard::vInitialize()
+{
+	ShogiBoard::vInitialize();
+
+	int arwidth = width() + 2;
+	m_knightOffsets[Side::White].resize(4);
+	m_knightOffsets[Side::White][0] = -2 * arwidth - 1;
+	m_knightOffsets[Side::White][1] = -2 * arwidth + 1;
+	m_knightOffsets[Side::White][2] = -1;
+	m_knightOffsets[Side::White][3] =  1;
+
+	m_knightOffsets[Side::Black].resize(4);
+	m_knightOffsets[Side::Black][0] =  2 * arwidth + 1;
+	m_knightOffsets[Side::Black][1] =  2 * arwidth - 1;
+	m_knightOffsets[Side::Black][2] =  1;
+	m_knightOffsets[Side::Black][3] = -1;
+}
+
+void EuroShogiBoard::generateMovesForPiece(QVarLengthArray< Chess::Move >& moves,
+					   int pieceType,
+					   int square) const
+{
+	if (pieceType != Knight)
+	{
+		ShogiBoard::generateMovesForPiece(moves, pieceType, square);
+		return;
+	}
+
+	// Generate Knight drops
+	if (square == 0)
+	{
+		int minIndex = 2 * (width() + 2) + 1;
+		int maxIndex = arraySize() - minIndex;
+		for (int i = minIndex; i < maxIndex; i++)
+		{
+			Piece tmp = pieceAt(i);
+			if (!tmp.isEmpty())
+				continue;
+
+			moves.append(Move(0, i, pieceType));
+		}
+		return;
+	}
+	//EuroShogi Knight movement
+	QVarLengthArray<Move> moves1;
+	Side side = sideToMove();
+	generateHoppingMoves(square, m_knightOffsets[side], moves1);
+
+	for (Move m: moves1)
+	{
+		moves.append(m);
+
+		int target = m.targetSquare();
+		int rank = chessSquare(target).rank();
+		int rrank = (sideToMove() == Side::White) ? rank : height() - 1 - rank;
+
+		if (rrank >= promotionRank())
+			moves.append(Move(square, m.targetSquare(), PromotedKnight));
+	}
+}
+
+bool EuroShogiBoard::ranksAreAllowed() const
+{
+	return true;
+}
+
+Result EuroShogiBoard::result()
+{
+	Side side = sideToMove();
+	QString str;
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+	{
+		if (inCheck(side))
+		{
+			  str = tr("Illegal perpetual");
+			  return Result(Result::Win, side, str);
+		}
+		str = tr("Draw by 3-fold repetition");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+	return ShogiBoard::result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/euroshogiboard.h
+++ b/projects/lib/src/board/euroshogiboard.h
@@ -1,0 +1,79 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef EUROSHOGIBOARD_H
+#define EUROSHOGIBOARD_H
+
+#include "shogiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for EuroShogi
+ *
+ * EuroShogi is a variant of Shogi which is played on a 8x8 board.
+ * In this variant either side begins with King, two (Gold) Generals,
+ * two Bishops (on squares of different colours), two Knights, one Rook
+ * (on 2nd rank), and eight Pawns on the third rank. Shogi rules apply.
+ *
+ * A Knight leaps like a chess Knight, but only in the two forward directions.
+ * In contrast to Shogi, a Knight can also move one square sideways.
+ * Therefore Knights can be dropped on any empty square of the board.
+ *
+ * The promotion zone consists of the three furthest ranks.
+ * In case of a position occurring for the third time with the same player
+ * to move and the same pieces in hands, the game is drawn. However,
+ * if this situation arises from a series of checks, the side giving
+ * perpetual check loses the game.
+ *
+ * EuroShogi was introduced in 2000 by Vladimír Pribylinec.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Euroshogi
+ *
+ * \sa ShogiBoard
+ */
+class LIB_EXPORT EuroShogiBoard : public ShogiBoard
+{
+	public:
+		/*! Creates a new EuroShogiBoard object. */
+		EuroShogiBoard();
+
+		// Inherited from ShogiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		// Inherited from ShogiBoard
+		virtual int promotionRank() const;
+		virtual void vInitialize();
+		virtual void generateMovesForPiece(QVarLengthArray< Chess::Move >& moves,
+					   int pieceType,
+					   int square) const;
+		virtual bool ranksAreAllowed() const;
+
+	private:
+		QVarLengthArray<int> m_knightOffsets[2];
+
+};
+
+} // namespace Chess
+#endif // EUROSHOGIBOARD_H

--- a/projects/lib/src/board/judkinsshogiboard.cpp
+++ b/projects/lib/src/board/judkinsshogiboard.cpp
@@ -1,0 +1,73 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "judkinsshogiboard.h"
+
+namespace Chess {
+
+JudkinsShogiBoard::JudkinsShogiBoard()
+	: ShogiBoard()
+{
+	setPieceType(Lance, tr("no-lance"), "", 0);
+	setPieceType(PromotedLance, tr("no-promoted-lance"), "", 0);
+}
+
+Board* JudkinsShogiBoard::copy() const
+{
+	return new JudkinsShogiBoard(*this);
+}
+
+QString JudkinsShogiBoard::variant() const
+{
+	return "judkins";
+}
+
+int JudkinsShogiBoard::height() const
+{
+	return 6;
+}
+
+int JudkinsShogiBoard::width() const
+{
+	return 6;
+}
+
+QString JudkinsShogiBoard::defaultFenString() const
+{
+	return "rbnsgk/5p/6/6/P5/KGSNBR[-] w - 1";
+}
+
+Result JudkinsShogiBoard::impassePointRule(int points, int) const
+{
+	// 12-Point rule
+	Side side = sideToMove();
+	Side winner;
+
+	if (points < 12)
+		winner = side.opposite();
+	else if (points > 16)
+		winner = side;
+	else
+		return Result(Result::Draw, Side::NoSide, tr("Impasse: draw"));
+
+	QString winStr = winner == Side::White ? "Sente" : "Gote";
+	QString str = tr("Impasse: %1 wins by 12-point rule").arg(winStr);
+	return Result(Result::Win, winner, str);
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/judkinsshogiboard.h
+++ b/projects/lib/src/board/judkinsshogiboard.h
@@ -1,0 +1,63 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef JUDKINSSHOGIBOARD_H
+#define JUDKINSSHOGIBOARD_H
+
+#include "shogiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Judkins shogi
+ *
+ * Judkins shogi is a variant of Shogi which is played on a 6x6 board.
+ * In this variant either side begins with one King, one Gold General,
+ * one SilverGeneral, one Knight, one Bishop, one Rook (all on their
+ * base rank), and one Pawn in front of the King. Shogi rules apply.
+ *
+ * The promotion zone consists of the two highest ranks.
+ * In case of a fourfold repetition of moves, the side giving perpetual
+ * check loses, else the game is drawn.
+ *
+ * Judkins shogi was introduced in 1998 by Paul Judkins, Norwich, UK.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Judkins_shogi
+ *
+ * \sa ShogiBoard
+ */
+class LIB_EXPORT JudkinsShogiBoard : public ShogiBoard
+{
+	public:
+		/*! Creates a new JudkinsShogiBoard object. */
+		JudkinsShogiBoard();
+
+		// Inherited from ShogiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+
+	protected:
+		// Inherited from ShogiBoard
+		virtual Result impassePointRule(int points, int) const;
+};
+
+} // namespace Chess
+#endif // JUDKINSSHOGIBOARD_H

--- a/projects/lib/src/board/minishogiboard.cpp
+++ b/projects/lib/src/board/minishogiboard.cpp
@@ -1,0 +1,76 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "minishogiboard.h"
+
+namespace Chess {
+
+MiniShogiBoard::MiniShogiBoard()
+	: ShogiBoard()
+{
+	setPieceType(Lance, tr("no-lance"), "", 0);
+	setPieceType(Knight, tr("no-knight"), "", 0);
+	setPieceType(PromotedLance, tr("no-promoted-lance"), "", 0);
+	setPieceType(PromotedKnight, tr("no-promoted-knight"), "", 0);
+}
+
+Board* MiniShogiBoard::copy() const
+{
+	return new MiniShogiBoard(*this);
+}
+
+QString MiniShogiBoard::variant() const
+{
+	return "minishogi";
+}
+
+int MiniShogiBoard::height() const
+{
+	return 5;
+}
+
+int MiniShogiBoard::width() const
+{
+	return 5;
+}
+
+QString MiniShogiBoard::defaultFenString() const
+{
+	return "rbsgk/4p/5/P4/KGSBR[-] w - 1";
+}
+
+Result MiniShogiBoard::result()
+{
+	Side side = sideToMove();
+	QString str;
+
+	// 4-fold repetition
+	if (repeatCount() >= 3)
+	{
+		if (inCheck(side))
+		{
+			  str = tr("Illegal perpetual");
+			  return Result(Result::Win, side, str);
+		}
+		str = tr("Fourfold repetition - Gote wins");
+		return Result(Result::Win, Side::Black, str);
+	}
+	return ShogiBoard::result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/minishogiboard.h
+++ b/projects/lib/src/board/minishogiboard.h
@@ -1,0 +1,63 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MINISHOGIBOARD_H
+#define MINISHOGIBOARD_H
+
+#include "shogiboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Minishogi (5五将棋 gogo shōgi)
+ *
+ * Minishogi is a variant of Shogi which is played on a 5x5 board.
+ * In this variant either side begins with one King, one Gold General,
+ * one SilverGeneral, one Bishop, one Rook (all on their base rank),
+ * and one Pawn in front of the King. Shogi rules apply.
+ *
+ * The promotion zone only consists of the opponent's base rank.
+ * In case of a fourfold repetition of moves, the side giving perpetual
+ * check loses, else the side starting the game (Sente) loses.
+ *
+ * Minishogi was introduced in 1970 by Shigenobu Kusumoto, Osaka, Japan.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Minishogi
+ *
+ * \sa ShogiBoard
+ */
+class LIB_EXPORT MiniShogiBoard : public ShogiBoard
+{
+	public:
+		/*! Creates a new MiniShogiBoard object. */
+		MiniShogiBoard();
+
+		// Inherited from ShogiBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual int height() const;
+		virtual int width() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+
+};
+
+} // namespace Chess
+#endif // MINISHOGIBOARD_H

--- a/projects/lib/src/board/shogiboard.cpp
+++ b/projects/lib/src/board/shogiboard.cpp
@@ -1,0 +1,980 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "shogiboard.h"
+#include "zobrist.h"
+#include "boardtransition.h"
+
+namespace Chess {
+
+ShogiBoard::ShogiBoard()
+	: Board(new Zobrist()),
+	m_kingSquare{0,0},
+	m_promotionRank(0),
+	m_minIndex(0),
+	m_maxIndex(0),
+	m_plyOffset(0),
+	m_multiDigitNotation(false),
+	m_hasImpassePointRule(false),
+	m_history()
+{
+	setPieceType(Pawn, tr("pawn"), "P");
+	setPieceType(Lance, tr("lance"), "L", LanceMovement, "M");
+	setPieceType(Knight, tr("knight"), "N", KnightMovement);
+	setPieceType(SilverGeneral, tr("silver"), "S", SilverMovement, "E");
+	setPieceType(GoldGeneral, tr("gold"), "G", GoldMovement, "W");
+	setPieceType(Bishop, tr("bishop"), "B", BishopMovement);
+	setPieceType(Rook, tr("rook"), "R", RookMovement);
+	setPieceType(King, tr("king"), "K");
+
+	setPieceType(PromotedPawn, tr("tokin"), "+P", GoldMovement, "W");
+	setPieceType(PromotedLance, tr("promoted lance"), "+L", GoldMovement, "W");
+	setPieceType(PromotedKnight, tr("promoted knight"), "+N", GoldMovement, "N~");
+	setPieceType(PromotedSilver, tr("promoted silver"), "+S", GoldMovement, "W");
+	setPieceType(PromotedBishop, tr("horse"), "+B", BishopMovement | WazirMovement, "B~");
+	setPieceType(PromotedRook, tr("dragon"), "+R", RookMovement | FerzMovement, "R~");
+}
+
+Board* ShogiBoard::copy() const
+{
+	return new ShogiBoard(*this);
+}
+
+QList<Piece> ShogiBoard::reservePieceTypes() const
+{
+	QList<Piece> list;
+
+	for (int i = 0; i < 2; i++)
+	{
+		for (int type = Pawn; type < King; type++)
+			list << Piece(Side::Type(i), type);
+	}
+
+	return list;
+}
+
+QString ShogiBoard::variant() const
+{
+	return "shogi";
+}
+
+bool ShogiBoard::variantHasDrops() const
+{
+	return true;
+}
+
+bool ShogiBoard::variantHasOptionalPromotions() const
+{
+	return true;
+}
+
+QString ShogiBoard::defaultFenString() const
+{
+	return "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL[-] w - 1";
+}
+
+int ShogiBoard::width() const
+{
+	return 9;
+}
+
+Board::CoordinateSystem ShogiBoard::coordinateSystem() const
+{
+	return Chess::Board::NormalCoordinates;
+}
+
+int ShogiBoard::height() const
+{
+	return 9;
+}
+
+int ShogiBoard::reserveType(int pieceType) const
+{
+	return normalPieceType(pieceType);
+}
+
+int ShogiBoard::normalPieceType(int type) const
+{
+	switch (type)
+	{
+	case PromotedPawn:
+		return Pawn;
+	case PromotedLance:
+		return Lance;
+	case PromotedKnight:
+		return Knight;
+	case PromotedSilver:
+		return SilverGeneral;
+	case PromotedBishop:
+		return Bishop;
+	case PromotedRook:
+		return Rook;
+
+	default:
+		return type;
+	}
+}
+
+int ShogiBoard::promotedPieceType(int type) const
+{
+	switch (type)
+	{
+	case Pawn:
+		return PromotedPawn;
+	case Lance:
+		return PromotedLance;
+	case Knight:
+		return PromotedKnight;
+	case SilverGeneral:
+		return PromotedSilver;
+	case Bishop:
+		return PromotedBishop;
+	case Rook:
+		return PromotedRook;
+
+	default:
+		return type;
+	}
+}
+
+int ShogiBoard::promotionRank() const
+{
+	// Promotion zone is opponent's third.
+	return height() - height() / 3;
+}
+
+bool ShogiBoard::hasImpassePointRule() const
+{
+	return true;
+}
+
+inline void rotateAndStoreOffsets(QVarLengthArray<int> a[2])
+{
+	a[Side::Black].resize(a[Side::White].size());
+	for (int i = 0; i < a[Side::White].count(); i++)
+		a[Side::Black][i] = -a[Side::White][i];
+}
+
+void ShogiBoard::vInitialize()
+{
+	// White as first player: Sente 先手.
+	m_kingSquare[Side::White] = 0;
+	// Black as second player: Gote 後手.
+	m_kingSquare[Side::Black] = 0;
+
+	m_promotionRank = promotionRank();
+
+	// First index on board ("a9", "9a", "91", "9一", "九一")
+	m_minIndex = 2 * (width() + 2) + 1;
+
+	// Upper limit of board indices (plus one)
+	m_maxIndex = arraySize() - m_minIndex;
+
+	/*
+	 * The Lance, Knight, Silver General and Gold General do not
+	 * have dyad (C_2, 180 degrees) rotation symmetric movement,
+	 * so offsets are different for White and Black.
+	 */
+	int arwidth = width() + 2;
+
+	m_bishopOffsets.resize(4);
+	m_bishopOffsets[0] = -arwidth - 1;
+	m_bishopOffsets[1] = -arwidth + 1;
+	m_bishopOffsets[2] = arwidth - 1;
+	m_bishopOffsets[3] = arwidth + 1;
+
+	m_rookOffsets.resize(4);
+	m_rookOffsets[0] = -arwidth;
+	m_rookOffsets[1] = -1;
+	m_rookOffsets[2] = 1;
+	m_rookOffsets[3] = arwidth;
+
+	m_lanceOffsets[Side::White].resize(1);
+	m_lanceOffsets[Side::White][0] = -arwidth;
+	m_lanceOffsets[Side::Black].resize(1);
+	m_lanceOffsets[Side::Black][0] = arwidth;
+
+	m_knightOffsets[Side::White].resize(2);
+	m_knightOffsets[Side::White][0] = -2 * arwidth - 1;
+	m_knightOffsets[Side::White][1] = -2 * arwidth + 1;
+
+	rotateAndStoreOffsets(m_knightOffsets);
+
+	m_silverGeneralOffsets[Side::White].resize(5);
+	m_silverGeneralOffsets[Side::White][0] = -arwidth - 1;
+	m_silverGeneralOffsets[Side::White][1] = -arwidth + 1;
+	m_silverGeneralOffsets[Side::White][2] = arwidth - 1;
+	m_silverGeneralOffsets[Side::White][3] = arwidth + 1;
+	m_silverGeneralOffsets[Side::White][4] = -arwidth;
+
+	rotateAndStoreOffsets(m_silverGeneralOffsets);
+
+	m_goldGeneralOffsets[Side::White].resize(6);
+	m_goldGeneralOffsets[Side::White][0] = -arwidth - 1;
+	m_goldGeneralOffsets[Side::White][1] = -arwidth + 1;
+	m_goldGeneralOffsets[Side::White][2] = -arwidth;
+	m_goldGeneralOffsets[Side::White][3] = 1;
+	m_goldGeneralOffsets[Side::White][4] = -1;
+	m_goldGeneralOffsets[Side::White][5] = arwidth;
+
+	rotateAndStoreOffsets(m_goldGeneralOffsets);
+
+	m_multiDigitNotation = (qMax(width(),height()) > 9);
+	m_hasImpassePointRule = hasImpassePointRule();
+}
+
+QString ShogiBoard::vFenString(Board::FenNotation) const
+{
+	QString fen;
+
+	//
+	fen += '-';
+
+	// Full move number
+	fen += ' ';
+	fen += QString::number((m_history.size() + m_plyOffset) / 2 + 1);
+
+	return fen;
+}
+
+bool ShogiBoard::vSetFenString(const QStringList& fen)
+{
+	if (fen.size() < 2)
+		return false;
+
+	m_history.clear();
+	m_kingSquare[Side::White] = 0;
+	m_kingSquare[Side::Black] = 0;
+
+	QStringList::const_iterator token = fen.begin();
+
+	// Ignore field
+	if (token != fen.end())
+	{
+		++token;
+	}
+
+	// Read the full move number and calculate m_plyOffset
+	if (token != fen.end())
+	{
+		bool ok;
+		int tmp = token->toInt(&ok);
+		if (!ok || tmp < 1)
+			return false;
+		m_plyOffset = 2 * (tmp - 1);
+	}
+	else
+		m_plyOffset = 0;
+
+	if (startingSide() == Side::Black)
+		m_plyOffset++;
+
+	for (int sq = m_minIndex; sq < m_maxIndex; ++sq)
+	{
+		const Piece piece = pieceAt(sq);
+		if (piece.type() == King)
+			m_kingSquare[piece.side()] = sq;
+	}
+	if (m_kingSquare[Side::White] == 0
+	||  m_kingSquare[Side::Black] == 0)
+		return false;
+
+	return true;
+}
+
+QString ShogiBoard::lanMoveString(const Move& move)
+{
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	int prom = move.promotion();
+
+	QString str;
+	// Piece drop
+	if (source == 0)
+	{
+		Q_ASSERT(prom != Piece::NoPiece);
+		QChar drop = true ? '@' : '*';
+		str += pieceSymbol(prom).toUpper() + drop;
+		str += squareString(target);
+		return str;
+	}
+
+	str = squareString(source);
+	str += squareString(target);
+	if (prom != Piece::NoPiece)
+		str += "+";
+	return str;
+}
+
+QString ShogiBoard::sanMoveString(const Move& move)
+{
+	QString str;
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	Piece piece = pieceAt(source);
+	Piece capture = pieceAt(target);
+	Square square = chessSquare(source);
+
+	if (source == target)
+		capture = Piece::NoPiece;
+
+	// Drop move
+	if (source == 0 && move.promotion() != Piece::NoPiece)
+	{
+		str = lanMoveString(move);
+		return str;
+	}
+
+	bool needRank = false;
+	bool needFile = false;
+
+	str += pieceSymbol(piece).toUpper();
+	QVarLengthArray<Move> moves;
+	generateMoves(moves, piece.type());
+
+	for (int i = 0; i < moves.size(); i++)
+	{
+		const Move& move2 = moves[i];
+		if (move2.sourceSquare() == 0
+		||  move2.sourceSquare() == source
+		||  move2.targetSquare() != target)
+			continue;
+
+		if (!vIsLegalMove(move2))
+			continue;
+
+		Square square2(chessSquare(move2.sourceSquare()));
+		if (square2.file() != square.file())
+			needFile = true;
+		else if (square2.rank() != square.rank())
+			needRank = true;
+	}
+
+	if (needFile)
+		str += 'a' + square.file();
+	if (needRank)
+		str += QString::number(1 + square.rank());
+
+	if (capture.isValid())
+		str += 'x';
+
+	str += squareString(target);
+
+	if (move.promotion() != Piece::NoPiece)
+		str += "+";
+
+	return str;
+}
+
+Move ShogiBoard::moveFromLanString(const QString& istr)
+{
+	QString str(istr);
+	// Use uniform drop move indicator "@"
+	str.replace(QRegExp("[*']"),"@");
+
+	Move move = Chess::Board::moveFromLanString(str);
+	bool isPromotion = (str.endsWith("+"));
+	if (!isPromotion)
+		return move;
+
+	int source = move.sourceSquare();
+	Piece piece = pieceAt(source);
+	int type = piece.type();
+	int promotion =  promotedPieceType(type);
+	return Move(move.sourceSquare(), move.targetSquare(), promotion);
+}
+
+Move ShogiBoard::moveFromSanString(const QString& str)
+{
+	if (str.length() < 2)
+		return Move();
+
+	QString mstr(str);
+	Side side = sideToMove();
+
+	// Ignore mate/skip promotion/strong move/blunder notation
+	while (mstr.endsWith('#') || mstr.endsWith('=')
+	||     mstr.endsWith('!') || mstr.endsWith('?'))
+	{
+		mstr.chop(1);
+	}
+	// Remove promotion notation from the end of the string
+	bool promotionMove = mstr.endsWith('+');
+	if (promotionMove)
+		mstr.chop(1);
+
+	if (mstr.length() < 2)
+		return Move();
+
+	// Number of digits in notation of squares
+	int digits = 1;
+
+	// Find maximum number of sequential digits
+	int count = 0;
+	if (m_multiDigitNotation)
+	{
+		foreach (const QChar& ch, mstr)
+		{
+			if (ch.isDigit())
+			{
+				count++;
+				if (count > digits)
+					digits = count;
+			}
+			else
+				count = 0;
+		}
+	}
+	Square sourceSq;
+	Square targetSq;
+	QString::const_iterator it = mstr.cbegin();
+
+	// A pawn move need not specify the piece type
+	if (pieceFromSymbol(*it) == Pawn)
+		it++; // ignore character
+	// Piece type
+	Piece piece = (*it != '+') ? pieceFromSymbol(*it)
+				   : pieceFromSymbol('+' + *++it);
+	if (piece.side() != Side::White)
+		piece = Piece::NoPiece;
+	else
+		piece.setSide(side);
+
+	if (piece.isEmpty())
+	{
+		piece = Piece(side, Pawn);
+		targetSq = chessSquare(mstr.mid(0, 1 + digits));
+		if (isValidSquare(targetSq))
+			it += 1 + digits;
+	}
+	else
+	{
+		++it;
+
+		// Drop moves
+		if (*it == '@' || *it == '*' || *it =='\'')
+		{
+			targetSq = chessSquare(mstr.right(1 + digits));
+			if (!isValidSquare(targetSq))
+				return Move();
+
+			Move move(0, squareIndex(targetSq), piece.type());
+			if (isLegalMove(move))
+				return move;
+			return Move();
+		}
+	}
+
+	int promotion = promotionMove ? promotedPieceType(piece.type())
+				      : Piece::NoPiece;
+
+	if (!isValidSquare(targetSq))
+	{
+		// Source square's file
+		sourceSq.setFile(it->toLatin1() - 'a');
+		if (sourceSq.file() < 0 || sourceSq.file() >= width())
+			sourceSq.setFile(-1);
+		else if (++it == mstr.cend())
+			return Move();
+
+		// Source square's rank
+		if (it->isDigit())
+		{
+			const QString tmp(mstr.mid(it - mstr.constBegin(),
+						   digits));
+			sourceSq.setRank(-1 + tmp.toInt());
+			if (sourceSq.rank() < 0 || sourceSq.rank() >= height())
+				return Move();
+			it += digits;
+		}
+
+		if (it == mstr.cend())
+		{
+			// What we thought was the source square, was
+			// actually the target square.
+			if (isValidSquare(sourceSq))
+			{
+				targetSq = sourceSq;
+				sourceSq.setRank(-1);
+				sourceSq.setFile(-1);
+			}
+			else
+				return Move();
+		}
+		// Capture
+		else if (*it == 'x')
+		{
+			if(++it == mstr.cend())
+				return Move();
+		}
+
+		// Target square
+		if (!isValidSquare(targetSq))
+		{
+			if (it + 1 >= mstr.cend())
+				return Move();
+			QString tmp(mstr.mid(it - mstr.cbegin(), 1 + digits));
+			targetSq = chessSquare(tmp);
+			it += tmp.size();
+		}
+	}
+	if (!isValidSquare(targetSq))
+		return Move();
+	int target = squareIndex(targetSq);
+
+	// Promotion
+	if (it != mstr.cend())
+	{
+		if ((*it == '=' || *it == '(') && ++it == mstr.cend())
+			return Move();
+
+		promotion = pieceFromSymbol(*it).type();
+		if (promotion == Piece::NoPiece)
+			return Move();
+	}
+
+	QVarLengthArray<Move> moves;
+	generateMoves(moves, piece.type());
+	const Move* match = nullptr;
+
+	// Loop through all legal moves to find a move that matches
+	// the data we got from the move string.
+	for (int i = 0; i < moves.size(); i++)
+	{
+		const Move& move = moves[i];
+		if (move.sourceSquare() == 0 || move.targetSquare() != target)
+			continue;
+		Square sourceSq2 = chessSquare(move.sourceSquare());
+		if (sourceSq.rank() != -1 && sourceSq2.rank() != sourceSq.rank())
+			continue;
+		if (sourceSq.file() != -1 && sourceSq2.file() != sourceSq.file())
+			continue;
+		if (move.promotion() != promotion)
+			continue;
+
+		if (!vIsLegalMove(move))
+			continue;
+
+		// Return an empty move if there are multiple moves that
+		// match the move string.
+		if (match != nullptr)
+			return Move();
+		match = &move;
+	}
+
+	if (match != nullptr)
+		return *match;
+
+	return Move();
+}
+
+void ShogiBoard::vMakeMove(const Move& move, BoardTransition* transition)
+{
+	Side side = sideToMove();
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	int prom = move.promotion();
+
+	MoveData md {pieceAt(target)};
+	m_history.append(md);
+
+	// Add captured pieces to reserve and remove dropped pieces
+	int ctype = captureType(move);
+	if (ctype != Piece::NoPiece)
+	{
+		Piece reservePiece(side, reserveType(ctype));
+		addToReserve(reservePiece);
+		if (transition != nullptr)
+			transition->addReservePiece(reservePiece);
+	}
+	else if (source == 0)
+		removeFromReserve(Piece(side, prom));
+
+	// Transitions for normal moves and drop moves
+	if (transition != nullptr)
+	{
+		if (source != 0)
+			transition->addMove(chessSquare(source),
+					    chessSquare(target));
+		else
+			transition->addDrop(Piece(side, prom),
+					    chessSquare(target));
+	}
+
+	// Set pieces onto target square: promotions and normal moves
+	if (prom != Piece::NoPiece)
+		setSquare(target, Piece(side, prom));
+	else
+		setSquare(target, pieceAt(source));
+
+	// Clear source square for normal moves
+	if (source != 0)
+		setSquare(source, Piece::NoPiece);
+
+	// Keep track of the King
+	if (source == m_kingSquare[side])
+		m_kingSquare[side] = target;
+}
+
+void ShogiBoard::vUndoMove(const Move& move)
+{
+	int source = move.sourceSquare();
+	int target = move.targetSquare();
+	int prom = move.promotion();
+
+	Side side = sideToMove();
+
+	// Restore piece on source square for promotions and normal moves
+	if (prom != Piece::NoPiece)
+	{
+		int normalType = normalPieceType(prom);
+		if (source != 0)
+			setSquare(source, Piece(side, normalType));
+	}
+	else
+		setSquare(source, pieceAt(target));
+
+	// Restore piece on target square from history
+	const MoveData& md = m_history.last();
+	setSquare(target, md.capture);
+
+	// Undo effects on reserve of captures and drops
+	int ctype = captureType(move);
+	if (ctype != Piece::NoPiece)
+		removeFromReserve(Piece(side, reserveType(ctype)));
+	else if (source == 0)
+		addToReserve(Piece(side, prom));
+
+	// Keep track of the King
+	if (target == m_kingSquare[side])
+		m_kingSquare[side] = source;
+
+	m_history.pop_back();
+}
+
+/*
+ * A normal move or a drop move is allowed if the piece is not a Pawn or
+ * a Lance on the highest rank or a Knight on the highest two ranks.
+*/
+bool ShogiBoard::rankIsAllowed(int pieceType, int square) const
+{
+	if (pieceType != Pawn && pieceType != Lance && pieceType != Knight)
+		return true;
+
+	int rank = chessSquare(square).rank();
+	int rrank = (sideToMove() == Side::White) ? rank : height() - 1 - rank;
+	int distance = height() - rrank;
+
+	return distance > 2 || (distance > 1 && pieceType != Knight);
+}
+
+/*
+ * Rule of Two Pawns (二歩, nifu):
+ * A Pawn must not be dropped onto a file where an own Pawn is already present
+ */
+bool ShogiBoard::fileIsAllowed(int pieceType, int square) const
+{
+	if (pieceType != Pawn)
+		return true;
+
+	Side side = sideToMove();
+	int arwidth = width() + 2;
+	int start = m_minIndex - 1 + square % arwidth;
+
+	for (int i = start; i < m_maxIndex; i += arwidth)
+	{
+		if (pieceAt(i) == Piece(side, Pawn))
+			return false;
+	}
+	return true;
+}
+
+bool ShogiBoard::inPromotionZone(int square) const
+{
+	Square sq = chessSquare(square);
+	int rank = sq.rank();
+	int rrank = (sideToMove() == Side::White) ? rank : height() - 1 - rank;
+
+	return rrank >= m_promotionRank;
+}
+
+void ShogiBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
+					    int pieceType,
+					    int square) const
+{
+	// Generate drops
+	if (square == 0)
+	{
+		for (int i = m_minIndex; i < m_maxIndex; i++)
+		{
+			if (!pieceAt(i).isEmpty())
+				continue;
+
+			if (rankIsAllowed(pieceType, i)
+			&&  fileIsAllowed(pieceType, i))
+				moves.append(Move(0, i, pieceType));
+		}
+		return;
+	}
+
+	Side side = sideToMove();
+
+	if (pieceType == King)
+	{
+		generateHoppingMoves(square, m_bishopOffsets, moves);
+		generateHoppingMoves(square, m_rookOffsets, moves);
+		return;
+	}
+	QVarLengthArray<Move>  moves1;
+	if (pieceType == Pawn)
+		generateHoppingMoves(square, m_lanceOffsets[side], moves1);
+	if (pieceHasMovement(pieceType, BishopMovement))
+		generateSlidingMoves(square, m_bishopOffsets, moves1);
+	if (pieceHasMovement(pieceType, RookMovement))
+		generateSlidingMoves(square, m_rookOffsets, moves1);
+	if (pieceHasMovement(pieceType, FerzMovement))
+		generateHoppingMoves(square, m_bishopOffsets, moves1);
+	if (pieceHasMovement(pieceType, WazirMovement))
+		generateHoppingMoves(square, m_rookOffsets, moves1);
+	if (pieceHasMovement(pieceType, LanceMovement))
+		generateSlidingMoves(square, m_lanceOffsets[side], moves1);
+	if (pieceHasMovement(pieceType, KnightMovement))
+		generateHoppingMoves(square, m_knightOffsets[side], moves1);
+	if (pieceHasMovement(pieceType, SilverMovement))
+		generateHoppingMoves(square, m_silverGeneralOffsets[side], moves1);
+	if (pieceHasMovement(pieceType, GoldMovement))
+		generateHoppingMoves(square, m_goldGeneralOffsets[side], moves1);
+
+	// Generate promotions and append valid moves to the list
+	int fromPromotionZone = inPromotionZone(square);
+	int promotionType = promotedPieceType(pieceType);
+	for (const Move m: moves1)
+	{
+		// No promotions for King, Gold and promoted piece types
+		if (pieceType == promotionType)
+		{
+			moves.append(m);
+			continue;
+		}
+
+		/*
+		 * A normal move is allowed if the piece is not a Pawn or a Lance
+		 * on the highest rank or a Knight on the highest two ranks.
+		 */
+		int target = m.targetSquare();
+
+		if (rankIsAllowed(pieceType, target))
+			moves.append(m);
+
+		// Promotion is allowed in opponent's third of the board.
+		if (fromPromotionZone || inPromotionZone(target))
+			moves.append(Move(square, target, promotionType));
+	}
+}
+
+bool ShogiBoard::ranksAreAllowed() const
+{
+	// No Pawns, Lances, and Knights allowed on the highest rank
+	for (int i = m_minIndex; i < m_minIndex + width(); i++)
+	{
+		Piece piece = pieceAt(i);
+		int type = piece.type();
+		if ((type == Pawn || type == Lance || type == Knight)
+		&&  piece.side() == Side::White)
+			return false;
+
+		piece = pieceAt(arraySize() - 1 - i);
+		type = piece.type();
+		if ((type == Pawn || type == Lance || type == Knight)
+		&&  piece.side() == Side::Black)
+			return false;
+	}
+	// No Knights allowed on the 2nd highest rank
+	int arwidth = width() + 2;
+	for (int i = m_minIndex; i < m_minIndex + width(); i++)
+	{
+		Piece piece = pieceAt(i + arwidth);
+		if (piece == Piece(Side::White, Knight))
+			return false;
+
+		piece = pieceAt(arraySize() - 1 - i - arwidth);
+		if (piece == Piece(Side::Black, Knight))
+			return false;
+	}
+
+	return true;
+}
+
+bool ShogiBoard::isLegalPosition()
+{
+	Side opp = sideToMove().opposite();
+	if (inCheck(opp))
+		return false;
+
+	return ranksAreAllowed();
+}
+
+bool ShogiBoard::vIsLegalMove(const Move& move)
+{
+	Q_ASSERT(!move.isNull());
+
+	makeMove(move);
+	bool isLegal = isLegalPosition();
+	bool isIncheck = inCheck(sideToMove());
+
+	// Illegal perpetual
+	if (isIncheck && repeatCount() > 2)
+		isLegal = false;
+
+	// Illegal mate by Pawn drop?  (打ち歩詰め, uchi-fu-zume)
+	if (move.promotion() == Pawn && move.sourceSquare() == 0)
+	{
+		if (isIncheck && !canMove())
+			isLegal = false;
+	}
+	undoMove();
+
+	return isLegal;
+}
+
+bool ShogiBoard::inCheck(Side side, int square) const
+{
+	if (square == 0)
+		square = m_kingSquare[side];
+
+	QVarLengthArray <Move> moves;
+	if (sideToMove() == side)
+		// needs C2-symmetry of piece movement between sides
+		for (int type = Pawn; type <= PromotedRook; type++)
+		{
+			generateMovesForPiece(moves, type, square);
+			for (const auto m: moves)
+			{
+				if (captureType(m) == type)
+					return true;
+			}
+			moves.clear();
+		}
+	else
+	{
+		generateMoves(moves);
+		for (const auto m: moves)
+		{
+			if (m.targetSquare() == square)
+				return true;
+		}
+	}
+	return false;
+}
+
+
+Result ShogiBoard::impassePointRule(int points, int pieces) const
+{
+	// 27-Point rule
+	Side side = sideToMove();
+	if (side == Side::Black)
+		points++;
+
+	if (points > 27 && pieces >= 10)
+	{
+		QString winStr = side == Side::White ? "Sente" : "Gote";
+		QString str = tr("Impasse: %1 wins by 27-point rule").arg(winStr);
+		return Result(Result::Win, side, str);
+	}
+	return Result();
+}
+
+Result ShogiBoard::resultFromImpassePointRule() const
+{
+	Side side = sideToMove();
+	if (!inPromotionZone(m_kingSquare[side]) || inCheck(side))
+		return Result();
+	if (!inPromotionZone(m_kingSquare[side.opposite()]))
+		return Result();
+
+	// Subtract one count for the King
+	int pieceValue = -1;
+	int pieceCount = -1;
+
+	// Count pieces in promotion zone and count piece values
+	for (int i = m_minIndex; i < m_maxIndex; i++)
+	{
+		Piece piece = pieceAt(i);
+		if (piece.side() != side)
+			continue;
+
+		if (inPromotionZone(i))
+			pieceCount++;
+
+		int type = piece.type();
+		if (type == Bishop || type == Rook
+		||  type == PromotedBishop || type == PromotedRook)
+			pieceValue += 5;
+		else
+			pieceValue ++;
+	}
+	// Count pieces in hand
+	for (int type = Pawn; type < King; type++)
+	{
+		if (type == Bishop || type == Rook)
+			pieceValue += 5 * reserveCount(Piece(side, type));
+		else
+			pieceValue += reserveCount(Piece(side, type));
+	}
+	return impassePointRule(pieceValue, pieceCount);
+}
+
+Result ShogiBoard::result()
+{
+	Side side = sideToMove();
+	QString str;
+
+	// Checkmate/Stalemate
+	if (!canMove())
+	{
+		Side winner = side.opposite();
+		QString winStr = winner == Side::White ? "Sente" : "Gote";
+		if (inCheck(side))
+			str = tr("%1 mates").arg(winStr);
+		else
+			str = tr("%1 wins by stalemate").arg(winStr);
+
+		return Result(Result::Win, winner, str);
+	}
+
+	// 4-fold repetition
+	if (repeatCount() >= 3)
+	{
+		if (inCheck(side))
+		{
+			  str = tr("Illegal perpetual");
+			  return Result(Result::Win, side, str);
+		}
+		// Sennichite 千日手
+		str = tr("Draw by fourfold repetition");
+		return Result(Result::Draw, Side::NoSide, str);
+	}
+
+	// Entering Kings (相入玉, ai-nyū gyoku) and Impasse (持将棋, jishōgi)
+	if (m_hasImpassePointRule)
+		return resultFromImpassePointRule();
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/shogiboard.h
+++ b/projects/lib/src/board/shogiboard.h
@@ -1,0 +1,214 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHOGIBOARD_H
+#define SHOGIBOARD_H
+
+#include "board.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Shogi
+ *
+ * Shōgi is a Japanese form of chess where captured
+ * pieces can be brought back ("dropped") into the game,
+ *
+ * It is played on a 9x9 board. The piece set traditionally consists of
+ * flat five-sided pieces with their names written on them. Such sets
+ * have been in use at least since the 11th century AD.
+ *
+ * Shōgi emerged from the earlier game of Shō Shōgi by the reinsertion
+ * of captured pieces as own pieces (15th century AD) and removal of the
+ * Drunk Elephant piece by imperial order (16th century AD).
+ *
+ * Shōgi has eight types of original pieces. Either side starts with a
+ * set of 9 x Pawn (on the third rank), 2 x Lance, 2 x Knight, 2 x Silver
+ * (General), 2 x Gold (General), 1 x Bishop, 1 x Rook, 1 x King.
+ * The latter three types move like in standard chess. The Pawn moves and
+ * captures 1 square straight forward. The Lance moves and captures like
+ * a Rook, but only forwards. Similarly, the Knight leaps like a chess
+ * Knight, but only in the two forward directions. The Silver goes one
+ * square diagonally or forward (5 moves). The Gold goes like a King but
+ * not diagonally backward (6 moves).
+ *
+ * All these pieces except King and Gold General have the option to promote
+ * if their move starts or ends in the opponent's third of the board.
+ * A Pawn or Lance reaching the highest rank must promote. A Knight must
+ * promote when reaching the highest two ranks. All promoted Pawns, Lances,
+ * Knights, and Silvers move like Gold Generals. A promoted Bishop moves
+ * like Bishop or King, a promoted Rook like Rook or King.
+ *
+ * A captured piece switches sides and goes into the hand of the capturing
+ * side. Promoted pieces change back to their original types. A player may
+ * drop a piece in hand onto an empty square of the board. This counts as a
+ * move. Pawns, Lances, and Knights must not be dropped onto the highest
+ * ranks where they would be unable to move. Pawns must not be dropped onto
+ * files with own Pawns and must not be dropped to give mate immediately.
+ *
+ * A side must avert an attack on their King (check, ote 王手) immediately.
+ * It is forbidden to enter check. If there is no legal move to avert check
+ * then the side in check loses by checkmate (tsumi 詰み).
+ *
+ * When a game position occurs four times with the same player to move and
+ * the same pieces in hand for each player the game is drawn by repetition
+ * (sennichite, 千日手). If the situation has arisen from a perpetual check
+ * then the side giving check loses.
+ *
+ * \note Rules: http://en.wikipedia.org/wiki/Shogi
+ */
+class LIB_EXPORT ShogiBoard : public Board
+{
+	public:
+		/*! Creates a new ShogiBoard object. */
+		ShogiBoard();
+
+		// Inherited from Board
+		virtual Board* copy() const;
+		virtual QList<Piece> reservePieceTypes() const;
+		virtual QString variant() const;
+		virtual bool variantHasDrops() const;
+		virtual bool variantHasOptionalPromotions() const;
+		virtual QString defaultFenString() const;
+		virtual CoordinateSystem coordinateSystem() const;
+		virtual int width() const;
+		virtual int height() const;
+		virtual Result result();
+
+	protected:
+		/*!
+		 * Piece types for Shogi.
+		 */
+		enum ShogiPieceType
+		{
+			Pawn = 1,		//!< Foot Soldier P (Fuhyō) FU
+			Lance,			//!< Incense Chariot L (Kyōsha) KY
+			Knight,			//!< Cassia Horse N (Keima) KE
+			SilverGeneral,		//!< Silver General S (Ginshō) GI
+			GoldGeneral,            //!< Gold General G (Kinshō) KI
+			Bishop,			//!< Angle Mover B (Kakugyō) KA
+			Rook,			//!< Flying Chariot R (Hisha) HI
+			King,			//!< King General K (Ōshō) OU
+						//!< Jeweled General K (GyoKushō) OU
+			/*!
+			 * Promoted piece types for Shogi.
+			 * When they are captured they get demoted back.
+			 */
+			PromotedPawn,		//!< Reaches Gold +P (Tokin) TO
+			PromotedLance,		//!< Promoted Incense +L (Narikyō) NY
+			PromotedKnight,		//!< Promoted Cassia +N (Narikei) NK
+			PromotedSilver,		//!< Promoted Silver +S (Narigin) NG
+			PromotedBishop,		//!< Dragon *Horse* +B (Ryūma) UM
+			PromotedRook		//!< *Dragon* King +R (Ryūō) RY
+		};
+
+		/*! Movement mask for Knight moves. */
+		static const unsigned KnightMovement = 2;
+		/*! Movement mask for Bishop moves. */
+		static const unsigned BishopMovement = 4;
+		/*! Movement mask for Rook moves. */
+		static const unsigned RookMovement = 8;
+		/*! Movement mask for Ferz move pattern. */
+		static const unsigned FerzMovement = 16;
+		/*! Movement mask for Wazir move pattern. */
+		static const unsigned WazirMovement = 64;
+		/*! Movement mask for Lance moves. */
+		static const unsigned LanceMovement = 128;
+		/*! Movement mask for Silver General moves. */
+		static const unsigned SilverMovement = 256;
+		/*! Movement mask for Gold General moves. */
+		static const unsigned GoldMovement = 512;
+
+		/*!
+		 * Returns promoted piece type corresponding to normal \a type.
+		 */
+		virtual int promotedPieceType(int type) const;
+		/*!
+		 * Returns the lowest (relative) rank of the promotion zone.
+		 */
+		virtual int promotionRank() const;
+		/*!
+		 * Returns original piece type corresponding to promoted \a type.
+		 */
+		virtual int normalPieceType(int type) const;
+		/*!
+		 * Returns whether the current position has no pieces on
+		 * forbidden ranks.
+		 */
+		virtual bool ranksAreAllowed() const;
+		/*!
+		 * Returns true if the impassé point rule is active else false.
+		 */
+		virtual bool hasImpassePointRule() const;
+		/*!
+		 * Criteria of impasse rule limit given material value of
+		 * \a points and the number of \a pieces of the side to move
+		 * in the promotion zone.
+		 */
+		virtual Result impassePointRule(int points, int pieces) const;
+
+		// Inherited from Board
+		virtual int reserveType(int pieceType) const;
+		virtual void vInitialize();
+		virtual QString vFenString(FenNotation notation) const;
+		virtual bool vSetFenString(const QStringList& fen);
+		virtual QString lanMoveString(const Move& move);
+		virtual QString sanMoveString(const Move& move);
+		virtual Move moveFromLanString(const QString& str);
+		virtual Move moveFromSanString(const QString& str);
+		virtual void vMakeMove(const Move& move,
+				       BoardTransition* transition);
+		virtual void vUndoMove(const Move& move);
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual bool isLegalPosition();
+		virtual bool vIsLegalMove(const Move& move);
+		virtual bool inCheck(Side side, int square = 0) const;
+
+	private:
+		// Data for reversing/unmaking a move
+		struct MoveData
+		{
+			Piece capture;
+		};
+
+		bool rankIsAllowed(int pieceType, int square) const;
+		bool fileIsAllowed(int pieceType, int square) const;
+		bool inPromotionZone(int square) const;
+		Result resultFromImpassePointRule() const;
+
+		int m_kingSquare[2];
+		int m_promotionRank;
+		int m_minIndex;
+		int m_maxIndex;
+		int m_plyOffset;
+		bool m_multiDigitNotation;
+		bool m_hasImpassePointRule;
+
+		QVarLengthArray<int> m_bishopOffsets;
+		QVarLengthArray<int> m_rookOffsets;
+		QVarLengthArray<int> m_lanceOffsets[2];
+		QVarLengthArray<int> m_knightOffsets[2];
+		QVarLengthArray<int> m_silverGeneralOffsets[2];
+		QVarLengthArray<int> m_goldGeneralOffsets[2];
+		QVector<MoveData> m_history;
+};
+
+} // namespace Chess
+#endif // SHOGIBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1499,6 +1499,13 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 719731, 5 plies: 19861490, 6 plies: 547581517
 		<< Q_UINT64_C(19861490);
 
+	variant = "minishogi";
+	QTest::newRow("minishogi startpos")
+		<< variant
+		<< "rbsgk/4p/5/P4/KGSBR[-] w - 1"
+		<< 5 // 4 plies: 35401, 5 plies: 533203, 6 plies: 8276188
+		<< Q_UINT64_C(533203);
+
 	variant = "twokings";
 	QTest::newRow("twokings startpos")
 		<< variant

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1506,6 +1506,15 @@ void tst_Board::perft_data() const
 		<< 5 // 4 plies: 35401, 5 plies: 533203, 6 plies: 8276188
 		<< Q_UINT64_C(533203);
 
+	variant = "euroshogi";
+	QTest::newRow("euroshogi startpos")
+		<< variant
+		<< "1nbgkgn1/1r4b1/pppppppp/8/8/PPPPPPPP/1B4R1/1NGKGBN1[-] w - 1"
+		<< 4 // 3 plies: 15473, 4 plies: 382870, 5 plies: 9594120
+		// stockfish, sjaakii: 4 plies: 380499, 5 plies: 9451149, 6 plies: 234638669
+		// these programs force promotion on Knights in promotion zone
+		<< Q_UINT64_C(382870);
+
 	variant = "twokings";
 	QTest::newRow("twokings startpos")
 		<< variant

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -538,6 +538,16 @@ void tst_Board::moveStrings_data() const
 		<< "Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3 Kf5 Kb2 Ke5 Kb3"
 		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 0 1"
 		<< "8/8/8/4K3/8/1kf5/8/8[-] w - - 16 9";
+	QTest::newRow("shogi fen lan1 normal coordinates")
+		<< "shogi"
+		<< "P@e1 b5b4 a3b4 f1h1 g2g1 P@b5 b4a3 h1g1 h2g1 N@c5"
+		<< "lR4snl/4k1g2/pgnspp1p1/2p3p1p/1p2b4/P6P1/BSPP1PP1P/4G1GS1/LNK2r1NL[PPp] w - 32"
+		<< "lR4snl/4k1g2/pgnspp1p1/2p3p1p/1pn1b4/P6P1/BSPP1PP1P/4G4/LNK1P1S1L[RPPg] w - 37";
+	QTest::newRow("shogi fen san1 normal coordinates")
+		<< "shogi"
+		<< "P@e1 Pb4 Bxb4 Rxh1+ Gg1 P@b5 Ba3 +Rxg1 Sxg1 N@c5"
+		<< "lR4snl/4k1g2/pgnspp1p1/2p3p1p/1p2b4/P6P1/BSPP1PP1P/4G1GS1/LNK2r1NL[PPp] w - 32"
+		<< "lR4snl/4k1g2/pgnspp1p1/2p3p1p/1pn1b4/P6P1/BSPP1PP1P/4G4/LNK1P1S1L[RPPg] w - 37";
 	QTest::newRow("losalamos san1")
 		<< "losalamos"
 		<< "d3 d4"
@@ -972,6 +982,18 @@ void tst_Board::results_data() const
 	QTest::newRow("jesonmor no white pieces")
 		<< variant
 		<< "9/9/1n7/9/9/9/3n5/9/9 w - - 0 24"
+		<< "0-1";
+
+	variant = "shogi";
+
+	QTest::newRow("shogi Sente win")
+		<< variant
+		<< "+B3G+N+L1+B/2P1k4/ppSppp1pp/4r4/9/P8/3PPP2P/3KGg+r2/LN6L[NNLgsssppppp] b - 39"
+		<< "1-0";
+
+	QTest::newRow("shogi Gote win")
+		<< variant
+		<< "2G3BnR/2+N2+S1lp/p4ppsk/3P3ps/1pp6/P1g6/1P1K5/1SP2g3/L3+r4[GNNLPPPPPPblp] w - 98"
 		<< "0-1";
 
 	variant = "almost";
@@ -1469,6 +1491,13 @@ void tst_Board::perft_data() const
 		<< "nnnnnnnnn/9/9/9/9/9/9/9/NNNNNNNNN w - - 0 1"
 		<< 4 // 3 plies: 27960, 4 plies: 868624, 5 plies: 27756588/27882796
 		<< Q_UINT64_C(868624);
+
+	variant = "shogi";
+	QTest::newRow("shogi startpos")
+		<< variant
+		<< "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL[-] w 0 1"
+		<< 5 // 4 plies: 719731, 5 plies: 19861490, 6 plies: 547581517
+		<< Q_UINT64_C(19861490);
 
 	variant = "twokings";
 	QTest::newRow("twokings startpos")


### PR DESCRIPTION
This patch adds support four modern small board shogi variants:

_Minishogi_ (gogo shōgi)
5 x 5 board, 1970 by Shigenobu Kusumoto, Japan.
http://en.wikipedia.org/wiki/Minishogi

_Dobutsu Shogi_ (Animal Chess, "Catch the Lion")
3 x 4 board, 2009 by Madoka Kitao, Japan.
http://en.wikipedia.org/wiki/Dōbutsu_shōgi

_EuroShogi_
8 x 8 board, 2000 by Vladimír Pribylinec.
http://en.wikipedia.org/wiki/Euroshogi

_Judkins Shogi_
6 x 6 board, 1998 by Paul Judkins, UK.
http://en.wikipedia.org/wiki/Judkins_shogi

The implementation depends on `ShogiBoard`, ref. #539 .