### PR TITLE
Support hourglass time control

### DIFF
--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -154,6 +154,7 @@ bool parseEngine(const QStringList& args, EngineData& data)
 			}
 
 			data.tc.setInfinity(tc.isInfinite());
+			data.tc.setHourglass(tc.isHourglass());
 			data.tc.setTimePerTc(tc.timePerTc());
 			data.tc.setMovesPerTc(tc.movesPerTc());
 			data.tc.setTimeIncrement(tc.timeIncrement());

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -21,6 +21,7 @@
 #include "board/board.h"
 #include "chessplayer.h"
 #include "openingbook.h"
+#include "timecontrol.h"
 
 namespace {
 
@@ -278,6 +279,10 @@ void ChessGame::onMoveMade(const Chess::Move& move)
 	m_board->undoMove();
 
 	ChessPlayer* player = playerToWait();
+	if (player->timeControl()->isHourglass()
+	&&  sender->timeControl()->isHourglass())
+		player->addTime(sender->timeControl()->lastMoveTime());
+
 	player->makeMove(move);
 	m_board->makeMove(move);
 

--- a/projects/lib/src/chessplayer.cpp
+++ b/projects/lib/src/chessplayer.cpp
@@ -154,6 +154,12 @@ void ChessPlayer::setTimeControl(const TimeControl& timeControl)
 	m_timeControl = timeControl;
 }
 
+void ChessPlayer::addTime(int bonus)
+{
+	int timeLeft = m_timeControl.timeLeft();
+	m_timeControl.setTimeLeft(timeLeft + bonus);
+}
+
 Chess::Side ChessPlayer::side() const
 {
 	return m_side;

--- a/projects/lib/src/chessplayer.h
+++ b/projects/lib/src/chessplayer.h
@@ -105,6 +105,9 @@ class LIB_EXPORT ChessPlayer : public QObject
 		/*! Sets the time control for the player. */
 		void setTimeControl(const TimeControl& timeControl);
 
+		/*! Adds \a bonus to the time left for the player */
+		void addTime(int bonus);
+
 		/*! Returns the side of the player. */
 		Chess::Side side() const;
 

--- a/projects/lib/src/timecontrol.h
+++ b/projects/lib/src/timecontrol.h
@@ -89,6 +89,9 @@ class LIB_EXPORT TimeControl
 		/*! Returns true if the time control is infinite. */
 		bool isInfinite() const;
 
+		/*! Returns true if the time control is in hourglass mode */
+		bool isHourglass() const;
+
 		/*!
 		 * Returns the time per time control,
 		 * or 0 if there's no specified total time.
@@ -142,6 +145,12 @@ class LIB_EXPORT TimeControl
 		 * otherwise it is disabled.
 		 */
 		void setInfinity(bool enabled = true);
+
+		/*!
+		 * If \a enabled is true, hourglass time control is enabled;
+		 * otherwise it is disabled.
+		 */
+		void setHourglass(bool enabled = false);
 
 		/*! Sets the time per time control. */
 		void setTimePerTc(int timePerTc);
@@ -217,6 +226,7 @@ class LIB_EXPORT TimeControl
 		int m_expiryMargin;
 		bool m_expired;
 		bool m_infinite;
+		bool m_hourglass;
 		QElapsedTimer m_time;
 };
 


### PR DESCRIPTION
This PR adds support for an hourglass-style time control. In this mode the sum of time left for both sides is constant. The time a player used for a move is added to the opponent's available time.

If the time control is specified starting with the `hg` token then the hourglass-mode will be activated.

E.g.: `tc=hg360` means that a side has 360 seconds left at start. If the opponent uses tc=hg180 then there will be 540 seconds available for both sides in total.

Hourglass mode cannot be used with increments. It is active only for both sides else none.

There is no GUI support for hourglass mode yet.

Refers to #273.
