### PR TITLE
Fix the initial ply count for bare king in ASEAN and Sittuyin

### DIFF
--- a/projects/lib/src/board/aseanboard.cpp
+++ b/projects/lib/src/board/aseanboard.cpp
@@ -77,6 +77,11 @@ MakrukBoard::CountingRules AseanBoard::countingRules() const
 	return BareKing;
 }
 
+int AseanBoard::initialPlyCount() const
+{
+	return 0;
+}
+
 int AseanBoard::countingLimit() const
 {
 	// ASEAN-Chess Article 5.2e

--- a/projects/lib/src/board/aseanboard.h
+++ b/projects/lib/src/board/aseanboard.h
@@ -76,6 +76,7 @@ class LIB_EXPORT AseanBoard : public MakrukBoard
 		virtual void addPromotions(int sourceSquare,
 					   int targetSquare,
 					   QVarLengthArray< Move >& moves) const;
+		virtual int initialPlyCount() const;
 		virtual int countingLimit() const;
 		virtual CountingRules countingRules() const;
 		virtual Result result();

--- a/projects/lib/src/board/makrukboard.cpp
+++ b/projects/lib/src/board/makrukboard.cpp
@@ -159,6 +159,11 @@ bool MakrukBoard::inCheck(Side side, int square) const
 	return ShatranjBoard::inCheck(side, square);
 }
 
+int MakrukBoard::initialPlyCount() const
+{
+	return 2 * pieceCount();
+}
+
 void MakrukBoard::vMakeMove(const Move& move, BoardTransition* transition)
 {
 	int capture = captureType(move);
@@ -205,7 +210,7 @@ void MakrukBoard::vMakeMove(const Move& move, BoardTransition* transition)
 	&&  (m_rules == BareKing || noPawns))
 	{
 		md.piecesHonour = true;
-		md.plyCount = 2 * pieceCount();
+		md.plyCount = initialPlyCount();
 		md.countingLimit = noPawns ? 2 * countingLimit() : 2 * 64;
 	}
 

--- a/projects/lib/src/board/makrukboard.h
+++ b/projects/lib/src/board/makrukboard.h
@@ -120,6 +120,10 @@ class LIB_EXPORT MakrukBoard : public ShatranjBoard
 		int pieceCount(Side side = Side::NoSide,
 			       int pieceType = Piece::NoPiece) const;
 		/*!
+		 * Returns ply count if counting is started in current position
+		 */
+		virtual int initialPlyCount() const;
+		/*!
 		 * Returns maximum count of plies allowed to finish the game:
 		 * Limit for Board's Honour or Pieces' Honour counting.
 		 */

--- a/projects/lib/src/board/sittuyinboard.cpp
+++ b/projects/lib/src/board/sittuyinboard.cpp
@@ -266,6 +266,11 @@ bool SittuyinBoard::isLegalPosition()
 	return true;
 }
 
+int SittuyinBoard::initialPlyCount() const
+{
+	return 0;
+}
+
 int SittuyinBoard::countingLimit() const
 {
 	// analoguous to ASEAN-Chess Article 5.2e

--- a/projects/lib/src/board/sittuyinboard.h
+++ b/projects/lib/src/board/sittuyinboard.h
@@ -112,6 +112,7 @@ class LIB_EXPORT SittuyinBoard : public MakrukBoard
 		virtual int promotionRank(int file = 0) const;
 		virtual bool vIsLegalMove(const Move& move);
 		virtual bool isLegalPosition();
+		virtual int initialPlyCount() const;
 		virtual int countingLimit() const;
 		virtual CountingRules countingRules() const;
 		virtual Result result();


### PR DESCRIPTION
 In _Makruk_ and _Ouk_ the weaker side initially adds the total number of pieces on the board to their move count. However, in _Sittuyin_ and _ASEAN_ the bare king move counting starts with no offset.

 Ref.: Article 5e of ASEAN chess rules https://aseanchess.org/laws-of-asean-chess/ and Article 5e of Sittuyin rules.

