### PR TITLE
Option to hide comments in move list

### DIFF
--- a/projects/gui/src/movelist.h
+++ b/projects/gui/src/movelist.h
@@ -89,6 +89,7 @@ class MoveList : public QWidget
 				const QString& comment);
 		void onLinkClicked(const QUrl& url);
 		void selectChosenMove();
+		void onContextMenuRequest();
 
 	private:
 		struct Move
@@ -105,11 +106,13 @@ class MoveList : public QWidget
 
 		QTextBrowser* m_moveList;
 		QPointer<ChessGame> m_game;
+		PgnGame* m_pgn;
 		QList<Move> m_moves;
 		int m_moveCount;
 		int m_startingSide;
 		int m_selectedMove;
 		int m_moveToBeSelected;
+		bool m_showComments;
 		QTextCharFormat m_defaultTextFormat;
 		QTimer* m_selectionTimer;
 };


### PR DESCRIPTION
This patch adds an action to toggle the visibility of move comments in the move list. The action is triggered by key "C" or by the "Toggle Comments" item of the context menu.

Resolves #145

![c1](https://user-images.githubusercontent.com/6425738/89665815-cb0e6b00-d8c8-11ea-81d9-ed5b8df5ad0a.png)![c0](https://user-images.githubusercontent.com/6425738/89665930-fe50fa00-d8c8-11ea-8f47-500f41a97e21.png)
_Move list with and without move comments_