### PR TITLE
GUI: Configure move animation speed and hiding of move arrows

### DIFF
--- a/projects/gui/src/boardview/boardscene.cpp
+++ b/projects/gui/src/boardview/boardscene.cpp
@@ -229,7 +229,7 @@ void BoardScene::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 	}
 
 	if (m_targets.contains(piece)
-	&&  QSettings().value("ui/highlight_legal_moves", true).toBool())
+	&&  m_settings.value("ui/highlight_legal_moves", true).toBool())
 	{
 		m_highlightPiece = piece;
 		m_squares->setHighlights(m_targets.values(piece));
@@ -439,7 +439,8 @@ QPropertyAnimation* BoardScene::pieceAnimation(GraphicsPiece* piece,
 	anim->setStartValue(startPoint);
 	anim->setEndValue(endPoint);
 	anim->setEasingCurve(QEasingCurve::InOutQuad);
-	anim->setDuration(300);
+	int duration = qMin(m_settings.value("ui/move_animation_duration", 300).toInt(), 400);
+	anim->setDuration(duration);
 
 	piece->setParentItem(nullptr);
 	piece->setPos(startPoint);
@@ -525,6 +526,8 @@ void BoardScene::addMoveArrow(const QPointF& sourcePos,
 			      const QPointF& targetPos)
 {
 	Q_ASSERT(m_moveArrows != nullptr);
+	if (!m_settings.value("ui/show_move_arrows", true).toBool())
+		return;
 
 	QLineF l1(sourcePos, targetPos);
 	QLineF l2(l1.normalVector());

--- a/projects/gui/src/boardview/boardscene.h
+++ b/projects/gui/src/boardview/boardscene.h
@@ -22,6 +22,7 @@
 #include <QGraphicsScene>
 #include <QMultiMap>
 #include <QPointer>
+#include <QSettings>
 #include <board/square.h>
 #include <board/genericmove.h>
 #include <board/boardtransition.h>
@@ -159,6 +160,7 @@ class BoardScene : public QGraphicsScene
 		Chess::GenericMove m_promotionMove;
 		GraphicsPiece* m_highlightPiece;
 		QGraphicsItemGroup* m_moveArrows;
+		QSettings m_settings;
 };
 
 #endif // BOARDSCENE_H

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -38,6 +38,12 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/highlight_legal_moves", checked);
 	});
 
+	connect(ui->m_showMoveArrowsCheck, &QCheckBox::toggled,
+		this, [=](bool checked)
+	{
+		QSettings().setValue("ui/show_move_arrows", checked);
+	});
+
 	connect(ui->m_closeUnusedInitialTabCheck, &QCheckBox::toggled,
 		this, [=](bool checked)
 	{
@@ -69,6 +75,11 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 				      checked);
 	});
 
