### PR TITLE
Fix castling

### DIFF
--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -1218,24 +1218,7 @@ bool WesternBoard::isLegalPosition()
 		int source = move.sourceSquare();
 		int target = m_castleTarget[side][cside];
 		int offset = (source <= target) ? 1 : -1;
-		
-		if (source == target)
-		{
-			offset = (cside == KingSide) ? 1 : -1;
-			int i = target - offset;
-			for (;;)
-			{
-				i -= offset;
-				Piece piece(pieceAt(i));
 
-				if (piece.isWall() || piece.side() == side)
-					return true;
-				if (piece.side() == sideToMove()
-				&&  pieceHasCaptureMovement(piece, i, RookMovement))
-					return false;
-			}
-		}
-		
 		for (int i = source; i != target; i += offset)
 		{
 			if (inCheck(side, i))
@@ -1250,10 +1233,22 @@ bool WesternBoard::vIsLegalMove(const Move& move)
 {
 	Q_ASSERT(!move.isNull());
 
-	if (!m_kingCanCapture
-	&&  move.sourceSquare() == m_kingSquare[sideToMove()]
-	&&  captureType(move) != Piece::NoPiece)
-		return false;
+	Side side(sideToMove());
+
+	if (move.sourceSquare() == m_kingSquare[side])
+	{
+		if (!m_kingCanCapture
+		&&  captureType(move) != Piece::NoPiece)
+			return false;
+
+		// No castling when in check
+		Piece piece = pieceAt(move.targetSquare());
+		if (m_hasCastling
+		&&  piece.type() == Rook
+		&&  piece.side() == side
+		&&  inCheck(side))
+			return false;
+	}
 
 	return Board::vIsLegalMove(move);
 }

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -684,6 +684,12 @@ void tst_Board::results_data() const
 		<< "8/8/k1K5/8/8/8/R7/8 b - - 100 1"
 		<< "1-0";
 
+	variant = "fischerandom";
+
+	QTest::newRow("FRC black win #1")
+		<< variant
+		<< "1k1r4/1pp2b1p/p7/P1B2R2/N7/3P2b1/1PP4Q/RK2r3 w Q - 1 29"
+		<< "0-1";
 
 	variant = "kingofthehill";
 
@@ -1058,6 +1064,13 @@ void tst_Board::perft_data() const
 		<< 6
 		<< Q_UINT64_C(11030083);
 
+	variant = "fischerandom";
+	QTest::newRow("FRC castling #1")
+		<< variant
+		<< "Q3B1kr/p5p1/1p3p1p/2p2P2/2br1N1P/8/P5P1/7K b k - 1 34"
+		<< 2
+		<< Q_UINT64_C(824);
+
 	variant = "capablanca";
 	QTest::newRow("gothic startpos")
 		<< variant
@@ -1226,7 +1239,6 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 5 // 4 plies: 197742, 5 plies: 4897256, 6 plies: 120921506
 		<< Q_UINT64_C(4897256);
-
 	variant = "grid";
 	QTest::newRow("grid startpos")
 		<< variant
@@ -1237,7 +1249,12 @@ void tst_Board::perft_data() const
 		<< variant
 		<< "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -"
 		<< 4
-		<< Q_UINT64_C(1853429);
+		<< Q_UINT64_C(1853380);
+	QTest::newRow("grid pos2a")
+		<< variant
+		<< "r3k2r/p1pPqpb1/bn3np1/4N3/1p2P3/2N2Q2/PPPBBPpP/R3K2R b KQkq -"
+		<< 1
+		<< Q_UINT64_C(4);
 	QTest::newRow("grid pos3")
 		<< variant
 		<< "8/3K4/2p5/p2b2r1/5k2/8/8/1q6 b - -"


### PR DESCRIPTION
Forbid castling when in check.
Allow castling if a rook attack is intercepted by another attacking
piece with different movement when castling target equals source.

Resolves #616
Resolves #637
Resolves #755
Resolves #756

A test whether the King is in check is added to `WesternBoard::vIsLegalMove` in order to forbid castling moves.
The special code in `WesternBoard::isLegalPosition` for the case of identical castling source and target (occurs in chess960) was removed.
Corrected test case for Grid Chess where a check by Pawn did not prevent castling. Added two of the three examples in issue 616 as test cases for FRC. Added a simple test case for Grid Chess.

**Help needed**: This patch needs intensive testing in chess960 and also in standard chess in order to avoid regression.
**Update**:  In his test run of about 2 million FRC games @AndyGrant encountered no problems.