### PR TITLE
Scale chess engine timeouts

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -481,6 +481,10 @@ Enable pondering if the engine supports it.
 Set the search depth limit.
 .It Ic nodes Ns = Ns Ar count
 Set the node count limit.
+.It Ic tscale Ns = Ns Ar factor
+Scale engine timeouts by
+.Ar factor .
+Only use this option if necessary.
 .El
 .Sh EXAMPLES
 Play ten games between two Sloppy engines with a time control of 40

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -215,5 +215,7 @@ Engine options:
   nodes=N		Set the node count limit to N nodes
   ponder		Enable pondering if the engine supports it. By default
 			pondering is disabled.
+  tscale=FACTOR		Scale engine timeouts by FACTOR. Only use this option
+			if necessary.
   option.OPTION=VALUE	Set custom option OPTION to value VALUE
 

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -143,6 +143,19 @@ bool parseEngine(const QStringList& args, EngineData& data)
 		{
 			data.config.setClaimsValidated(false);
 		}
+		// Scaling timeouts
+		else if (name == "tscale")
+		{
+			bool ok = false;
+			double value = val.toDouble(&ok);
+			if (!ok || value < EngineConfiguration::timeoutScaleMin
+				|| value > EngineConfiguration::timeoutScaleMax)
+			{
+				qWarning() << "Invalid timeout scale factor:" << val;
+				return false;
+			}
+			data.config.setTimeoutScale(value);
+		}
 		// Time control (moves/time+increment)
 		else if (name == "tc")
 		{

--- a/projects/gui/src/engineconfigurationdlg.cpp
+++ b/projects/gui/src/engineconfigurationdlg.cpp
@@ -62,6 +62,9 @@ EngineConfigurationDialog::EngineConfigurationDialog(
 
 	ui->m_protocolCombo->addItems(EngineFactory::protocols());
 
+	ui->m_tscaleSpin->setStyleSheet("QDoubleSpinBox {color: black} \
+					 QDoubleSpinBox[value='1'] {color: #d0d0d0}");
+
 	ui->m_optionsView->setModel(m_engineOptionModel);
 	connect(m_engineOptionModel, SIGNAL(modelReset()),
 		this, SLOT(resizeColumns()));
@@ -99,6 +102,16 @@ EngineConfigurationDialog::EngineConfigurationDialog(
 		}
 	});
 
+	connect(ui->m_tscaleSpin,
+		static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
+		[=](double value)
+	{
+		if (value != 1.)
+			ui->m_tscaleSpin->setStyleSheet("QDoubleSpinBox {color: black}");
+		else
+			ui->m_tscaleSpin->setStyleSheet("QDoubleSpinBox {color: #d0d0d0}");
+	});
+
 	ui->m_tabs->setTabEnabled(1, false);
 	ui->m_buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 }
