### PR TITLE
Issue warning if a UCI engine sends a PV when not supposed to do this

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -407,7 +407,13 @@ void UciEngine::parseInfo(const QVarLengthArray<QStringRef>& tokens,
 		eval->setPvNumber(tokens[0].toString().toInt());
 		break;
 	case InfoPv:
-		eval->setPv(m_useDirectPv ?  directPv(tokens) : sanPv(tokens));
+		if (this->state() == Thinking
+		|| (this->state() == Observing && pondering()))
+			eval->setPv(m_useDirectPv ? directPv(tokens) : sanPv(tokens));
+		else if (this->state() != FinishingGame)
+			qWarning("Unexpected PV from %s: %s",
+				 qUtf8Printable(name()),
+				 qUtf8Printable(directPv(tokens)));
 		break;
 	case InfoScore:
 		{


### PR DESCRIPTION
If a UCI engine sends a PV when not supposed to be in the thinking state or pondering, then issue a warning instead of logging an illegal PV move.

Resolves #472