### PR TITLE
Add support for r-mobility (https://wiki.chessdom.org/R-Mobility)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -220,6 +220,9 @@ Only use tablebase adjudication for positions with
 pieces or less.
 .It Fl tbignore50
 Disable the fifty move rule for tablebase adjudication.
+.It Fl rmobility
+Score match using r-mobility and disable insufficient material adjudication.
+Warning: if any adjudication is enabled, this will make r-mobility scoring inconsistent.
 .It Fl tournament Ar type
 Set the tournament type, where
 .Ar type

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -105,6 +105,9 @@ Options:
   -tbpieces N		Only use tablebase adjudication for positions with
 			N pieces or less.
   -tbignore50		Disable the fifty move rule for tablebase adjudication.
+  -rmobility		Score match using r-mobility and disable insufficient
+			material adjudication. Warning: if any adjudication is enabled,
+			this will make r-mobility scoring inconsistent.
   -tournament TYPE	Set the tournament type to TYPE, which can be one of:
 			'round-robin': Round-robin tournament (default)
 			'gauntlet': First engine(s) against the rest

--- a/projects/cli/src/enginematch.cpp
+++ b/projects/cli/src/enginematch.cpp
@@ -133,6 +133,14 @@ void EngineMatch::onGameFinished(ChessGame* game, int number)
 		      fcp.wins(), scp.wins(), fcp.draws(),
 		      double(fcp.score()) / (totalResults * 2),
 		      totalResults);
+		if (game->result().rMobility().isValid()) {
+			QString rMobilityScore = QString("R-mobility: %0 - %1 [%2] %3")
+			.arg(fcp.rMobilityScore())
+			.arg(scp.rMobilityScore())
+			.arg(double(fcp.rMobilityScore()) / (fcp.rMobilityScore() + scp.rMobilityScore()), 0, 'f', 3)
+			.arg(totalResults);
+			qInfo("...      %s", qUtf8Printable(rMobilityScore));
+		}
 	}
 
 	if (m_ratingInterval != 0

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -250,6 +250,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-tb", QVariant::String, 1, 1);
 	parser.addOption("-tbpieces", QVariant::Int, 1, 1);
 	parser.addOption("-tbignore50", QVariant::Bool, 0, 0);
+	parser.addOption("-rmobility", QVariant::Bool, 0, 0);
 	parser.addOption("-event", QVariant::String, 1, 1);
 	parser.addOption("-games", QVariant::Int, 1, 1);
 	parser.addOption("-rounds", QVariant::Int, 1, 1);
@@ -322,6 +323,9 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 			if (ok)
 				manager->setConcurrency(value.toInt());
 		}
