### PR TITLE
Aligned PGN output

### DIFF
--- a/projects/gui/src/movelist.cpp
+++ b/projects/gui/src/movelist.cpp
@@ -25,7 +25,9 @@
 #include <QAction>
 #include <chessgame.h>
 #include <QMenu>
-
+#include <QClipboard>
+#include "cutechessapp.h"
+#include <QTextStream>
 
 MoveList::MoveList(QWidget* parent)
 	: QWidget(parent),
@@ -89,6 +91,21 @@ MoveList::MoveList(QWidget* parent)
 		{
 			toggleCommentAct->setEnabled(true);
 		});
+	});
+	QAction* copyListAct = new QAction("Copy with PGN header", m_moveList);
+	m_moveList->addAction(copyListAct);
+	connect(copyListAct, &QAction::triggered, this, [=]()
+	{
+		if (m_game.isNull() && m_pgn == nullptr)
+			return;
+
+		PgnGame::PgnMode mode = m_showComments ?PgnGame::PgnMode::Verbose:
+							PgnGame::PgnMode::Minimal;
+		QClipboard* cb = CuteChessApplication::clipboard();
+		QString str;
+		QTextStream s(&str);
+		m_pgn->write(s, mode, true);
+		cb->setText(s.readAll());
 	});
 	m_moveList->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
 

--- a/projects/lib/src/pgngame.h
+++ b/projects/lib/src/pgngame.h
@@ -114,19 +114,23 @@ class LIB_EXPORT PgnGame
 		bool read(PgnStream& in, int maxMoves = INT_MAX - 1,
 				  bool addEco = true);
 		/*!
-		 * Writes the game to a text stream.
+		 * Writes the game to a text stream. If \a aligned is true,
+		 * then only one full move per line is listed.
 		 *
 		 * Returns true if successful; otherwise returns false.
 		 */
-		bool write(QTextStream& out, PgnMode mode = Verbose) const;
+		bool write(QTextStream& out, PgnMode mode = Verbose,
+			   bool aligned = false) const;
 		/*!
 		 * Writes the game to a file.
 		 * If the file already exists, the game will be appended
-		 * to the end of the file.
+		 * to the end of the file. If \a aligned is true,
+		 * then only one full move per line is listed.
 		 *
 		 * Returns true if successful; otherwise returns false.
 		 */
-		bool write(const QString& filename, PgnMode mode = Verbose) const;
+		bool write(const QString& filename, PgnMode mode = Verbose,
+			   bool aligned = false) const;
 		
 		/*!
 		 * Returns true if the game's variant is "standard" and it's


### PR DESCRIPTION
In issue #662 a more readable PGN output has been requested. Usually PGN outputs are listing more than one move per line with the line with limited to 80 characters. This patch provides a method to list one full move per line with aligned columns. The output is copied to the application clipboard.

The patch adds a lambda expression to` MoveList::MoveList` to copy the game's PGN header and a formatted move list to the clipboard. The move comments are omitted if the are hidden in the MoveList.

An alignment flag is introduced as method parameter to the two `PgnGame::write()` methods.

Resolves #662

