### PR TITLE
Maintainance

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -493,7 +493,7 @@ Play a single game between Atak and Glaurung engines with a time
 control of 40 moves in one minute and 30 seconds with one second
 increment:
 .Pp
-.Dl $ cutechess-cli \-engine name=Atak cmd=Atak32.exe dir=C:\eatak proto=xboard -engine cmd=glaurung proto=uci option.Threads=1 -both tc=40/1:30+1
+.Dl $ cutechess-cli \-engine name=Atak cmd=Atak32.exe dir=C:\eatak proto=xboard -engine cmd=glaurung proto=uci option.Threads=1 -each tc=40/1:30+1
 .Bl -bullet
 .It
 Use the name=Atak parameter because it's a Xboard protocol 1 engine

--- a/projects/lib/src/gameadjudicator.cpp
+++ b/projects/lib/src/gameadjudicator.cpp
@@ -146,7 +146,7 @@ void GameAdjudicator::addEval(const Chess::Board* board, const MoveEvaluation& e
 	if (m_maxGameLength > 0
 	&&  board->plyCount() >= 2 * m_maxGameLength)
 	{
-		m_result = Chess::Result(Chess::Result::Adjudication, Chess::Side::NoSide);
+		m_result = Chess::Result(Chess::Result::Adjudication, Chess::Side::NoSide, "maximal game length");
 		return;
 	}
 }


### PR DESCRIPTION
This PR contains small fixes.

- replace the old option `-both` in the manual page by `-each`.
- if a game is drawn after a user defined maximal move number has been reached then set a corresponding result text to be more specific.