+		// Whether to enable r-mobility scoring
+		else if (name == "-rmobility")
+			adjudicator.setRMobilityEnabled(true);
 		// Threshold for draw adjudication
 		else if (name == "-draw")
 		{

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -242,6 +242,11 @@ class LIB_EXPORT Board
 		void undoMove();
 
 		/*!
+		 * Informs the board object that it should now calculate r-mobility if it supports it.
+		 */
+		virtual void vCalculateRMobility() { /*does nothing by default*/ }
+
+		/*!
 		 * Converts a Move into a string.
 		 *
 		 * \note The board must be in a position where \a move can be made.
@@ -286,6 +291,13 @@ class LIB_EXPORT Board
 		 * the game is in progress.
 		 */
 		virtual Result result() = 0;
+		/*!
+		 * Returns the result of the game, or Result::NoResult if
+		 * the game is in progress and honors the r-mobility setting by
+		 * disabling insufficient material adjudication for instance if
+		 * the board supports r-mobility scoring.
+		 */
+		virtual Result result(bool rMobilityEnabled) { Q_UNUSED(rMobilityEnabled); return result(); }
 		/*!
 		 * Returns the expected game result according to endgame tablebases.
 		 *

--- a/projects/lib/src/board/result.cpp
+++ b/projects/lib/src/board/result.cpp
@@ -56,14 +56,16 @@ bool Result::operator==(const Result& other) const
 {
 	return (m_type == other.m_type &&
 		m_winner == other.m_winner &&
-		m_description == other.m_description);
+		m_description == other.m_description &&
+		m_rMobility == other.m_rMobility);
 }
 
 bool Result::operator!=(const Result& other) const
 {
 	return (m_type != other.m_type ||
 		m_winner != other.m_winner ||
-		m_description != other.m_description);
+		m_description != other.m_description ||
+		m_rMobility != other.m_rMobility);
 }
 
 bool Result::isNone() const
@@ -175,9 +177,29 @@ QString Result::toShortString() const
 	return "1/2-1/2";
 }
 
+QString Result::toShortStringWithRMobility() const
+{
+	if (m_type == NoResult || m_type == ResultError)
+		return "*";
+	if (m_winner == Side::White)
+		return "1-0";
+	if (m_winner == Side::Black)
+		return "0-1";
+	if (m_rMobility.isValid())
+		return m_rMobility.toString();
+	return "1/2-1/2";
+}
+
+QString Result::toRMobilityString() const
+{
+	if (!m_rMobility.isValid() || m_type == NoResult || m_type == ResultError)
+		return "*";
+	return m_rMobility.toString();
+}
+
 QString Result::toVerboseString() const
 {
-	return toShortString() + QString(" {") + description() + "}";
+	return toShortStringWithRMobility() + QString(" {") + description() + "}";
 }
 
 } // namespace Chess

--- a/projects/lib/src/board/result.h
+++ b/projects/lib/src/board/result.h
@@ -22,6 +22,7 @@
 #include "side.h"
 #include <QMetaType>
 #include <QCoreApplication>
+#include <cmath>
 
 namespace Chess {
 
@@ -43,6 +44,14 @@ public:
 	void setResult(float r) { m_result = r; }
 	Side winning() const { return m_winning; }
 	void setWinning(Side side) { m_winning = side; }
+	float score(Side side) const
+	{
+		float winningScore = 0.5f + powf(0.5f, 1.0f + ceilf(m_result));
+		if (side == m_winning)
+			return winningScore;
+		else
+			return 1.0f - winningScore;
+	}
 	QString toString() const
 	{
 		if (!isValid())

--- a/projects/lib/src/board/result.h
+++ b/projects/lib/src/board/result.h
@@ -26,6 +26,47 @@
 namespace Chess {
 
 /*!
+ * \brief The r-mobility (https://wiki.chessdom.org/R-Mobility) result of a chess game
+ *
+ * The RMobilityResult class is used to store the rmobility result of a chess game,
+ * and to compare it to other results.
+ */
+class LIB_EXPORT RMobility
+{
+	Q_DECLARE_TR_FUNCTIONS(RMobility)
+public:
+	explicit RMobility() : m_isValid(false), m_result(0.0f), m_winning(Side::White) {}
+	explicit RMobility(float r, Side w) : m_isValid(true), m_result(r), m_winning(w) {}
+	bool isValid() const { return m_isValid; }
+	void reset() { m_isValid = false; m_result = 0.0; m_winning = Side::White; }
+	float result() const { return m_result; }
+	void setResult(float r) { m_result = r; }
+	Side winning() const { return m_winning; }
+	void setWinning(Side side) { m_winning = side; }
+	QString toString() const
+	{
+		if (!isValid())
+			return QString();
+		return QString("%0G%1").arg(m_winning == Side::White ? "" : "-").arg(m_result, 0, 'f', 1);
+	}
+	inline bool operator==(const RMobility& other) const
+	{
+		return m_isValid == other.m_isValid && m_result == other.m_result &&
+			m_winning == other.m_winning;
+	}
+	bool operator!=(const RMobility& other) const
+	{
+		return m_isValid != other.m_isValid || m_result != other.m_result ||
+			m_winning != other.m_winning;
+	}
+
+private:
+	bool m_isValid;
+	float m_result;
+	Side m_winning;
+};
+
+/*!
  * \brief The result of a chess game
  *
  * The Result class is used to store the result of a chess game,
@@ -102,6 +143,17 @@ class LIB_EXPORT Result
 		 */
 		QString toShortString() const;
 		/*!
+		 * Returns the short string representation of the result.
+		 * Can be "1-0", "0-1", "G0.5, G1.5, etc", or "*".
+		*/
+		QString toShortStringWithRMobility() const;
+
+		/*!
+		* Returns the r-mobility string representation of the result.
+		* Can be "G0.0", "-G0.0", "G0.5, G1.5, etc", or "*".
+		*/
+		QString toRMobilityString() const;
+		/*!
 		 * Returns the verbose string representation of the result.
 		 *
 		 * Uses the format "result {description}".
@@ -109,10 +161,14 @@ class LIB_EXPORT Result
 		 */
 		QString toVerboseString() const;
 
+		RMobility rMobility() const { return m_rMobility; }
+		void setRMobility(const RMobility &r) { m_rMobility = r; }
+
 	private:
 		Type m_type;
 		Side m_winner;
 		QString m_description;
+		RMobility m_rMobility;
 };
 
 } // namespace Chess

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -58,6 +58,7 @@ class LIB_EXPORT WesternBoard : public Board
 		virtual int width() const;
 		virtual int height() const;
 		virtual Result result();
