### PR TITLE
For UCI command "setoption" send keyword "value" even if null value follows

### DIFF
--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -854,7 +854,7 @@ QString UciEngine::sanPv(const QVarLengthArray<QStringRef>& tokens)
 
 void UciEngine::sendOption(const QString& name, const QVariant& value)
 {
-	if (!value.isNull())
+	if (!value.isNull() || getOption(name)->valueType() != QVariant::Invalid)
 		write(QString("setoption name %1 value %2").arg(name, value.toString()));
 	else
 		write(QString("setoption name %1").arg(name));


### PR DESCRIPTION
Currently, if a  UCI option of type string has a void value, cutechess  omits the keyworld `value`, For example, it only sends `setopton name Debug Log File`,
To comply with the specification it should send 
`setopton name Debug Log File value`.

This patch resolves #663
