### PR TITLE
Support Lines of Action (LOA)

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -127,6 +127,8 @@ Kinglet Chess
 King of the Hill Chess
 .It knightmate
 Knightmate
+.It linesofaction
+Lines of Action
 .It loop
 Loop Chess (Drop Chess Variant)
 .It losalamos

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -56,6 +56,7 @@ Options:
 			'kinglet': Kinglet Chess
 			'kingofthehill': King of the Hill Chess
 			'knightmate': Knightmate
+			'linesofaction': Lines of Action
 			'loop': Loop Chess (Drop Chess)
 			'losalamos': Los Alamos Chess
 			'losers': Loser's Chess

--- a/projects/lib/src/board/board.pri
+++ b/projects/lib/src/board/board.pri
@@ -64,6 +64,7 @@ SOURCES += $$PWD/board.cpp \
     $$PWD/hoppelpoppelboard.cpp \
     $$PWD/placementboard.cpp \
     $$PWD/gustavboard.cpp \
+    $$PWD/linesofactionboard.cpp \
     $$PWD/boardfactory.cpp \
     $$PWD/boardtransition.cpp \
     $$PWD/syzygytablebase.cpp
@@ -134,6 +135,7 @@ HEADERS += $$PWD/board.h \
     $$PWD/hoppelpoppelboard.h \
     $$PWD/placementboard.h \
     $$PWD/gustavboard.h \
+    $$PWD/linesofactionboard.h \
     $$PWD/boardfactory.h \
     $$PWD/boardtransition.h \
     $$PWD/syzygytablebase.h

--- a/projects/lib/src/board/boardfactory.cpp
+++ b/projects/lib/src/board/boardfactory.cpp
@@ -53,6 +53,7 @@
 #include "judkinsshogiboard.h"
 #include "kingofthehillboard.h"
 #include "knightmateboard.h"
+#include "linesofactionboard.h"
 #include "loopboard.h"
 #include "losalamosboard.h"
 #include "losersboard.h"
@@ -122,6 +123,7 @@ REGISTER_BOARD(JudkinsShogiBoard, "judkins")
 REGISTER_BOARD(KarOukBoard,"karouk")
 REGISTER_BOARD(KingOfTheHillBoard, "kingofthehill")
 REGISTER_BOARD(KnightMateBoard, "knightmate")
+REGISTER_BOARD(LinesOfActionBoard, "linesofaction")
 REGISTER_BOARD(LoopBoard, "loop")
 REGISTER_BOARD(LosAlamosBoard, "losalamos")
 REGISTER_BOARD(LosersBoard, "losers")