+		virtual Result result(bool rMobilityEnabled);
 		virtual int reversibleMoveCount() const;
 
 	protected:
@@ -213,6 +214,7 @@ class LIB_EXPORT WesternBoard : public Board
 		virtual void vMakeMove(const Move& move,
 				       BoardTransition* transition);
 		virtual void vUndoMove(const Move& move);
+		virtual void vCalculateRMobility();
 		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
 						   int pieceType,
 						   int square) const;
@@ -237,6 +239,7 @@ class LIB_EXPORT WesternBoard : public Board
 			CastlingRights castlingRights;
 			CastlingSide castlingSide;
 			int reversibleMoveCount;
+			RMobility rMobility;
 		};
 
 		void generateCastlingMoves(QVarLengthArray<Move>& moves) const;
@@ -255,6 +258,8 @@ class LIB_EXPORT WesternBoard : public Board
 		 *  given \a step with orientation \a sign. */
 		inline int pawnPushOffset(const PawnStep& ps,
 					  int sign) const;
+		void setReversibleMoveCount(int moveCount);
+		void undoReversibleMoveCount(int moveCount, RMobility rMobility);
 
 		int m_arwidth;
 		int m_sign;
@@ -263,6 +268,7 @@ class LIB_EXPORT WesternBoard : public Board
 		int m_enpassantTarget;
 		int m_plyOffset;
 		int m_reversibleMoveCount;
+		RMobility m_rMobility;
 		bool m_kingCanCapture;
 		bool m_hasCastling;
 		bool m_pawnHasDoubleStep;

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -267,7 +267,10 @@ void ChessGame::onMoveMade(const Chess::Move& move)
 
 	// Get the result before sending the move to the opponent
 	m_board->makeMove(move);
