### PR TITLE
Support Makpong  (Makruk variant)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -133,6 +133,8 @@ Loop Chess (Drop Chess Variant)
 Los Alamos Chess
 .It losers
 Loser's Chess
+.It makpong
+Makpong (Makruk variant)
 .It makruk
 Makruk (Thai Chess)
 .It minishogi

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -59,6 +59,7 @@ Options:
 			'loop': Loop Chess (Drop Chess)
 			'losalamos': Los Alamos Chess
 			'losers': Loser's Chess
+			'makpong': Makpong (Makruk variant)
 			'makruk': Makruk (Thai Chess)
 			'minishogi': Minishogi (5x5)
 			'modern': Modern Chess (9x9)

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -47,6 +47,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/shatranjboard.cpp \
     $$PWD/courierboard.cpp \
     $$PWD/makrukboard.cpp \
+    $$PWD/makpongboard.cpp \
     $$PWD/oukboard.cpp \
     $$PWD/aseanboard.cpp \
     $$PWD/aiwokboard.cpp \
@@ -117,6 +118,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/shatranjboard.h \
     $$PWD/courierboard.h \
     $$PWD/makrukboard.h \
+    $$PWD/makpongboard.h \
     $$PWD/oukboard.h \
     $$PWD/aseanboard.h \
     $$PWD/aiwokboard.h \

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -57,6 +57,7 @@
 #include "losalamosboard.h"
 #include "losersboard.h"
 #include "ncheckboard.h"
+#include "makpongboard.h"
 #include "makrukboard.h"
 #include "minishogiboard.h"
 #include "modernboard.h"
@@ -125,6 +126,7 @@ REGISTER_BOARD(KnightMateBoard, "knightmate")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")
+REGISTER_BOARD(MakpongBoard, "makpong")
 REGISTER_BOARD(MakrukBoard, "makruk")
 REGISTER_BOARD(MiniShogiBoard, "minishogi")
 REGISTER_BOARD(ModernBoard, "modern")

--- a/projects/lib/src/board/makpongboard.cpp
+++ b/projects/lib/src/board/makpongboard.cpp
@@ -1,0 +1,100 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "makpongboard.h"
+
+namespace Chess {
+
+MakpongBoard::MakpongBoard()
+	: MakrukBoard()
+{
+}
+
+Board * MakpongBoard::copy() const
+{
+	return new MakpongBoard(*this);
+}
+
+QString MakpongBoard::variant() const
+{
+	return "makpong";
+}
+
+bool MakpongBoard::insufficientMaterial() const
+{
+	for (int i = 0; i < arraySize(); i++)
+	{
+		const Piece& piece = pieceAt(i);
+		if (piece.isValid() && piece.type() != King)
+			return false;
+	}
+	return true;
+}
+
+void MakpongBoard::generateMovesForPiece(QVarLengthArray<Chess::Move>& moves,
+					 int pieceType,
+					 int square) const
+{
+	// King cannot move out of check
+	Side side = sideToMove();
+	if (pieceType != King || square != kingSquare(side) || !inCheck(side))
+	{
+		MakrukBoard::generateMovesForPiece(moves, pieceType, square);
+		return;
+	}
+
+	// Find pieces attacking the King
+	int attacker = 0;
+	Side opp = side.opposite();
+	QVarLengthArray<Move> moves1;
+
+	int minIndex = 2 * (width() + 2) + 1;
+	int maxIndex = arraySize() - 1 - minIndex;
+	for (int i = minIndex; i <= maxIndex; i++)
+	{
+		Piece piece = pieceAt(i);
+		if (piece.side() != opp)
+			continue;
+
+		moves1.clear();
+		MakrukBoard::generateMovesForPiece(moves1, piece.type(), square);
+		for (const Move& m: moves1)
+		{
+			// Test assumes point symmetry of movement between sides
+			if (m.targetSquare() == i)
+			{
+				// No moves if in double check
+				if (attacker != 0)
+					return;
+				attacker = i;
+			}
+		}
+	}
+
+	// When in check only pieces giving check can be captured by the King
+	moves1.clear();
+	MakrukBoard::generateMovesForPiece(moves1, King, square);
+	for (const Move move: moves1)
+	{
+		int index = move.targetSquare();
+		if (attacker == index)
+			moves.append(move);
+	}
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/makpongboard.h
+++ b/projects/lib/src/board/makpongboard.h
@@ -1,0 +1,57 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MAKPONGBOARD_H
+#define MAKPONGBOARD_H
+
+#include "makrukboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Makpong
+ *
+ * Makpong is a variant of Makruk where the King may not move out of check.
+ * The King may capture an attacking piece if in range, but cannot capture
+ * out of double check.
+ *
+ * This variant is designed to reduce draws. It is used as tie breaker in
+ * Makruk single elimination tournaments.
+ *
+ * \sa MakrukBoard
+ */
+class LIB_EXPORT MakpongBoard : public MakrukBoard
+{
+	public:
+		/*! Creates a new MakpongBoard object. */
+		MakpongBoard();
+
+		// Inherited from MakrukBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+
+	protected:
+		// Inherited from MakrukBoard
+		virtual bool insufficientMaterial() const;
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+};
+
+} // namespace Chess
+#endif // MAKPONGBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -933,6 +933,20 @@ void tst_Board::results_data() const
 		<< "8/8/8/2K1k3/8/3R1R2/8/8 w - 16 13 128"
 		<< "*";
 
+	variant = "makpong";
+	QTest::newRow("makpong black win KSvsKS")
+		<< variant
+		<< "8/SK6/2s5/2k5/8/8/8/8 w - 128 110 124"
+		<< "0-1";
+	QTest::newRow("makpong double check")
+		<< variant
+		<< "4k3/4r3/8/3s4/4K3/8/8/8 w - - 0 12"
+		<< "0-1";
+	QTest::newRow("makpong KMvK sufficient material")
+		<< variant
+		<< "8/8/3k4/8/4M3/4K3/8/8 w - 128 2 1"
+		<< "*";
+
 	variant = "karouk";
 
 	QTest::newRow("karouk KRRvKM black wins by check")


### PR DESCRIPTION
 Makpong is a variant of Makruk where the King may not move out of check.  The King may capture an attacking piece if in range, but cannot capture out of double check.

 This variant is designed to reduce draws. Over the board it is used as tie breaker in Makruk single elimination tournaments.

`MakpongBoard` modifies the move generation of `MakrukBoard` and the adjudication /wrt to material. It has been tested with Fairy-Stockfish.