--- a/projects/lib/src/board/linesofactionboard.cpp
+++ b/projects/lib/src/board/linesofactionboard.cpp
@@ -1,0 +1,221 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "linesofactionboard.h"
+#include "westernzobrist.h"
+
+namespace Chess {
+
+LinesOfActionBoard::LinesOfActionBoard()
+	: WesternBoard(new WesternZobrist())
+{
+	setPieceType(Pawn,   "piece",    "P");
+	setPieceType(Knight, "no-knight", "");
+	setPieceType(Bishop, "no-bishop", "");
+	setPieceType(Rook,   "no-rook",   "");
+	setPieceType(Queen,  "no-queen",  "");
+	setPieceType(King,   "no-king",   "");
+}
+
+Board* LinesOfActionBoard::copy() const
+{
+	return new LinesOfActionBoard(*this);
+}
+
+QString LinesOfActionBoard::variant() const
+{
+	return "linesofaction";
+}
+
+QString LinesOfActionBoard::defaultFenString() const
+{
+	return "1pppppp1/P6P/P6P/P6P/P6P/P6P/P6P/1pppppp1 b - - 0 1";
+}
+
+bool LinesOfActionBoard::kingsCountAssertion(int whiteKings,
+					     int blackKings) const
+{
+	return whiteKings == 0 && blackKings == 0;
+}
+
+void LinesOfActionBoard::vInitialize()
+{
+	WesternBoard::vInitialize();
+
+	int arwidth = width() + 2;
+
+	m_offsets.resize(8);
+	m_offsets[0] = -arwidth - 1;
+	m_offsets[1] = -arwidth + 1;
+	m_offsets[2] = arwidth - 1;
+	m_offsets[3] = arwidth + 1;
+	m_offsets[4] = -arwidth;
+	m_offsets[5] = -1;
+	m_offsets[6] = 1;
+	m_offsets[7] = arwidth;
+
+	m_minIndex = 2 * arwidth  + 1;
+	m_maxIndex = arraySize() - 1 - m_minIndex;
+	m_drawIfBothFinished = false;
+}
+
+bool LinesOfActionBoard::isLegalPosition()
+{
+	return true;
+}
+
+QString LinesOfActionBoard::sanMoveString(const Move& move)
+{
+	QString str = squareString(move.sourceSquare());
+	str.append(captureType(move) != Piece::NoPiece ?  "x" : "-" );
+	str.append(squareString(move.targetSquare()));
+
+	return str;
+}
+
+Move LinesOfActionBoard::moveFromSanString(const QString& str)
+{
+	QString s(str);
+	s.remove(QRegExp("[-:]"));
+	return WesternBoard::moveFromLanString(s);
+}
+
+void LinesOfActionBoard::generateLineMoves(int sourceSquare,
+					   const QVarLengthArray<int>& offsets,
+					   QVarLengthArray<Move>& moves) const
+{
+	Side side = sideToMove();
+	Side opp = side.opposite();
+	for (int i = 0; i < offsets.size(); i++)
+	{
+		// At first count all pieces on the line
+		int offset = offsets[i];
+		int targetSquare = sourceSquare + offset;
+		int count = 0;
+		Piece capture;
+		while (!(capture = pieceAt(targetSquare)).isWall())
+		{
+			if (capture.isValid())
+				count++;
+			targetSquare += offset;
+		}
+		targetSquare = sourceSquare;
+		while (!(capture = pieceAt(targetSquare)).isWall())
+		{
+			if (capture.isValid())
+				count++;
+			targetSquare -= offset;
+		}
+
+		// Move exactly count squares in offset direction
+		targetSquare = sourceSquare + offset;
+		while (!(capture = pieceAt(targetSquare)).isWall())
+		{
+			count--;
+			if (count == 0 && capture.side() != side)
+				moves.append(Move(sourceSquare, targetSquare));
+			// Done / Cannot jump over opponent pieces
+			if (count == 0 || capture.side() == opp)
+				break;
+			targetSquare += offset;
+		}
+	}
+}
+
+void LinesOfActionBoard::generateMovesForPiece(QVarLengthArray<Move>& moves,
+					       int pieceType,
+					       int square) const
+{
+	if (pieceType != Pawn)
+		return;
+
+	generateLineMoves(square, m_offsets, moves);
+}
+
+int LinesOfActionBoard::components(Side side) const
+{
+	QVarLengthArray<int> pieces;
+	int areas = 0;
+	int count = 0;
+
+	for (int index = m_minIndex; index <= m_maxIndex; index++)
+	{
+		if (pieceAt(index).side() != side)
+			continue;
+
+		if (!pieces.contains(index))
+		{
+			pieces.append(index);
+			++areas;
+		}
+
+		while (count < pieces.count())
+		{
+			int square = pieces.at(count++);
+			for (int offset: m_offsets)
+			{
+				int target = square + offset;
+				if (pieceAt(target).side() == side
+				&& !pieces.contains(target))
+					pieces.append(target);
+			}
+		}
+	}
+	return areas;
+}
+
+Result LinesOfActionBoard::result()
+{
+	Side side = sideToMove();
+	Side opp  = side.opposite();
+	bool sideFinished = (components(side) < 2);
+	bool oppFinished  = (components(opp) < 2);
+
+	// Gamut of Games (1st ed.) rule by Sackson: draw if both connected
+	if (oppFinished && sideFinished && m_drawIfBothFinished)
+		return Result(Result::Draw, Side::NoSide, tr("Draw"));
+
+	// Soucie's rule: player making last move wins if both connected
+	Side winner = Side::NoSide;
+	if (oppFinished)
+		winner = opp;
+	else if (sideFinished)
+		winner = side;
+
+	// Normal wins
+	if (oppFinished || sideFinished)
+	{
+		QString str = tr("%1 wins").arg(winner.toString());
+		return Result(Result::Win, winner, str);
+	}
+
+	// 3-fold repetition
+	if (repeatCount() >= 2)
+		return Result(Result::Draw, Side::NoSide, tr("Draw by repetition"));
+
+	// Stalemated player loses
+	if(!canMove())
+	{
+		QString str = tr("%1 wins by stalemate").arg(opp.toString());
+		return Result(Result::Win, opp, str);
+	}
+
+	return Result();
+}
+
+} // namespace Chess

