### PR TITLE
Fix and generalize the book start option.

### DIFF
--- a/projects/lib/src/openingsuite.cpp
+++ b/projects/lib/src/openingsuite.cpp
@@ -19,6 +19,7 @@
 #include "openingsuite.h"
 #include <QFile>
 #include <QTextStream>
+#include <algorithm>
 #include "pgnstream.h"
 #include "epdrecord.h"
 #include "mersenne.h"
@@ -123,7 +124,7 @@ bool OpeningSuite::initialize()
 
 	if (m_order == RandomOrder)
 	{
-		// Create a shuffled vector of file positions
+		// Create a vector of file positions
 		for (;;)
 		{
 			FilePosition pos;
@@ -135,14 +136,14 @@ bool OpeningSuite::initialize()
 			if (pos.pos == -1)
 				break;
 
-			int i = Mersenne::random() % (m_filePositions.size() + 1);
-			if (i == m_filePositions.size())
-				m_filePositions.append(pos);
-			else
-			{
-				m_filePositions.append(m_filePositions.at(i));
-				m_filePositions[i] = pos;
-			}
+			m_filePositions.append(pos);
+		}
+
+		// use a Knuth shuffle to generate a random permutation
+                for (int i = 0; i <= m_filePositions.size() - 2; i++)
+		{
+			int j = i + Mersenne::random() % (m_filePositions.size() - i);
+			std::swap(m_filePositions[i], m_filePositions[j]);
 		}
 
 		if (m_startIndex > m_filePositions.size())

--- a/projects/lib/src/openingsuite.cpp
+++ b/projects/lib/src/openingsuite.cpp
@@ -146,7 +146,7 @@ bool OpeningSuite::initialize()
 			std::swap(m_filePositions[i], m_filePositions[j]);
 		}
 
-		if (m_startIndex > m_filePositions.size())
+		if (m_startIndex >= m_filePositions.size())
 			qWarning("Start index larger than book size, wrapping after %d.", m_filePositions.size());
 
 		m_gameIndex += m_startIndex % m_filePositions.size();


### PR DESCRIPTION
Fixes #550 and Fixes #552

* allow the start option to be larger than the number of positions in the book file, using wrapping semantics. Makes it easier to use (no need to know the size of the book, or to restart after N games where N is larger than the size of the book)

* fix the start option to work with epd opening books, right now it was ignored/overwritten.

* introduce the start option to work not only with sequential but also with random order, picking the appropriate location in the random stream.

* fix the generation of the random permutation of the book.

tested to behave as expected looking at a couple of corner cases (start=N, with N=size of the book, size + 1, size + N, etc)

Will also help fixing https://github.com/glinscott/fishtest/issues/478