### PR TITLE
Sittuyin: Do not allow promotions to attack an opponent piece directly.

### DIFF
--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -228,18 +228,15 @@ void SittuyinBoard::vUndoMove(const Move& move)
 bool SittuyinBoard::vIsLegalMove(const Move& move)
 {
 	int promotion = move.promotion();
-	Side side = sideToMove();
-	Side opp = side.opposite();
-	int oppKingSquare = kingSquare(opp);
 
-	// Pawn promotion: must not give check
+	// Pawn promotion: must neither give check nor attack the opponent directly
 	if (!m_inSetUp && promotion == General)
 	{
 		QVarLengthArray<Move> moves;
 		generateMovesForPiece(moves, General, move.targetSquare());
 		for (const Move& m: moves)
 		{
-			if (m.targetSquare() == oppKingSquare)
+			if (captureType(m) != Piece::NoPiece)
 				return false;
 		}
 	}

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -1435,11 +1435,21 @@ void tst_Board::perft_data() const
 		<< "8/8/4pppp/pppp4/4PPPP/PPPP4/8/8[KFRRSSNNkfrrssnn] w - 0 0 1"
 		<< 3 // 1 ply: 88, 2 plies: 7744, 3 plies: 580096, 4 plies: 43454464
 		<< Q_UINT64_C(580096);
-	QTest::newRow("sittuyin midgame")
+	QTest::newRow("sittuyin midgame 1")
 		<< variant
 		<< "8/8/6R1/s3r3/P5R1/1KP3p1/1F2kr2/8[-] b - 0 0 72"
-		<< 4 // 1 ply: 35, 2 plies: 825, 3 plies: 26791, 4 plies: 657824
-		<< Q_UINT64_C(657824);
+		<< 4 // 1 ply: 35, 2 plies: 825, 3 plies: 26596, 4 plies: 652686
+		<< Q_UINT64_C(652686);
+	QTest::newRow("sittuyin midgame 2")
+		<< variant
+		<< "2r5/6k1/6p1/3s2P1/3npR2/8/p2N2F1/3K4[] w - - 1 50"
+		<< 4 // 1 ply: 21, 2 plies: 656, 3 plies: 12939, 4 plies: 373984
+		<< Q_UINT64_C(373984);
+	QTest::newRow("sittuyin midgame 3")
+		<< variant
+		<< "8/6s1/5P2/3n4/pR2K2S/1P6/1k4p1/8[] w - - 1 50"
+		<< 4 // 1 ply: 22, 2 plies: 557, 3 plies: 11912, 4 plies: 268869
+		<< Q_UINT64_C(268869);
 	QTest::newRow("sittuyin promotion1")
 		<< variant
 		<< "8/8/S2P1k2/8/8/8/8/4K3[-] w - - 0 9"


### PR DESCRIPTION
This fix implements missing Sittuyin rule 3.9 c.4.

Thanks to @teakado, @gbtami and @ianfab for pointing this out.
Ref.: https://github.com/ianfab/Fairy-Stockfish/issues/14