### PR TITLE
Enhance the output of tournament and game results

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -281,6 +281,10 @@ is reached.
 Set the interval for printing the ratings to
 .Ar n
 games.
+.It Fl outcomeinterval Ar n
+Set the interval for printing outcomes to
+.Ar n
+games.
 .It Fl debug
 Display all engine input and output.
 .It Fl openings Cm file Ns = Ns Ar file Cm format Ns = Ns Bo Cm epd | Cm pgn Ns Bc Cm order Ns = Ns Bo Cm random | Cm sequential Bc Cm plies Ns = Ns Ar plies Cm start Ns = Ns Ar start Cm policy Ns = Ns Bo Cm default | Cm encounter | Cm round Bc

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -130,7 +130,8 @@ Options:
 			[ELO0, ELO1] are ALPHA and BETA. The match is stopped if
 			either H0 or H1 is accepted or if the maximum number of
 			games set by '-rounds' and/or '-games' is reached.
-  -ratinginterval N	Set the interval for printing the ratings to N games
+  -ratinginterval N	Set the interval for printing the ratings to N games.
+  -outcomeinterval N	Set the interval for printing outcomes to N games.
   -debug		Display all engine input and output
   -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START policy=POLICY
 			Pick game openings from FILE. The file's format is

--- a/projects/cli/src/enginematch.cpp
+++ b/projects/cli/src/enginematch.cpp
@@ -31,6 +31,7 @@ EngineMatch::EngineMatch(Tournament* tournament, QObject* parent)
 	  m_tournament(tournament),
 	  m_debug(false),
 	  m_ratingInterval(0),
+	  m_outcomeInterval(0),
 	  m_bookMode(OpeningBook::Ram)
 {
 	Q_ASSERT(tournament != nullptr);
@@ -95,6 +96,12 @@ void EngineMatch::setRatingInterval(int interval)
 	m_ratingInterval = interval;
 }
 
+void EngineMatch::setOutcomeInterval(int interval)
+{
+	Q_ASSERT(interval >= 0);
+	m_outcomeInterval = interval;
+}
+
 void EngineMatch::setBookMode(OpeningBook::AccessMode mode)
 {
 	m_bookMode = mode;
@@ -138,6 +145,9 @@ void EngineMatch::onGameFinished(ChessGame* game, int number)
 	if (m_ratingInterval != 0
 	&&  (m_tournament->finishedGameCount() % m_ratingInterval) == 0)
 		printRanking();
+	if (m_outcomeInterval != 0
+	&&  (m_tournament->finishedGameCount() % m_outcomeInterval) == 0)
+		printOutcomes();
 }
 
 void EngineMatch::onTournamentFinished()
@@ -145,6 +155,9 @@ void EngineMatch::onTournamentFinished()
 	if (m_ratingInterval == 0
 	||  m_tournament->finishedGameCount() % m_ratingInterval != 0)
 		printRanking();
+	if (m_outcomeInterval == 0
+	||  m_tournament->finishedGameCount() % m_outcomeInterval != 0)
+		printOutcomes();
 
 	QString error = m_tournament->errorString();
 	if (!error.isEmpty())
@@ -164,4 +177,9 @@ void EngineMatch::print(const QString& msg)
 void EngineMatch::printRanking()
 {
 	qInfo("%s", qUtf8Printable(m_tournament->results()));
+}
+
+void EngineMatch::printOutcomes()
+{
+	qInfo("%s", qUtf8Printable(m_tournament->outcomes()));
 }

--- a/projects/cli/src/enginematch.h
+++ b/projects/cli/src/enginematch.h
@@ -41,6 +41,7 @@ class EngineMatch : public QObject
 		OpeningBook* addOpeningBook(const QString& fileName);
 		void setDebugMode(bool debug);
 		void setRatingInterval(int interval);
+		void setOutcomeInterval(int interval);
 		void setBookMode(OpeningBook::AccessMode mode);
 
 		void start();
@@ -57,10 +58,12 @@ class EngineMatch : public QObject
 
 	private:
 		void printRanking();
+		void printOutcomes();
 
 		Tournament* m_tournament;
 		bool m_debug;
 		int m_ratingInterval;
+		int m_outcomeInterval;
 		OpeningBook::AccessMode m_bookMode;
 		QMap<QString, OpeningBook*> m_books;
 		QElapsedTimer m_startTime;

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -255,6 +255,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-rounds", QVariant::Int, 1, 1);
 	parser.addOption("-sprt", QVariant::StringList);
 	parser.addOption("-ratinginterval", QVariant::Int, 1, 1);
