### PR TITLE
Re-use previous tournament's settings

### DIFF
--- a/projects/gui/src/gamesettingswidget.h
+++ b/projects/gui/src/gamesettingswidget.h
@@ -53,6 +53,7 @@ class GameSettingsWidget : public QWidget
 
 		void applyEngineConfiguration(EngineConfiguration* config);
 		void enableSettingsUpdates();
+		void readSettings();
 
 	public slots:
 		void onHumanCountChanged(int count);
@@ -67,8 +68,6 @@ class GameSettingsWidget : public QWidget
 		void showTimeControlDialog();
 
 	private:
-		void readSettings();
-
 		Ui::GameSettingsWidget *ui;
 		TimeControl m_timeControl;
 		Chess::Board* m_board;

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -74,7 +74,8 @@ MainWindow::TabData::TabData(ChessGame* game, Tournament* tournament)
 }
 
 MainWindow::MainWindow(ChessGame* game)
-	: m_game(nullptr),
+	: m_tournamentDlg(nullptr),
+	  m_game(nullptr),
 	  m_closing(false),
 	  m_readyToClose(false),
 	  m_firstTabAutoCloseEnabled(true)
@@ -785,13 +786,17 @@ void MainWindow::onGameFinished(ChessGame* game)
 
 void MainWindow::newTournament()
 {
-	NewTournamentDialog dlg(CuteChessApplication::instance()->engineManager(), this);
-	if (dlg.exec() != QDialog::Accepted)
+	if (m_tournamentDlg == nullptr)
+		m_tournamentDlg = new NewTournamentDialog(
+					CuteChessApplication::instance()->engineManager(),
+					this);
+
+	if (m_tournamentDlg->exec() != QDialog::Accepted)
 		return;
 
 	GameManager* manager = CuteChessApplication::instance()->gameManager();
 
-	Tournament* t = dlg.createTournament(manager);
+	Tournament* t = m_tournamentDlg->createTournament(manager);
 	auto resultsDialog = CuteChessApplication::instance()->tournamentResultsDialog();
 	connect(t, SIGNAL(finished()),
 		this, SLOT(onTournamentFinished()));

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -31,6 +31,7 @@ class QMenu;
 class QAction;
 class QCloseEvent;
 class QTabBar;
+class NewTournamentDialog;
 class GameViewer;
 class MoveList;
 class PlainTextLog;
@@ -134,6 +135,8 @@ class MainWindow : public QMainWindow
 		GameViewer* m_gameViewer;
 		MoveList* m_moveList;
 		PgnTagsModel* m_tagsModel;
+
+		NewTournamentDialog* m_tournamentDlg;
 
 		QAction* m_quitGameAct;
 		QAction* m_newGameAct;

--- a/projects/gui/src/newtournamentdialog.cpp
+++ b/projects/gui/src/newtournamentdialog.cpp
@@ -123,6 +123,17 @@ NewTournamentDialog::NewTournamentDialog(EngineManager* engineManager,
 	ui->m_gameSettings->onHumanCountChanged(0);
 	onVariantChanged(ui->m_gameSettings->chessVariant());
 	readSettings();
+
+	ui->buttonBox->addButton(QDialogButtonBox::Reset);
+	connect(ui->buttonBox->button(QDialogButtonBox::Reset),
+		&QAbstractButton::clicked, this, [=]()
+	{
+		ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+		readSettings();
+		ui->m_tournamentSettings->readSettings();
+		ui->m_gameSettings->readSettings();
+		m_addedEnginesManager->setEngines({});
+	});
 }
 
 NewTournamentDialog::~NewTournamentDialog()
@@ -316,21 +327,14 @@ Tournament* NewTournamentDialog::createTournament(GameManager* gameManager) cons
 
 void NewTournamentDialog::readSettings()
 {
+	ui->m_nameEdit->setText(QSettings().value("pgn/event", "My Tournament").toString());
 	ui->m_siteEdit->setText(QSettings().value("pgn/site").toString());
 
-	QString pgnName = ui->m_pgnoutEdit->text();
-	if (pgnName.isEmpty())
-	{
-		pgnName = QSettings().value("tournament/default_pgn_output_file",
+	QString pgnName = QSettings().value("tournament/default_pgn_output_file",
 					    QString()).toString();
-		ui->m_pgnoutEdit->setText(pgnName);
-	}
+	ui->m_pgnoutEdit->setText(pgnName);
 
-	QString epdName = ui->m_epdoutEdit->text();
-	if (epdName.isEmpty())
-	{
-		epdName = QSettings().value("tournament/default_epd_output_file",
+	QString epdName = QSettings().value("tournament/default_epd_output_file",
 					    QString()).toString();
-		ui->m_epdoutEdit->setText(epdName);
-	}
+	ui->m_epdoutEdit->setText(epdName);
 }

--- a/projects/gui/src/tournamentsettingswidget.h
+++ b/projects/gui/src/tournamentsettingswidget.h
@@ -46,13 +46,12 @@ class TournamentSettingsWidget : public QWidget
 		QString resultFormat() const;
 
 		void enableSettingsUpdates();
+		void readSettings();
 
 	signals:
 		void tournamentTypeChanged(const QString& tournamentType);
 
 	private:
-		void readSettings();
-
 		Ui::TournamentSettingsWidget *ui;
 };
 


### PR DESCRIPTION
This patch changes the usage of the `NewTournamentDialog` in the GUI. Currently this dialog is deleted after use (OK or Cancel) and a new instance with the default settings is used for the next tournament. 

This code re-uses the existing `NewTournamentDialog` with old values to speed up the set-up of the next - probably similar - tournament. A new _Reset_-Button triggers the reset to values originating from the settings in the file _cutechess.ini_ . However, other values which have no setting in _cutechess.ini_  remain unchanged.

The method `NewTournamentDialog::readSettings` has been simplified and corrected.

This PR is an **alternative** to the patch which uses a new dialog after reset, PR #707.

Resolves #209

![nt1](https://user-images.githubusercontent.com/6425738/150648403-e478702a-2c2e-4973-b0d8-71583901a128.png)
_A "Reset"-button has been added to NewTournamentDialog._

_Example: Values before ..._
![nt2](https://user-images.githubusercontent.com/6425738/150648406-5e51eb33-c7fa-41ca-bde7-aef6a9a5a325.png)

_... and after pressing the "Reset"-button._
![nt3](https://user-images.githubusercontent.com/6425738/150648422-3fc213c9-2d4a-4b2f-969f-4e7dba1a0382.png)


HTH.