### PR TITLE
GUI: Add tooltip text to resultformat edit

### DIFF
--- a/projects/gui/src/tournamentsettingswidget.cpp
+++ b/projects/gui/src/tournamentsettingswidget.cpp
@@ -76,6 +76,24 @@ TournamentSettingsWidget::TournamentSettingsWidget(QWidget *parent)
 	});
 
 	readSettings();
+
+	// Build text for tool tip of result formats
+	QString s("\n\nField tokens:\n   ");
+	for (const QString& token: tournament.resultFieldTokens())
+	{
+			s.append(qUtf8Printable(token));
+			s.append(" ");
+	}
+	s.append("\n\nNamed shortcuts:");
+	const auto& map2(tournament.resultFieldGroups());
+	for (auto it = map2.constBegin(); it != map2.constEnd(); ++it)
+	{
+		s.append("\n");
+		s.append(qUtf8Printable(it.key()));
+		s.append("\n   ");
+		s.append(qUtf8Printable(it.value()));
+	}
+	ui->m_resultFormatEdit->setToolTip(ui->m_resultFormatEdit->toolTip().append(s));
 }
 
 TournamentSettingsWidget::~TournamentSettingsWidget()

--- a/projects/gui/ui/tournamentsettingswidget.ui
+++ b/projects/gui/ui/tournamentsettingswidget.ui
@@ -326,6 +326,9 @@
         <height>25</height>
        </rect>
       </property>
+      <property name="toolTip">
+       <string>Format accepts a comma separated list of fields or shortcuts</string>
+      </property>
       <property name="autoFillBackground">
        <bool>false</bool>
       </property>


### PR DESCRIPTION
In the CLI help to control the format of the result table can be listed by `-resultformat help`.
This patch adds a tooltip with available format fields and shortcuts to the GUI's format line edit.