### PR TITLE
Remove "fischerandom" from UCI combo variants

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -44,6 +44,9 @@ QString variantFromUci(QString str, bool uciPrefix = true)
 		return QString();
 
 	str = str.toLower();
+	if (str == "fischerandom")
+		return QString();
+
 	if (str == "chess960")
 		str = "fischerandom";
 
@@ -738,14 +741,17 @@ void UciEngine::addVariantsFromOption(const EngineOption* option)
 		return;
 	}
 
+	m_comboVariants.clear();
 	const auto choices = combo->choices();
 	for (const auto& choice : choices)
 	{
 		QString variant = variantFromUci(choice, false);
 		if (!variant.isEmpty())
+		{
 			addVariant(variant);
+			m_comboVariants << variant;
+		}
 	}
-	m_comboVariants = choices;
 }
 
 void UciEngine::setVariant(const QString& variant)


### PR DESCRIPTION
UCI uses boolean option "UCI_Chess960" or combo UCI_Variant value "var chess960"
Boolean option "UCI_Fischerandom" and combo UCI_Variant value "var fischerandom" are not supported.

Resolves #667

This commit avoids an inconsistent behaviour of CC for FRC/Chess960 when an engine (here: _Fairy-Stockfish_, versions 10.4 and newer) has both boolean option `UCI_Chess960` and combo option `UCI_Variant` and not using value **var chess960** (like _Sjaak II_) but **var fischerandom**. CC reads **var fischerandom** and activates `FRCBoard` but inconsistently issues **setoption name UCI_Variant value chess960**. The engine then remains in standard chess mode and loses.
```
148 >stockfish-fairy-10.4(1): setoption name UCI_Variant value chess960
```
Older versions of Fairy-Stockfish did not have value **var fischerandom** and thus the boolean option UCI_Chess960 was used without problem.
```
148 >stockfish-fairy-10.3(0): setoption name UCI_Chess960 value true
```

This PR removes **var fischerandom** from the values of `UCI_Variant`. 
Tested as working with _Fairy.Stockfish 10.3, Fairy.Stockfish 10.4, Fairy.Stockfish 14_ and _Sjaak II_ version 1.3.1.

```
126 >stockfish-fairy-10.4(0): setoption name UCI_Chess960 value true
...
126 >stockfish-fairy-10.3(1): setoption name UCI_Chess960 value true
```
```
140 >stockfish-fairy-14(0): setoption name UCI_Chess960 value true
...
140 >sjaakii(1): setoption name UCI_Variant value chess960
```

This can be considered as a work-around before more profound solution is in place.
HTH