### PR TITLE
Flip board if gauntlet player plays Black against unseeded player

### DIFF
--- a/projects/lib/src/gauntlettournament.cpp
+++ b/projects/lib/src/gauntlettournament.cpp
@@ -39,7 +39,9 @@ void GauntletTournament::onGameAboutToStart(ChessGame* game,
 {
 	Q_UNUSED(black);
 	const int blackIndex = playerIndex(game, Chess::Side::Black);
-	if (!white->isHuman() && blackIndex == 0)
+
+	if (!white->isHuman()
+	&&  (blackIndex == 0 || blackIndex < seedCount()))
 		game->setBoardShouldBeFlipped(true);
 }
 


### PR DESCRIPTION
Recently, in gauntlet tournaments all seeded players have been gauntlet players .
To accommodate this, the PR extends support for flipping the board for gauntlet players.