### PR TITLE
Replace obsolete signal QComboBox::currentIndexChanged

### DIFF
--- a/projects/gui/src/gamesettingswidget.cpp
+++ b/projects/gui/src/gamesettingswidget.cpp
@@ -37,7 +37,7 @@ GameSettingsWidget::GameSettingsWidget(QWidget *parent)
 	ui->setupUi(this);
 
 	ui->m_variantCombo->addItems(Chess::BoardFactory::variants());
-	connect(ui->m_variantCombo, SIGNAL(currentIndexChanged(QString)),
+	connect(ui->m_variantCombo, SIGNAL(currentTextChanged(const QString &)),
 		this, SIGNAL(variantChanged(QString)));
 	int index = ui->m_variantCombo->findText("standard");
 	ui->m_variantCombo->setCurrentIndex(index);


### PR DESCRIPTION
Replace obsolete `signal QComboBox::currentIndexChanged(const QString &`) by
`signal QComboBox::currentTextChanged(const QString &)` for Qt-6 and Qt-5 compatibility. The former signal has been dropped from Qt-6. 

Tested for Qt-5.9.5. The variant change is reflected in the according choice of engines.

Resolves #703 .