-	m_result = m_board->result();
+	const bool useRMobility = m_adjudicator.rMobilityEnabled();
+	if (useRMobility)
+		m_board->vCalculateRMobility();
+	m_result = m_board->result(useRMobility);
 	if (m_result.isNone())
 	{
 		if (m_board->reversibleMoveCount() == 0)
@@ -285,6 +288,8 @@ void ChessGame::onMoveMade(const Chess::Move& move)
 
 	player->makeMove(move);
 	m_board->makeMove(move);
+	if (useRMobility)
+		m_board->vCalculateRMobility();
 
 	if (m_result.isNone())
 	{

--- a/projects/lib/src/gameadjudicator.cpp
+++ b/projects/lib/src/gameadjudicator.cpp
@@ -29,7 +29,8 @@ GameAdjudicator::GameAdjudicator()
 	  m_resignScore(0),
 	  m_twoSided(false),
 	  m_maxGameLength(0),
-	  m_tbEnabled(false)
+	  m_tbEnabled(false),
+	  m_rMobilityEnabled(false)
 {
 	m_resignScoreCount[0] = 0;
 	m_resignScoreCount[1] = 0;
@@ -159,4 +160,14 @@ void GameAdjudicator::resetDrawMoveCount()
 Chess::Result GameAdjudicator::result() const
 {
 	return m_result;
+}
+
+bool GameAdjudicator::rMobilityEnabled() const
+{
+	return m_rMobilityEnabled;
+}
+
+void GameAdjudicator::setRMobilityEnabled(bool b)
+{
+	m_rMobilityEnabled = b;
 }

--- a/projects/lib/src/gameadjudicator.h
+++ b/projects/lib/src/gameadjudicator.h
@@ -97,6 +97,16 @@ class LIB_EXPORT GameAdjudicator
 		 */
 		Chess::Result result() const;
 
+		/*!
+		 * Returns whether r-mobility is enabled.
+		 */
+		bool rMobilityEnabled() const;
+
+		/*!
+		 * Sets r-mobility enabled flag.
+		 */
+		void setRMobilityEnabled(bool);
+
 	private:
 		int m_drawMoveNum;
 		int m_drawMoveCount;
@@ -110,6 +120,7 @@ class LIB_EXPORT GameAdjudicator
 		int m_maxGameLength;
 		bool m_tbEnabled;
 		Chess::Result m_result;
+		bool m_rMobilityEnabled;
 };
 
 #endif // GAMEADJUDICATOR_H

--- a/projects/lib/src/knockouttournament.cpp
+++ b/projects/lib/src/knockouttournament.cpp
@@ -130,7 +130,7 @@ int KnockoutTournament::gamesPerCycle() const
 	return total;
 }
 
-void KnockoutTournament::addScore(int player, Chess::Side side, int score)
+void KnockoutTournament::addScore(int player, Chess::Side side, int score, float rMobilityScore)
 {
 	for (TournamentPair* pair : m_rounds.last())
 	{
@@ -146,7 +146,7 @@ void KnockoutTournament::addScore(int player, Chess::Side side, int score)
 		}
 	}
 
-	Tournament::addScore(player, side, score);
+	Tournament::addScore(player, side, score, rMobilityScore);
 }
 
 QList<int> KnockoutTournament::lastRoundWinners() const

--- a/projects/lib/src/knockouttournament.h
+++ b/projects/lib/src/knockouttournament.h
@@ -47,7 +47,7 @@ class LIB_EXPORT KnockoutTournament : public Tournament
 		virtual void initializePairing();
 		virtual int gamesPerCycle() const;
 		virtual TournamentPair* nextPair(int gameNumber);
-		virtual void addScore(int player, Chess::Side side, int score);
+		virtual void addScore(int player, Chess::Side side, int score, float rMobilityScore);
 		virtual bool areAllGamesFinished() const;
 
 	private:

