### PR TITLE
Fix problem with ignored pins in S-Chess

### DIFF
--- a/projects/lib/src/board/seirawanboard.cpp
+++ b/projects/lib/src/board/seirawanboard.cpp
@@ -78,6 +78,22 @@ QList<Piece> SeirawanBoard::reservePieceTypes() const
 	return list;
 }
 
+bool SeirawanBoard::vIsLegalMove(const Move& move)
+{
+	Q_ASSERT(!move.isNull());
+	int src = move.sourceSquare();
+
+	// Normal moves and promotions
+	if (move.promotion() == 0
+	||  !m_squareMap.contains(src)
+	||  m_squareMap[src] > 0)
+		return WesternBoard::vIsLegalMove(move);
+
+	// Channeling: the initial part of the move must be legal in chess
+	Move m(move.sourceSquare(), move.targetSquare());
+	return WesternBoard::vIsLegalMove(m);
+}
+
 void SeirawanBoard::addPromotions(int sourceSquare,
 				  int targetSquare,
 				  QVarLengthArray<Move>& moves) const

--- a/projects/lib/src/board/seirawanboard.h
+++ b/projects/lib/src/board/seirawanboard.h
@@ -38,7 +38,8 @@ namespace Chess {
  * after this square has been vacated for the first time. Squares that have
  * been vacant before can not be used for entry, nor squares where captures
  * removed the original pieces. Only one piece may enter per move. There is
- * no obligation to use the reserve pieces.
+ * no obligation to use the reserve pieces. The insertion of reserve pieces
+ * must not be used to block check.
  *
  * \note Rules: http://en.wikipedia.org/wiki/Seirawan_chess
  *
@@ -66,6 +67,7 @@ class LIB_EXPORT SeirawanBoard : public WesternBoard
 		virtual bool variantHasDrops() const;
 		virtual bool variantHasChanneling(Side side, int square) const;
 		virtual QList< Piece > reservePieceTypes() const;
+		virtual bool vIsLegalMove(const Chess::Move & move);
 		virtual void addPromotions(int sourceSquare,
 					   int targetSquare,
 					   QVarLengthArray<Move>& moves) const;


### PR DESCRIPTION
In S-chess the insertion of reserve pieces must not be used to block check.

Resolves #569