### PR TITLE
GUI equivalent to the CLI option -reverse to reverse schedule for sides

### DIFF
--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -298,6 +298,7 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 	t->setRecoveryMode(ts->engineRecovery());
 	t->setPgnWriteUnfinishedGames(ts->savingOfUnfinishedGames());
 	t->setSwapSides(ts->swappingSides());
+	t->setReverseSides(ts->reversingSchedule());
 	t->setResultFormat(ts->resultFormat());
 
 	const auto engines = m_addedEnginesManager->engines();

--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -141,6 +141,11 @@ bool TournamentSettingsWidget::swappingSides() const
 	return ui->m_swapCheck->isChecked();
 }
 
+bool TournamentSettingsWidget::reversingSchedule() const
+{
+	return ui->m_reverseCheck->isChecked();
+}
+
 QString TournamentSettingsWidget::resultFormat() const
 {
 	return ui->m_resultFormatEdit->text();
@@ -171,6 +176,7 @@ void TournamentSettingsWidget::readSettings()
 	ui->m_saveUnfinishedGamesCheck->setChecked(
 		s.value("save_unfinished_games", true).toBool());
 	ui->m_swapCheck->setChecked(s.value("swap_sides", true).toBool());
+	ui->m_reverseCheck->setChecked(s.value("reverse_schedule", false).toBool());
 
 	QString format = s.value("result_format").toString();
 	if (format.isEmpty())
@@ -248,6 +254,10 @@ void TournamentSettingsWidget::enableSettingsUpdates()
 	connect(ui->m_swapCheck, &QCheckBox::toggled, [=](bool checked)
 	{
 		QSettings().setValue("tournament/swap_sides", checked);
+	});
+	connect(ui->m_reverseCheck, &QCheckBox::toggled, [=](bool checked)
+	{
+		QSettings().setValue("tournament/reverse_schedule", checked);
 	});
 	connect(ui->m_resultFormatEdit, &QLineEdit::textChanged, [=](const QString &text)
 	{

--- a/projects/gui/src/tournamentsettingswidget.h
+++ b/projects/gui/src/tournamentsettingswidget.h
@@ -42,6 +42,7 @@ class TournamentSettingsWidget : public QWidget
 		bool engineRecovery() const;
 		bool savingOfUnfinishedGames() const;
 		bool swappingSides() const;
+		bool reversingSchedule() const;
 		QString resultFormat() const;
 
 		void enableSettingsUpdates();

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>419</width>
-    <height>436</height>
+    <height>497</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -259,6 +259,16 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QCheckBox" name="m_reverseCheck">
+        <property name="toolTip">
+         <string>Reverse sides in schedule: A vs B, C vs D ... to  B vs A, D vs C ... (default: false)</string>
+        </property>
+        <property name="text">
+         <string>Reverse schedule</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This patch adds a checkbox `Reverse schedule` to the tournament settings. If checked, the color schedule for the tournament is reversed, i. e. a sequence` PlayerA vs PlayerB, PlayerC vs PlayerD, ...` is transformed into `PlayerB vs PlayerA, PlayerD vs PlayerC ... `. The CLI already has the option `-reverse` to do this.

When swapping of sides is deactivated a gauntlet player then plays a sequence of games with Black instead of White.

Completion  /wrt feature request, resolves #520, resolves #521 .
@Oragonon: I forgot the request was related to the GUI, not the CLI.