--- a/projects/lib/src/board/linesofactionboard.h
+++ b/projects/lib/src/board/linesofactionboard.h
@@ -1,0 +1,107 @@
+/*
+    This file is part of Cute Chess.
+    Copyright (C) 2008-2018 Cute Chess authors
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LINESOFACTIONBOARD_H
+#define LINESOFACTIONBOARD_H
+
+#include "westernboard.h"
+
+namespace Chess {
+
+/*!
+ * \brief A board for Lines of Action (LOA)
+ *
+ * Lines of Action is an abstract strategy game on a 8 x 8 board.
+ * It has been introduced by Claude Soucie, France in about 1960. It has
+ * been described by Sid Sackson in 1969 in "Gamut of Games".
+ *
+ * At start both sides have 12 pieces lined up at the boundary squares of
+ * the board. The corner squares are free. Black has their pieces on the
+ * 1st and 8th rank of the board and starts the game. White occupies the
+ * a- and the h-file and moves second. Both sides take turns moving.
+ *
+ * A piece can move horizontally, vertically, or diagonally. The step size
+ * of a move equals the total number of pieces on the line of movement.
+ * Opponent pieces can be captured but not be jumped over. Own pieces can
+ * be jumped over but not be captured.
+ *
+ * The goal of the game is to connect all of a side's on-board pieces so
+ * that they are touching horizontally, vertically, or diagonally.
+ *
+ * When all pieces of both sides get connected by the same move the game
+ * is either drawn (Sackson's draw rule) or the side making the last move
+ * wins (Soucie's rule - used here).
+ *
+ * \note Rules: https://en.wikipedia.org/wiki/Lines_of_Action
+ *
+ * \note If a side has no legal moves left this implementation adjudicates
+ * a win for the opponent. When a position occurs for the third time the
+ * game is drawn. When both sides finish at the same time the side making
+ * the last move wins.
+ *
+ * \note There is a variant "Scrambled Eggs" where white and black pieces
+ * are placed alternately on the outer squares.
+ * FEN: 1PpPpPp1/p6P/P6p/p6P/P6p/p6P/P6p/1pPpPpP1 b - - 0 1
+ * */
+class LIB_EXPORT LinesOfActionBoard : public WesternBoard
+{
+	public:
+		/*! Creates a new LinesOfActionBoard object. */
+		LinesOfActionBoard();
+
+		// Inherited from WesternBoard
+		virtual Board* copy() const;
+		virtual QString variant() const;
+		virtual QString defaultFenString() const;
+		virtual Result result();
+
+	protected:
+		/*!
+		 * Generates moves with a range equal to the number of pieces
+		 * on the line and without jumping over opponent pieces.
+		 *
+		 * \param sourceSquare The source square of the piece
+		 * \param offsets An array of offsets for the target square
+		 * \note The generated \a moves include captures.
+		 */
+		void generateLineMoves(int sourceSquare,
+				       const QVarLengthArray<int>& offsets,
+				       QVarLengthArray<Move>& moves) const;
+
+		// Inherited from WesternBoard
+		virtual void vInitialize();
+		virtual bool kingsCountAssertion(int whiteKings,
+						 int blackKings) const;
+		virtual bool isLegalPosition();
+		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
+						   int pieceType,
+						   int square) const;
+		virtual QString sanMoveString(const Move& move);
+		virtual Move moveFromSanString(const QString& str);
+
+	private:
+		int components(Side side) const;
+
+		int m_minIndex;
+		int m_maxIndex;
+		int m_drawIfBothFinished;
+		QVarLengthArray<int> m_offsets;
+};
+
+} // namespace Chess
+#endif // LINESOFACTIONBOARD_H

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -984,6 +984,29 @@ void tst_Board::results_data() const
 		<< "9/9/1n7/9/9/9/3n5/9/9 w - - 0 24"
 		<< "0-1";
 