@@ -119,6 +132,7 @@ void EngineConfigurationDialog::applyEngineInformation(
 	int i = ui->m_protocolCombo->findText(engine.protocol());
 	ui->m_protocolCombo->setCurrentIndex(i);
 
+	ui->m_tscaleSpin->setValue(engine.timeoutScale());
 	ui->m_initStringEdit->setPlainText(engine.initStrings().join("\n"));
 
 	if (engine.whiteEvalPov())
@@ -144,6 +158,7 @@ EngineConfiguration EngineConfigurationDialog::engineConfiguration()
 	engine.setCommand(ui->m_commandEdit->text());
 	engine.setWorkingDirectory(ui->m_workingDirEdit->text());
 	engine.setProtocol(ui->m_protocolCombo->currentText());
+	engine.setTimeoutScale(ui->m_tscaleSpin->value());
 
 	QString initStr(ui->m_initStringEdit->toPlainText());
 	if (!initStr.isEmpty())

--- a/projects/gui/ui/engineconfigdlg.ui
+++ b/projects/gui/ui/engineconfigdlg.ui
@@ -98,10 +98,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QComboBox" name="m_protocolCombo"/>
-       </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>&amp;Init Strings:</string>
@@ -111,14 +108,14 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QPlainTextEdit" name="m_initStringEdit">
          <property name="lineWrapMode">
           <enum>QPlainTextEdit::NoWrap</enum>
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QCheckBox" name="m_whitePovCheck">
          <property name="enabled">
           <bool>false</bool>
@@ -130,6 +127,67 @@
           <string>Scores from &amp;white's perspective</string>
          </property>
         </widget>
+       </item>
+       <item row="3" column="1">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QComboBox" name="m_protocolCombo"/>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="m_timeoutsLabel">
+           <property name="text">
+            <string>Scale Timeouts:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="m_tscaleSpin">
+           <property name="toolTip">
+            <string>Scale engine timeouts by this factor. Only use if necessary! Default: 1.00</string>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="wrapping">
+            <bool>false</bool>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="specialValueText">
+            <string/>
+           </property>
+           <property name="correctionMode">
+            <enum>QAbstractSpinBox::CorrectToNearestValue</enum>
+           </property>
+           <property name="minimum">
+            <double>0.200000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>120.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.200000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -43,6 +43,11 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 	Q_OBJECT
 
 	public:
+		static constexpr int defaultPingTimeout = 15000;
+		static constexpr int defaultQuitTimeout =  5000;
+		static constexpr int defaultIdleTimeout = 15000;
+		static constexpr int defaultProtocolStartTimeout = 35000;
+
 		/*!
 		 * The write mode used by \a write() when the engine is
 		 * being pinged. This doesn't affect the IO device's
@@ -76,7 +81,7 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		void start();
 
 		/*! Applies \a configuration to the engine. */
-		void applyConfiguration(const EngineConfiguration& configuration);
+		virtual void applyConfiguration(const EngineConfiguration& configuration);
 
 		/*!
 		 * Sends a ping message (an echo request) to the engine to
@@ -282,6 +287,7 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		bool m_pinging;
 		bool m_whiteEvalPov;
 		bool m_pondering;
+		double m_timeoutScale;
 		QTimer* m_pingTimer;
 		QTimer* m_quitTimer;
 		QTimer* m_idleTimer;

--- a/projects/lib/src/engineconfiguration.cpp
+++ b/projects/lib/src/engineconfiguration.cpp
@@ -27,6 +27,7 @@ EngineConfiguration::EngineConfiguration()
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
+	  m_timeoutScale(1.0),
 	  m_restartMode(RestartAuto)
 {
 }
@@ -41,6 +42,7 @@ EngineConfiguration::EngineConfiguration(const QString& name,
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
+	  m_timeoutScale(1.0),
 	  m_restartMode(RestartAuto)
 {
 }
@@ -50,6 +52,7 @@ EngineConfiguration::EngineConfiguration(const QVariant& variant)
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
+	  m_timeoutScale(1.0),
 	  m_restartMode(RestartAuto)
 {
 	const QVariantMap map = variant.toMap();
@@ -59,6 +62,13 @@ EngineConfiguration::EngineConfiguration(const QVariant& variant)
 	setWorkingDirectory(map["workingDirectory"].toString());
 	setStderrFile(map["stderrFile"].toString());
 	setProtocol(map["protocol"].toString());
+
+	bool ok = true;
+	if (map.contains("timeout_scale_factor"))
+	{
+		double tscale = map["timeout_scale_factor"].toDouble(&ok);
+		setTimeoutScale(ok ? tscale : 1.0);
+	}
 
 	if (map.contains("initStrings"))
 		setInitStrings(map["initStrings"].toStringList());
@@ -109,6 +119,7 @@ EngineConfiguration::EngineConfiguration(const EngineConfiguration& other)
 	  m_whiteEvalPov(other.m_whiteEvalPov),
 	  m_pondering(other.m_pondering),
 	  m_validateClaims(other.m_validateClaims),
+	  m_timeoutScale(other.m_timeoutScale),
 	  m_restartMode(other.m_restartMode)
 {
 	const auto options = other.options();
@@ -133,6 +144,7 @@ EngineConfiguration& EngineConfiguration::operator=(EngineConfiguration&& other)
 	m_whiteEvalPov = other.m_whiteEvalPov;
 	m_pondering = other.m_pondering;
 	m_validateClaims = other.m_validateClaims;
+	m_timeoutScale = other.m_timeoutScale;
 	m_restartMode = other.m_restartMode;
 	m_options = other.m_options;
 
@@ -155,6 +167,7 @@ QVariant EngineConfiguration::toVariant() const
 	map.insert("workingDirectory", m_workingDirectory);
 	map.insert("stderrFile", m_stderrFile);
 	map.insert("protocol", m_protocol);
+	map.insert("timeout_scale_factor", m_timeoutScale);
 
 	if (!m_initStrings.isEmpty())
 		map.insert("initStrings", m_initStrings);
@@ -361,6 +374,16 @@ void EngineConfiguration::setClaimsValidated(bool validate)
 	m_validateClaims = validate;
 }
 
+double EngineConfiguration::timeoutScale() const
+{
+	return m_timeoutScale;
+}
+
+void EngineConfiguration::setTimeoutScale(double value)
+{
+	m_timeoutScale = qBound(timeoutScaleMin, value, timeoutScaleMax);
+}
+
 EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& other)
 {
 	if (this != &other)
@@ -370,6 +393,7 @@ EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& o
 		m_workingDirectory = other.m_workingDirectory;
 		m_stderrFile = other.m_stderrFile;
 		m_protocol = other.m_protocol;
+		m_timeoutScale = other.m_timeoutScale;
 		m_arguments = other.m_arguments;
 		m_initStrings = other.m_initStrings;
 		m_variants = other.m_variants;

--- a/projects/lib/src/engineconfiguration.h
+++ b/projects/lib/src/engineconfiguration.h
@@ -44,6 +44,11 @@ class LIB_EXPORT EngineConfiguration
 			RestartOff	//!< The engine is never restarted between games
 		};
 
+		/*! Minimal value for timeout scaling */
+		static constexpr double timeoutScaleMin = 0.2;
+		/*! Maximal value for timeout scaling */
+		static constexpr double timeoutScaleMax = 120.0;
+
 		/*! Creates an empty chess engine configuration. */
 		EngineConfiguration();
 		/*!
@@ -207,6 +212,22 @@ class LIB_EXPORT EngineConfiguration
 		void setClaimsValidated(bool validate);
 
 		/*!
+		 * Returns the timeout scale factor.
+		 *
+		 * A value of 1.0 corresponds to default timeouts.
+		 */
+		double timeoutScale() const;
+		/*!
+		 * Set the protocol timeout scale factor to \a value.
+		 * Values range between 0.01 and 120.
+		 *
+		 * Increasing \a value increases all protocol timeout
+		 * settings. The value of 1.0 corresponds to normal
+		 * timeouts.
+		 */
+		void setTimeoutScale(double value);
+
+		/*!
 		 * Assigns \a other to this engine configuration and returns
 		 * a reference to this object.
 		 */
@@ -225,6 +246,7 @@ class LIB_EXPORT EngineConfiguration
 		bool m_whiteEvalPov;
 		bool m_pondering;
 		bool m_validateClaims;
+		double m_timeoutScale;
 		RestartMode m_restartMode;
 };
 

