### PR TITLE
GUI: Add hourglass time control

### DIFF
--- a/projects/gui/src/timecontroldlg.cpp
+++ b/projects/gui/src/timecontroldlg.cpp
@@ -33,6 +33,8 @@ TimeControlDialog::TimeControlDialog(const TimeControl& tc,
 		this, SLOT(onTimePerMoveSelected()));
 	connect(ui->m_infiniteRadio, SIGNAL(clicked()),
 		this, SLOT(onInfiniteSelected()));
+	connect(ui->m_hourglassRadio, SIGNAL(clicked()),
+		this, SLOT(onHourglassSelected()));
 
 	if (!tc.isValid())
 		return;
@@ -41,6 +43,12 @@ TimeControlDialog::TimeControlDialog(const TimeControl& tc,
 	{
 		ui->m_infiniteRadio->setChecked(true);
 		onInfiniteSelected();
+	}
+	else if (tc.isHourglass())
+	{
+		ui->m_hourglassRadio->setChecked(true);
+		setTime(tc.timePerTc());
+		onHourglassSelected();
 	}
 	else if (tc.timePerMove() != 0)
 	{
@@ -94,6 +102,15 @@ void TimeControlDialog::onInfiniteSelected()
 	ui->m_marginSpin->setEnabled(false);
 }
 
+void TimeControlDialog::onHourglassSelected()
+{
+	ui->m_movesSpin->setEnabled(false);
+	ui->m_timeSpin->setEnabled(true);
+	ui->m_timeUnitCombo->setEnabled(true);
+	ui->m_incrementSpin->setEnabled(false);
+	ui->m_marginSpin->setEnabled(true);
+}
+
 int TimeControlDialog::timeToMs() const
 {
 	switch (ui->m_timeUnitCombo->currentIndex())
@@ -142,6 +159,12 @@ TimeControl TimeControlDialog::timeControl() const
 		tc.setMovesPerTc(ui->m_movesSpin->value());
 		tc.setTimePerTc(timeToMs());
 		tc.setTimeIncrement(ui->m_incrementSpin->value() * 1000.0);
+	}
+	else if (ui->m_hourglassRadio->isChecked())
+	{
+		tc.setHourglass(true);
+		tc.setTimePerTc(timeToMs());
+		tc.setTimeIncrement(0);
 	}
 
 	tc.setNodeLimit(ui->m_nodesSpin->value());

--- a/projects/gui/src/timecontroldlg.h
+++ b/projects/gui/src/timecontroldlg.h
@@ -51,6 +51,7 @@ class TimeControlDialog : public QDialog
 		void onTournamentSelected();
 		void onTimePerMoveSelected();
 		void onInfiniteSelected();
+		void onHourglassSelected();
 
 	private:
 		enum TimeUnit

--- a/projects/gui/ui/timecontroldlg.ui
+++ b/projects/gui/ui/timecontroldlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>284</width>
-    <height>367</height>
+    <width>289</width>
+    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,6 +62,16 @@
         </property>
         <property name="text">
          <string>Infinite</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="m_hourglassRadio">
+        <property name="toolTip">
+         <string>Time used is added to opponent's available time</string>
+        </property>
+        <property name="text">
+         <string>Hourglass</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This patch adds initial support of the new hourglass time control to the GUI.
A new radio button is added to the time control dialog.

Reference: Feature request #273

This implementation does not add a textual or graphical indicator to the clock.
Such an indicator may be useful for extensions like hourglass mode or paused games.

This implementation is independent of a possible protocol update for engines.
It should work for existing engines and human players.

I hope this is useful.