### PR TITLE
Add notes to engine configurations

### DIFF
--- a/projects/gui/src/engineconfigurationdlg.cpp
+++ b/projects/gui/src/engineconfigurationdlg.cpp
@@ -120,6 +120,7 @@ void EngineConfigurationDialog::applyEngineInformation(
 	ui->m_protocolCombo->setCurrentIndex(i);
 
 	ui->m_initStringEdit->setPlainText(engine.initStrings().join("\n"));
+	ui->m_notesEdit->setPlainText(engine.notes());
 
 	if (engine.whiteEvalPov())
 		ui->m_whitePovCheck->setCheckState(Qt::Checked);
@@ -148,6 +149,8 @@ EngineConfiguration EngineConfigurationDialog::engineConfiguration()
 	QString initStr(ui->m_initStringEdit->toPlainText());
 	if (!initStr.isEmpty())
 		engine.setInitStrings(initStr.split('\n'));
+
+	engine.setNotes(ui->m_notesEdit->toPlainText());
 
 	engine.setWhiteEvalPov(ui->m_whitePovCheck->checkState() == Qt::Checked);
 

--- a/projects/gui/ui/engineconfigdlg.ui
+++ b/projects/gui/ui/engineconfigdlg.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>400</height>
+    <height>500</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -118,7 +118,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <widget class="QCheckBox" name="m_whitePovCheck">
          <property name="enabled">
           <bool>false</bool>
@@ -128,6 +128,16 @@
          </property>
          <property name="text">
           <string>Scores from &amp;white's perspective</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QPlainTextEdit" name="m_notesEdit"/>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="m_notesLabel">
+         <property name="text">
+          <string>Notes:</string>
          </property>
         </widget>
        </item>

--- a/projects/lib/src/engineconfiguration.cpp
+++ b/projects/lib/src/engineconfiguration.cpp
@@ -95,6 +95,9 @@ EngineConfiguration::EngineConfiguration(const QVariant& variant)
 				addOption(option);
 		}
 	}
+
+	if(map.contains("notes"))
+		setNotes(map["notes"].toString());
 }
 
 EngineConfiguration::EngineConfiguration(const EngineConfiguration& other)
@@ -103,6 +106,7 @@ EngineConfiguration::EngineConfiguration(const EngineConfiguration& other)
 	  m_workingDirectory(other.m_workingDirectory),
 	  m_stderrFile(other.m_stderrFile),
 	  m_protocol(other.m_protocol),
+	  m_notes(other.m_notes),
 	  m_arguments(other.m_arguments),
 	  m_initStrings(other.m_initStrings),
 	  m_variants(other.m_variants),
@@ -127,6 +131,7 @@ EngineConfiguration& EngineConfiguration::operator=(EngineConfiguration&& other)
 	m_workingDirectory = other.m_workingDirectory;
 	m_stderrFile = other.m_stderrFile;
 	m_protocol = other.m_protocol;
+	m_notes = other.m_notes;
 	m_arguments = other.m_arguments;
 	m_initStrings = other.m_initStrings;
 	m_variants = other.m_variants;
@@ -182,6 +187,9 @@ QVariant EngineConfiguration::toVariant() const
 
 		map.insert("options", optionsList);
 	}
+
+	if(!m_notes.isEmpty())
+		map.insert("notes", m_notes);
 
 	return map;
 }
@@ -361,6 +369,16 @@ void EngineConfiguration::setClaimsValidated(bool validate)
 	m_validateClaims = validate;
 }
 
+QString EngineConfiguration::notes() const
+{
+	return m_notes;
+}
+
+void EngineConfiguration::setNotes(const QString thenotes)
+{
+	m_notes = thenotes;
+}
+
 EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& other)
 {
 	if (this != &other)
@@ -370,6 +388,7 @@ EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& o
 		m_workingDirectory = other.m_workingDirectory;
 		m_stderrFile = other.m_stderrFile;
 		m_protocol = other.m_protocol;
+		m_notes = other.m_notes;
 		m_arguments = other.m_arguments;
 		m_initStrings = other.m_initStrings;
 		m_variants = other.m_variants;

--- a/projects/lib/src/engineconfiguration.h
+++ b/projects/lib/src/engineconfiguration.h
@@ -206,6 +206,10 @@ class LIB_EXPORT EngineConfiguration
 		/*! Sets result claim validation mode to \a validate. */
 		void setClaimsValidated(bool validate);
 
+		/*! Returns the notes regarding the engine. */
+		QString notes() const;
+		/*! Sets notes regarding the engine. */
+		void setNotes(const QString thenotes);
 		/*!
 		 * Assigns \a other to this engine configuration and returns
 		 * a reference to this object.
@@ -218,6 +222,7 @@ class LIB_EXPORT EngineConfiguration
 		QString m_workingDirectory;
 		QString m_stderrFile;
 		QString m_protocol;
+		QString m_notes;
 		QStringList m_arguments;
 		QStringList m_initStrings;
 		QStringList m_variants;


### PR DESCRIPTION
This patch enables users to add comments to engine configurations. I hope this is useful.

A `QPlainTextEdit`  is added to `EngineConfigDlg`.
`QString` notes fields are added to `EngineConfiguration` and `EngineConfigurationDlg`

Resolves #651

![n2](https://user-images.githubusercontent.com/6425738/147839226-b790af32-4ba6-4404-b06d-152087b16ffe.png)