+	parser.addOption("-outcomeinterval", QVariant::Int, 1, 1);
 	parser.addOption("-resultformat", QVariant::String, 1, 1);
 	parser.addOption("-debug", QVariant::Bool, 0, 0);
 	parser.addOption("-openings", QVariant::StringList);
@@ -426,7 +427,10 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		// Interval for rating list updates
 		else if (name == "-ratinginterval")
 			match->setRatingInterval(value.toInt());
-		// Interval for rating list updates
+		// Interval for outcome updates
+		else if (name == "-outcomeinterval")
+			match->setOutcomeInterval(value.toInt());
+		// Format of the result list
 		else if (name == "-resultformat")
 		{
 			if (value == "help")
@@ -444,6 +448,11 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 					 s.append(" ");
 				}
 				qInfo() << "  " << qUtf8Printable(s);
+				qInfo() <<"\nNamed shortcuts:";
+				const auto& map2(tournament->resultFieldGroups());
+				for (auto it = map2.constBegin(); it != map2.constEnd(); ++it)
+					qInfo() << qUtf8Printable(it.key()) << "\n  "
+						<< qUtf8Printable(it.value());
 				return 0;
 			}
 			tournament->setResultFormat(value.toString().left(256).trimmed());

--- a/projects/gui/src/tournamentresultsdlg.cpp
+++ b/projects/gui/src/tournamentresultsdlg.cpp
@@ -85,5 +85,8 @@ void TournamentResultsDialog::update()
 	text += tr("\n%1 of %2 games finished.")
 		.arg(tournament->finishedGameCount())
 		.arg(tournament->finalGameCount());
+	if (tournament->finishedGameCount() >= tournament->finalGameCount()
+	|| tournament->isStopping())
+		text.append("\n").append(tournament->outcomes());
 	m_resultsEdit->setPlainText(text);
 }

--- a/projects/lib/src/tournamentplayer.cpp
+++ b/projects/lib/src/tournamentplayer.cpp
@@ -32,7 +32,9 @@ TournamentPlayer::TournamentPlayer(PlayerBuilder* builder,
 	  m_losses(0),
 	  m_whiteWins(0),
 	  m_whiteDraws(0),
-	  m_whiteLosses(0)
+	  m_whiteLosses(0),
+	  m_terminations(24),
+	  m_outcome()
 {
 	Q_ASSERT(builder != nullptr);
 }
@@ -152,4 +154,20 @@ void TournamentPlayer::addScore(Chess::Side side, int score)
 int TournamentPlayer::gamesFinished() const
 {
 	return m_wins + m_draws + m_losses;
+}
+
+void TournamentPlayer::addOutcome(int type, QString str)
+{
+	m_outcome[str]++;
+	m_terminations[type]++;
+}
+
+int TournamentPlayer::outcomes(int type) const
+{
+	return m_terminations.at(type);
+}
+
+const QMap<QString, int> & TournamentPlayer::outcomeMap() const
+{
+	return m_outcome;
 }

--- a/projects/lib/src/tournamentplayer.h
+++ b/projects/lib/src/tournamentplayer.h
@@ -22,6 +22,8 @@
 #include "playerbuilder.h"
 #include "timecontrol.h"
 #include "board/side.h"
+#include <QVector>
+#include <QMap>
 
 class OpeningBook;
 
@@ -97,10 +99,22 @@ class LIB_EXPORT TournamentPlayer
 		/*! Adds \a score to the player's score in the tournament. */
 		void addScore(Chess::Side side, int score);
 		/*!
+		 * Adds a game outcome of \a type with description \a str
+		 * to the player's statistics.
+		 */
+		void addOutcome(int type, QString str);
+		/*!
 		 * Returns the total number of games the player has finished
 		 * in the tournament.
 		 */
 		int gamesFinished() const;
+		/*!
+		 * Returns the player's count of game outcomes of type
+		 * \a type.
+		 */
+		int outcomes(int type) const;
+		/*! Returns the player's game outcome statistics. */
+		const QMap<QString, int>& outcomeMap() const;
 
 	private:
 		PlayerBuilder* m_builder;
@@ -113,6 +127,8 @@ class LIB_EXPORT TournamentPlayer
 		int m_whiteWins;
 		int m_whiteDraws;
 		int m_whiteLosses;
+		QVector<int> m_terminations;
+		QMap <QString, int> m_outcome;
 };
 
 #endif // TOURNAMENTPLAYER_H


### PR DESCRIPTION
This PR adds support for termination type and draw type statistics. Various new format fields are introduced. Resolves #355

