### PR TITLE
Fix ai-wok variant name in docs

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -39,7 +39,7 @@ is one of:
 Three-check Chess
 .It 5check
 Five-check Chess
-.It aiwok
+.It ai-wok
 Ai-Wok (Makruk variant)
 .It almost
 Almost Chess

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -12,7 +12,7 @@ Options:
   -variant VARIANT	Set the chess variant to VARIANT, which can be one of:
 			'3check': Three-check Chess
 			'5check': Five-check Chess
-			'aiwok': Ai-Wok (Makruk variant)
+			'ai-wok': Ai-Wok (Makruk variant)
 			'almost': Almost Chess
 			'amazon': Amazon Chess
 			'andernach': Andernach Chess


### PR DESCRIPTION
The cutechess CLI expects to use the variant name `ai-wok`, while the docs say `aiwok`. This PR should make the naming consistent.