### PR TITLE
GUI: Add tournament progress counter to window title

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -922,7 +922,7 @@ QString MainWindow::genericTitle(const TabData& gameData) const
 
 	QString info;
 	Tournament* t = gameData.m_game ? gameData.m_tournament: nullptr;
-	if (t)
+	if (t && QSettings().value("ui/display_game_count_in_title", false).toBool())
 		info = tr(" [%1/%2]").arg(QString::number(t->finishedGameCount()),
 					  QString::number(t->finalGameCount()));
 	if (result.isNone())

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -920,11 +920,16 @@ QString MainWindow::genericTitle(const TabData& gameData) const
 		result = gameData.m_pgn->result();
 	}
 
+	QString info;
+	Tournament* t = gameData.m_game ? gameData.m_tournament: nullptr;
+	if (t)
+		info = tr(" [%1/%2]").arg(QString::number(t->finishedGameCount()),
+					  QString::number(t->finalGameCount()));
 	if (result.isNone())
-		return tr("%1 vs %2").arg(white, black);
+		return tr("%1 vs %2%3").arg(white, black, info);
 	else
-		return tr("%1 vs %2 (%3)")
-		       .arg(white, black, result.toShortString());
+		return tr("%1 vs %2 (%3)%4")
+		       .arg(white, black, result.toShortString(), info);
 }
 
 void MainWindow::updateMenus()

--- a/projects/gui/src/settingsdlg.cpp
+++ b/projects/gui/src/settingsdlg.cpp
@@ -62,6 +62,12 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 		QSettings().setValue("ui/display_players_sides_on_clocks", checked);
 	});
 
+	connect(ui->m_gameCountInTitleCheck, &QCheckBox::toggled,
+		this, [=](bool checked)
+	{
+		QSettings().setValue("ui/display_game_count_in_title", checked);
+	});
+
 	connect(ui->m_autoFlipBoardForHumanGamesCheck, &QCheckBox::toggled,
 		[=](bool checked)
 	{
@@ -223,6 +229,8 @@ void SettingsDialog::readSettings()
 		s.value("use_full_user_name", true).toBool());
 	ui->m_playersSidesOnClocksCheck->setChecked(
 		s.value("display_players_sides_on_clocks", false).toBool());
+	ui->m_gameCountInTitleCheck->setChecked(
+		s.value("display_game_count_in_title", false).toBool());
 	ui->m_autoFlipBoardForHumanGamesCheck->setChecked(
 		s.value("auto_flip_board_for_human_games", false).toBool());
 	ui->m_tbPathEdit->setText(s.value("tb_path").toString());

--- a/projects/gui/ui/settingsdlg.ui
+++ b/projects/gui/ui/settingsdlg.ui
@@ -79,14 +79,14 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="8" column="0">
           <widget class="QCheckBox" name="m_autoFlipBoardForHumanGamesCheck">
            <property name="text">
             <string>Auto flip board for human vs human</string>
            </property>
           </widget>
          </item>
-         <item row="8" column="0">
+         <item row="9" column="0">
           <widget class="QCheckBox" name="m_humanCanPlayAfterTimeoutCheck">
            <property name="text">
             <string>Human player can play after timeout</string>
@@ -96,7 +96,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0">
+         <item row="10" column="0">
           <widget class="QLabel" name="m_moveAnimationLabel">
            <property name="text">
             <string>Duration of mo&amp;ve animation:</string>
@@ -106,7 +106,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="1">
+         <item row="10" column="1">
           <widget class="QSpinBox" name="m_moveAnimationSpin">
            <property name="toolTip">
             <string>duration of a move animation (default: 300 ms)</string>
@@ -125,6 +125,13 @@
            </property>
            <property name="value">
             <number>300</number>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QCheckBox" name="m_gameCountInTitleCheck">
+           <property name="text">
+            <string>Display game count in title</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
This PR resolves #112 and resolves #658, a suggestion how to follow the progress of tournaments more easily. It consists of two commits.

By the first commit the **number of finished tournament games** and the **final number of games** are added to the title text.
The title text for non-tournament games is unchanged. Currently the sequence number of a tournament game is neither transmitted nor stored in the GUI accessibly, so the number of finished games is used.

The second commit provides a checkbox in the `SettingsDlg`  (in _Tools->Settings->General_) to enable/disable the display of the counter. At the moment the default is set to false - do not display.

I hope this is useful.

![tt3](https://user-images.githubusercontent.com/6425738/147887361-95aec40a-1fa0-49e0-9b61-37753a20b62a.png)
_The tabs of a single game and two tournament games just after tournament start._

![tt2](https://user-images.githubusercontent.com/6425738/147887273-2caddeb0-bff5-48c3-be9b-94a088f011b5.png)
_The tabs of two tournament games after tournament end. A single game is shown in the right tab._

![se1](https://user-images.githubusercontent.com/6425738/153858635-37e1519d-bc50-44e7-86fd-2afb6eb5cc32.png)
_The feature can be activated by ticking the checkbox Tools->Settings->General->Display game count in title._