### PR TITLE
Improve communication with old CECP engines

### DIFF
--- a/projects/lib/src/xboardengine.h
+++ b/projects/lib/src/xboardengine.h
@@ -81,6 +81,7 @@ class LIB_EXPORT XboardEngine : public ChessEngine
 		
 		bool m_forceMode;
 		bool m_drawOnNextMove;
+		enum {InitPhase, GamePhase} m_comPhase;
 		
 		// Engine features
 		bool m_ftName;


### PR DESCRIPTION
An addition to `XboardEngine`  (#411) leads to some problems. Older CECP engines do not understand many of the version 2 protocol keywords. During initialisation they claim "Illegal Move" when given an unknown command. This causes game terminations even before the first move.

This PR Introduces the flag `m_comPhase`, an enumeration to discriminate the initialisation phase from the phase of game play.
Now "Illegal move" claims by an CECP engine are only checked during the game phase.