--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -62,6 +62,7 @@ QString variantToXboard(const QString& str)
 }
 
 const int s_infiniteSec = 86400;
+const int s_initTimerDefaultInterval = 8000;
 
 } // anonymous namespace
 
@@ -82,11 +83,19 @@ XboardEngine::XboardEngine(QObject* parent)
 	  m_initTimer(new QTimer(this))
 {
 	m_initTimer->setSingleShot(true);
-	m_initTimer->setInterval(8000);
+	m_initTimer->setInterval(s_initTimerDefaultInterval);
 	connect(m_initTimer, SIGNAL(timeout()), this, SLOT(initialize()));
 
 	addVariant("standard");
 	setName("XboardEngine");
+}
+
+void XboardEngine::applyConfiguration(const EngineConfiguration& configuration)
+{
+	ChessEngine::applyConfiguration(configuration);
+
+	int timeout = s_initTimerDefaultInterval * configuration.timeoutScale();
+	m_initTimer->setInterval(timeout);
 }
 
 void XboardEngine::startProtocol()

--- a/projects/lib/src/xboardengine.h
+++ b/projects/lib/src/xboardengine.h
@@ -42,6 +42,7 @@ class LIB_EXPORT XboardEngine : public ChessEngine
 
 	protected:
 		// Inherited from ChessEngine
+		virtual void applyConfiguration(const EngineConfiguration& configuration);
 		virtual bool sendPing();
 		virtual void sendStop();
 		virtual void sendQuit();


### PR DESCRIPTION
Some issues have been raised regarding cutechess's strict timing especially at game start. Problems have been reported both for NN engines and for configurations allocating vast amounts of Hash memory.

To get around this a new CLI engine option `tscale` is introduced to scale the protocol timeouts. It can be used on a per-player (per-configuration) basis, e.g.
`cutechess-cli -engine cmd=engine1 proto=uci tscale=2.0 -engine cmd= ...` .

To achieve this a scale factor for timeouts is added to the `ChessEngine` and `EngineConfiguration` classes. The relevant engine protocol timeouts will all be multiplied with this factor. This apllies to ping, quit, idle, and  protocol start timeouts. Also for CECP engines the init timeout is scaled.

In the GUI a spin box for the scaling factor has been added to the engine configuration dialog.
The value of 1.00 is the default and displayed in gray. The increase/decrease arrows of the spin box have intentionally been omitted to discourage tinkering with the timeouts.

The scale factor can have values between 0.2 and 120.0.
I hope this is useful.

Resolves #459
Resolves #618