### PR TITLE
Also add time increment before the first move (TimeControl::initialize)

### DIFF
--- a/projects/lib/src/timecontrol.cpp
+++ b/projects/lib/src/timecontrol.cpp
@@ -218,7 +218,7 @@ void TimeControl::initialize()
 
 	if (m_timePerTc != 0)
 	{
-		m_timeLeft = m_timePerTc;
+		m_timeLeft = m_timePerTc + m_increment;
 		m_movesLeft = m_movesPerTc;
 	}
 	else if (m_timePerMove != 0)


### PR DESCRIPTION
Achieves more compliance with FIDE rules

[FIDE rules, Glossary, p. 31](http://rules.fide.com/images/stories/Laws_of_Chess_2018_-_EB_approved_-_clean_version.pdf)
> increment: 6.1. An amount of time (from 2 to 60 seconds) added from the start before each
move for the player. This can be in either delay or cumulative mode.

E.g. for 5 Minutes with 3 seconds increment the clocks would start at 5:03 instead of 5:00.
Resolves #451.

Book moves still are not awarded increments in order to stabilize testing conditions.