### PR TITLE
Make UCI options case insensitive

### DIFF
--- a/projects/lib/src/chessengine.cpp
+++ b/projects/lib/src/chessengine.cpp
@@ -152,12 +152,24 @@ void ChessEngine::addOption(EngineOption* option)
 
 EngineOption* ChessEngine::getOption(const QString& name) const
 {
-	for (EngineOption* option : qAsConst(m_options))
+	if (hasCaseSensitiveOptions())
 	{
-		if (option->alias() == name || option->name() == name)
-			return option;
+		for (EngineOption* option : qAsConst(m_options))
+		{
+			if (option->alias() == name || option->name() == name)
+				return option;
+		}
 	}
-
+	else
+	{
+		QString lowerCaseName = name.toLower();
+		for (EngineOption* option : qAsConst(m_options))
+		{
+			if (option->alias().toLower() == lowerCaseName
+			||  option->name().toLower() == lowerCaseName)
+				return option;
+		}
+	}
 	return nullptr;
 }
 
@@ -306,6 +318,11 @@ bool ChessEngine::supportsVariant(const QString& variant) const
 int ChessEngine::id() const
 {
 	return m_id;
+}
+
+bool ChessEngine::hasCaseSensitiveOptions() const
+{
+	return true;
 }
 
 bool ChessEngine::stopThinking()

--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -231,6 +231,11 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		 * Gives id number of the engine
 		 */
 		int id() const;
+		/*!
+		 * Returns true if option names are case sensitive else false.
+		 * The default value is true.
+		 */
+		virtual bool hasCaseSensitiveOptions() const;
 
 	protected slots:
 		// Inherited from ChessPlayer

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -319,6 +319,11 @@ QString UciEngine::protocol() const
 	return "uci";
 }
 
+bool UciEngine::hasCaseSensitiveOptions() const
+{
+	return false;
+}
+
 bool UciEngine::sendPing()
 {
 	write("isready");

--- a/projects/lib/src/uciengine.h
+++ b/projects/lib/src/uciengine.h
@@ -54,6 +54,7 @@ class LIB_EXPORT UciEngine : public ChessEngine
 		virtual void parseLine(const QString& line);
 		virtual void sendOption(const QString& name, const QVariant& value);
 		virtual bool isPondering() const;
+		virtual bool hasCaseSensitiveOptions() const override;
 		
 	private:
 		enum PonderState


### PR DESCRIPTION
The UCI specification says option names should be case insensitive.

This patch resolves #683