+	variant = "linesofaction";
+
+	QTest::newRow("LOA continue")
+		<< variant
+		<< "4P3/3PP3/4Ppp1/2p1PpP1/1PPp1pP1/1P1P1p2/3pp3/8 b - - 0 20"
+		<< "*";
+	QTest::newRow("LOA black win1")
+		<< variant
+		<< "4P3/3PP3/4Ppp1/4PpP1/1PPp1pP1/1P1Ppp2/3pp3/8 w - - 0 21"
+		<< "0-1";
+	QTest::newRow("LOA white win1")
+		<< variant
+		<< "4P3/3pP3/4Ppp1/2p1PpP1/2P2PP1/3PPp2/4pp2/8 b - - 0 22"
+		<< "1-0";
+	QTest::newRow("LOA black win2")
+		<< variant
+		<< "8/3PP3/4Ppp1/2P1PpP1/4PpP1/3PPp2/3ppp2/8 b - - 0 28"
+		<< "0-1";
+	QTest::newRow("LOA both finished")
+		<< variant
+		<< "8/4P3/4P3/3PPP2/4Ppp1/3PP1p1/5pp1/4pp2 w - - 0 35"
+		<< "0-1";
+
 	variant = "shogi";
 
 	QTest::newRow("shogi Sente win")
@@ -1661,6 +1684,13 @@ void tst_Board::perft_data() const
 		<< "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 		<< 4 // 4 plies: 153023, 5 plies: 2735167, 6 plies: 46678307
 		<< Q_UINT64_C(153023);
+
+	variant = "linesofaction";
+	QTest::newRow("LOA startpos")
+		<< variant
+		<< "1PPPPPP1/p6p/p6p/p6p/p6p/p6p/p6p/1PPPPPP1 b - - 0 1"
+		<< 4 // 3 plies: 44952, 4 plies: 1563146, 5 plies: 55963208
+		<< Q_UINT64_C(1563146);
 }
 
 void tst_Board::perft()


### PR DESCRIPTION
[_Lines of Action_](https://en.wikipedia.org/wiki/Lines_of_Action) is an abstract strategy game on a 8 x 8 board. It has been introduced by Claude Soucie (–1960).

At start both sides have 12 pieces lined up at the boundary squares of the board. The corner squares are free. Black has their pieces on the 1st and 8th rank of the board and starts the game. White occupies the
a- and the h-file and moves second. Both sides take turns moving.

A piece can move horizontally, vertically, or diagonally. The step size  of a move equals the total number of pieces on the line of movement. Opponent pieces can be captured but not be jumped over. Own pieces can be jumped over but not be captured.

The goal of the game is to connect all of a side's on-board pieces so that they are touching horizontally, vertically, or diagonally.

When all pieces of both sides get connected by the same move the game is either drawn (Sackson's draw rule) or the side making the last move wins (Soucie's rule - which is used here). From Wikipedia: _"Despite the intention of the inventor of LOA, most present day tournaments including the World Championships at the Mind Sports Olympiad score simultaneous connection as a draw. "_ Therefore the implementation also supports Sackson's draw rule, but currently the controlling flag is set to false.

If a side has no legal moves left this implementation adjudicates a win for the opponent. When a position occurs for the third time the game is drawn.

This implementation is based on `WesternBoard`, it. uses the standard chess implementation and chess notation.

![loa0](https://user-images.githubusercontent.com/6425738/96366924-3e8aef00-113a-11eb-80f8-a9242e07575f.png) 
_LOA Starting Position_
![loa1](https://user-images.githubusercontent.com/6425738/96366912-2dda7900-113a-11eb-8627-2cc661a7635b.png)
_All black pieces are connected, Black wins._ 

There is a variant "Scrambled Eggs" where white and black pieces are placed alternately on the outer squares.
 FEN: 1PpPpPp1/p6P/P6p/p6P/P6p/p6P/P6p/1pPpPpP1 b - - 0 1
This variant can be set-up via FEN (directly or per openings file). 

![loa3](https://user-images.githubusercontent.com/6425738/96367065-1c45a100-113b-11eb-96c1-311a1fbd88f3.png)
_"Scambled Eggs" starting position_

I hope this is OK to be included. 


