### PR TITLE
Fix wrong illegal move claims when using UCI with variants kinglet and extinction

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -126,7 +126,10 @@ void UciEngine::sendPosition()
 void UciEngine::startGame()
 {
 	Q_ASSERT(supportsVariant(board()->variant()));
-	const QList<QString> directPvList = {"giveaway", "suicide", "antichess"};
+	const QList<QString> directPvList =
+	{
+		"giveaway", "suicide", "antichess", "kinglet", "extinction"
+	};
 
 	m_ignoreThinking = false;
 	m_rePing = false;


### PR DESCRIPTION
This is a workaround until the root cause is solved.

Resolves #563 .