The field tokens  `DAdj`, `DAgree`, `DCount`, `DMater`, `DMoves`, `DRepet`, `DStale`, and `OtherD` are new for draw statistics.
The new field tokens  `Time`, `Illegal`, `Discon`, `Stall`, `WrClaim`  are used for termination statistics. The type of the termination are only attributed to the losing side, the winning side are attributed an `OtherW` ("other win" ) for mishaps of their opponents.

Named shortcuts `DrawStats`, `Terminations`, `WLDStats`  are introduced for groups of format fields in order to alleviate the construction of broad tables.

A format field `TC` for time control is added for presentation of tournaments with non-uniform time controls among the contestants.
The format enhancement is implemented in the `Tournament` and `TournamentPlayer` classes, so both CLI and GUI are affected.

`cli/cutechess-cli -resultformat help` yields:

```
Option -resultformat accepts a comma separated list of fields or one of following format names:

concise 
   Rank,Name,Elo,Error,Games
default 
   Rank,Name,Elo,Error,Games,Score,DScore
draws 
   Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore,DStale,DMater,DRepet,DMoves,DAdj,DAgree,OtherD
minimal 
   Rank,Name
ordo 
   Rank,Name,Elo,Points,Games,Score
per-color 
   Rank,Name,Elo,Error,Games,W,L,D,Points,wW,wL,wD,wPoints,bW,bL,bD,bPoints
short 
   Rank,Name,Elo,Games
small 
   Rank,Name,Games,Points
term 
   Rank,Name,Elo,Error,Games,Score,Time,Illegal,Discon,Stall,WrClaim
wide 
   Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore
wide2 
   Rank,Name,Elo,Error,Games,W,L,D,Points,Score,DScore,wScore,bScore
wide3 
   Rank,Name,TC,Elo,Error,Games,WLDStats,DrawStats,Terminations
with-points 
   Rank,Name,Elo,Error,Games,Points,Score,DScore

Field tokens:
   D DAdj DAgree DCount DMater DMoves DRepet DScore DStale Discon Elo Error Games Illegal L LOS Name OtherD
OtherW Points Rank RegulL RegulW Score Stall TC Time W WrClaim bD bDScore bElo bError bL bScore bW wD wDScore
wElo wError wL wLOS wScore wW 

Named shortcuts:
DrawStats 
   DScore,DStale,DMater,DRepet,DMoves,DAdj,DAgree,OtherD
Terminations 
   Time,Illegal,Discon,Stall,WrClaim
WLDStats 
   W,L,D,Points,Score,wW,wL,wD,wPoints,wScore,bW,bL,bD,bPoints,bScore
```

---
As a second feature verbose statistics of game outcomes by player have been added. The verbose comments and their numbers of occurrences are listed for each player, broken down for wins, draws, and losses.
```
Finished game 60 (komodo-9.02-linux vs stockfish-11): 1/2-1/2 {Draw by insufficient mating material}
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw  DStale  DMater  DRepet  DMoves    DAdj  DAgree  OtherD 
   1 stockfish-11                  127      87      40      19       5      16     27.0   67.5%   40.0%       0       5       7       4       0       0       0 
   2 komodo-9.02-linux              17      81      40      12      10      18     21.0   52.5%   45.0%       0       3      10       5       0       0       0 
   3 firenzina-2.4.3              -147      82      40       3      19      18     12.0   30.0%   45.0%       0       2      13       3       0       0       0 

2059200 
Player: stockfish-11
   "Draw by 3-fold repetition": 7
   "Draw by fifty moves rule": 4
   "Draw by insufficient mating material": 5
   "Loss: Black wins by adjudication": 1
   "Loss: White wins by adjudication": 4
   "Win: Black wins by adjudication": 7
   "Win: White wins by adjudication": 12
Player: komodo-9.02-linux
   "Draw by 3-fold repetition": 10
   "Draw by fifty moves rule": 5
   "Draw by insufficient mating material": 3
   "Loss: Black wins by adjudication": 4
   "Loss: White wins by adjudication": 6
   "Win: Black wins by adjudication": 6
   "Win: White wins by adjudication": 6
Player: firenzina-2.4.3
   "Draw by 3-fold repetition": 13
   "Draw by fifty moves rule": 3
   "Draw by insufficient mating material": 2
   "Loss: Black wins by adjudication": 9
   "Loss: White wins by adjudication": 10
   "Win: Black wins by adjudication": 1
   "Win: White wins by adjudication": 2
Finished match

```
_Example of the result table given by resultformat "draws".  Below the table the outcomes are listed at the end of a tournament. Please scroll to the right to see more of the table_

To control the frequency of the outcome output there is a new CLI option
```
-outcomeinterval N   Set the interval for printing outcomes to N games.
```
In the CLI and the GUI the outcomes are (also) printed at the end of the tournament.

I hope this is useful.