+	connect(ui->m_moveAnimationSpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+		this, [=](int value)
+	{
+		QSettings().setValue("ui/move_animation_duration", value);
+	});
 
 	connect(ui->m_concurrencySpin, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
 		this, [=](int value)
@@ -204,6 +215,8 @@ void SettingsDialog::readSettings()
 	s.beginGroup("ui");
 	ui->m_highlightLegalMovesCheck->setChecked(
 		s.value("highlight_legal_moves", true).toBool());
+	ui->m_showMoveArrowsCheck->setChecked(
+		s.value("show_move_arrows", true).toBool());
 	ui->m_closeUnusedInitialTabCheck->setChecked(
 		s.value("close_unused_initial_tab", true).toBool());
 	ui->m_useFullUserNameCheck->setChecked(
@@ -213,6 +226,8 @@ void SettingsDialog::readSettings()
 	ui->m_autoFlipBoardForHumanGamesCheck->setChecked(
 		s.value("auto_flip_board_for_human_games", false).toBool());
 	ui->m_tbPathEdit->setText(s.value("tb_path").toString());
+	ui->m_moveAnimationSpin->setValue(
+		s.value("move_animation_duration", 300).toInt());
 	s.endGroup();
 
 	s.beginGroup("pgn");

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>552</width>
-    <height>467</height>
+    <height>501</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="m_generalTab">
       <attribute name="title">
@@ -32,33 +32,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
         <layout class="QFormLayout" name="formLayout_6">
-         <item row="7" column="0">
-          <widget class="QCheckBox" name="m_humanCanPlayAfterTimeoutCheck">
-           <property name="text">
-            <string>Human player can play after timeout</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QCheckBox" name="m_playersSidesOnClocksCheck">
-           <property name="text">
-            <string>Display players' sides on clocks </string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="m_closeUnusedInitialTabCheck">
-           <property name="text">
-            <string>Close initial game tab if unused</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QCheckBox" name="m_highlightLegalMovesCheck">
            <property name="text">
@@ -69,7 +42,27 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0">
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="m_showMoveArrowsCheck">
+           <property name="text">
+            <string>Show move arrows</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="m_closeUnusedInitialTabCheck">
+           <property name="text">
+            <string>Close initial game tab if unused</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
           <widget class="QCheckBox" name="m_useFullUserNameCheck">
            <property name="text">
             <string>Use full name of human player</string>
@@ -79,10 +72,59 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="5" column="0">
+          <widget class="QCheckBox" name="m_playersSidesOnClocksCheck">
+           <property name="text">
+            <string>Display players' sides on clocks </string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
           <widget class="QCheckBox" name="m_autoFlipBoardForHumanGamesCheck">
            <property name="text">
             <string>Auto flip board for human vs human</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QCheckBox" name="m_humanCanPlayAfterTimeoutCheck">
+           <property name="text">
+            <string>Human player can play after timeout</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="m_moveAnimationLabel">
+           <property name="text">
+            <string>Duration of mo&amp;ve animation:</string>
+           </property>
+           <property name="buddy">
+            <cstring>m_moveAnimationSpin</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QSpinBox" name="m_moveAnimationSpin">
+           <property name="toolTip">
+            <string>duration of a move animation (default: 300 ms)</string>
+           </property>
+           <property name="specialValueText">
+            <string>Off</string>
+           </property>
+           <property name="suffix">
+            <string> ms</string>
+           </property>
+           <property name="maximum">
+            <number>400</number>
+           </property>
+           <property name="singleStep">
+            <number>50</number>
+           </property>
+           <property name="value">
+            <number>300</number>
            </property>
           </widget>
          </item>
@@ -105,18 +147,18 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item row="1" column="1">
-          <widget class="QLineEdit" name="m_siteEdit"/>
-         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="m_siteLabel">
            <property name="text">
-            <string>PGN Site:</string>
+            <string>&amp;PGN Site:</string>
            </property>
            <property name="buddy">
             <cstring>m_siteEdit</cstring>
            </property>
           </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="m_siteEdit"/>
          </item>
          <item row="2" column="0">
           <widget class="QLabel" name="m_defaultPgnOutFileLabel">
@@ -149,7 +191,7 @@
          <item row="3" column="0">
           <widget class="QLabel" name="m_tbPathLabel">
            <property name="text">
-            <string>Syzygy tablebases path:</string>
+            <string>Sy&amp;zygy tablebases path:</string>
            </property>
            <property name="buddy">
             <cstring>m_tbPathEdit</cstring>
@@ -265,7 +307,7 @@
             <item row="1" column="0">
              <widget class="QLabel" name="m_concurrencyLabel">
               <property name="text">
-               <string>Concurrent games:</string>
+               <string>&amp;Concurrent games:</string>
               </property>
               <property name="buddy">
                <cstring>m_concurrencySpin</cstring>
@@ -382,6 +424,27 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>m_highlightLegalMovesCheck</tabstop>
+  <tabstop>m_showMoveArrowsCheck</tabstop>
+  <tabstop>m_closeUnusedInitialTabCheck</tabstop>
+  <tabstop>m_useFullUserNameCheck</tabstop>
+  <tabstop>m_playersSidesOnClocksCheck</tabstop>
+  <tabstop>m_autoFlipBoardForHumanGamesCheck</tabstop>
+  <tabstop>m_humanCanPlayAfterTimeoutCheck</tabstop>
+  <tabstop>m_moveAnimationSpin</tabstop>
+  <tabstop>m_siteEdit</tabstop>
+  <tabstop>m_defaultPgnOutFileEdit</tabstop>
+  <tabstop>m_defaultPgnOutFileBtn</tabstop>
+  <tabstop>m_tbPathEdit</tabstop>
+  <tabstop>m_browseTbPathBtn</tabstop>
+  <tabstop>m_concurrencySpin</tabstop>
+  <tabstop>m_tournamentDefaultPgnOutFileEdit</tabstop>
+  <tabstop>m_tournamentDefaultPgnOutFileBtn</tabstop>
+  <tabstop>m_tournamentDefaultEpdOutFileEdit</tabstop>
+  <tabstop>m_tournamentDefaultEpdOutFileBtn</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
In SettingsDialog add spin box to choose move animation speed.
Add checkbox to enable or disable move arrows.

Resolves #204, resolves #458

![set1](https://user-images.githubusercontent.com/6425738/89667396-9b149700-d8cb-11ea-8ed6-65c05efd017c.png)