--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -461,6 +461,8 @@ void PgnGame::setPlayerName(Chess::Side side, const QString& name)
 void PgnGame::setResult(const Chess::Result& result)
 {
 	setTag("Result", result.toShortString());
+	if (result.rMobility().isValid())
+		setTag("RMobilityResult", result.toRMobilityString());
 
 	switch (result.type())
 	{

--- a/projects/lib/src/tournament.cpp
+++ b/projects/lib/src/tournament.cpp
@@ -599,9 +599,9 @@ bool Tournament::writeEpd(ChessGame *game)
 	return ok;
 }
 
-void Tournament::addScore(int player, Chess::Side side, int score)
+void Tournament::addScore(int player, Chess::Side side, int score, float rMobilityScore)
 {
-	m_players[player].addScore(side, score);
+	m_players[player].addScore(side, score, rMobilityScore);
 }
 
 void Tournament::onGameStarted(ChessGame* game)
@@ -640,23 +640,26 @@ void Tournament::onGameFinished(ChessGame* game)
 	if (!blackName.isEmpty())
 		m_players[iBlack].setName(blackName);
 
+	float whiteRMobility = game->result().rMobility().score(Chess::Side::White);
+	float blackRMobility = game->result().rMobility().score(Chess::Side::Black);
+
 	switch (game->result().winner())
 	{
 	case Chess::Side::White:
-		addScore(iWhite, Chess::Side::White, 2);
-		addScore(iBlack, Chess::Side::Black, 0);
+		addScore(iWhite, Chess::Side::White, 2, whiteRMobility);
+		addScore(iBlack, Chess::Side::Black, 0, blackRMobility);
 		sprtResult = (iWhite == 0) ? Sprt::Win : Sprt::Loss;
 		break;
 	case Chess::Side::Black:
-		addScore(iBlack, Chess::Side::Black, 2);
-		addScore(iWhite, Chess::Side::White, 0);
+		addScore(iBlack, Chess::Side::Black, 2, blackRMobility);
+		addScore(iWhite, Chess::Side::White, 0, whiteRMobility);
 		sprtResult = (iBlack == 0) ? Sprt::Win : Sprt::Loss;
 		break;
 	default:
 		if (game->result().isDraw())
 		{
-			addScore(iWhite,  Chess::Side::White, 1);
-			addScore(iBlack,  Chess::Side::Black, 1);
+			addScore(iWhite,  Chess::Side::White, 1, whiteRMobility);
+			addScore(iBlack,  Chess::Side::Black, 1, blackRMobility);
 			sprtResult = Sprt::Draw;
 		}
 		break;

--- a/projects/lib/src/tournament.h
+++ b/projects/lib/src/tournament.h
@@ -429,7 +429,7 @@ class LIB_EXPORT Tournament : public QObject
 		 * 1-0, 0-1 or 1/2-1/2 result. Subclasses can reimplement this
 		 * to do their own score tracking.
 		 */
-		virtual void addScore(int player, Chess::Side side, int score);
+		virtual void addScore(int player, Chess::Side side, int score, float rMobilityScore);
 		/*!
 		 * Returns true if all games in the tournament have finished;
 		 * otherwise returns false.

--- a/projects/lib/src/tournamentplayer.cpp
+++ b/projects/lib/src/tournamentplayer.cpp
@@ -32,7 +32,8 @@ TournamentPlayer::TournamentPlayer(PlayerBuilder* builder,
 	  m_losses(0),
 	  m_whiteWins(0),
 	  m_whiteDraws(0),
-	  m_whiteLosses(0)
+	  m_whiteLosses(0),
+	  m_rMobilityScore(0.0f)
 {
 	Q_ASSERT(builder != nullptr);
 }
@@ -118,7 +119,12 @@ int TournamentPlayer::score() const
 	return m_wins * 2 + m_draws;
 }
 
-void TournamentPlayer::addScore(Chess::Side side, int score)
+float TournamentPlayer::rMobilityScore() const
+{
+	return m_rMobilityScore;
+}
+
+void TournamentPlayer::addScore(Chess::Side side, int score, float rMobilityScore)
 {
 	if (side == Chess::Side::NoSide)
 		Q_UNREACHABLE();
@@ -147,6 +153,8 @@ void TournamentPlayer::addScore(Chess::Side side, int score)
 		Q_UNREACHABLE();
 		break;
 	}
+	if (rMobilityScore > 0)
+		m_rMobilityScore += rMobilityScore;
 }
 
 int TournamentPlayer::gamesFinished() const

--- a/projects/lib/src/tournamentplayer.h
+++ b/projects/lib/src/tournamentplayer.h
@@ -94,8 +94,10 @@ class LIB_EXPORT TournamentPlayer
 		int blackLosses() const;
 		/*! Returns the player's total score in the tournament. */
 		int score() const;
+		/*! Returns the player's r-mobility score in the tournament. */
+		float rMobilityScore() const;
 		/*! Adds \a score to the player's score in the tournament. */
-		void addScore(Chess::Side side, int score);
+		void addScore(Chess::Side side, int score, float rMobilityScore);
 		/*!
 		 * Returns the total number of games the player has finished
 		 * in the tournament.
@@ -113,6 +115,7 @@ class LIB_EXPORT TournamentPlayer
 		int m_whiteWins;
 		int m_whiteDraws;
 		int m_whiteLosses;
+		float m_rMobilityScore;
 };
 
 #endif // TOURNAMENTPLAYER_H


### PR DESCRIPTION
    Introduce support for r-mobility (https://wiki.chessdom.org/R-Mobility).
    
    * Adds basic support for scoring via r-mobility
    * Outputs r-mobility score at end of game
    * Adds RMobilityResult tag to pgnout
    * Adds '-rmobility' flag to cutechess-cli which disables insufficient
      material adjudication
    * Add support for r-mobility scoring based on point system.