### PR TITLE
Windows: Add matching command line when warning of destroyed Engine Process

### DIFF
--- a/projects/lib/src/engineprocess_win.cpp
+++ b/projects/lib/src/engineprocess_win.cpp
@@ -45,7 +45,8 @@ EngineProcess::~EngineProcess()
 {
 	if (m_started)
 	{
-		qWarning("EngineProcess: Destroyed while process is still running.");
+		qWarning("EngineProcess: Destroyed while process is still running.\r\n"
+			 "Command line: %s", m_cmdLine.toLatin1().data());
 		kill();
 		waitForFinished();
 	}
@@ -295,6 +296,7 @@ void EngineProcess::start(const QString& program,
 
 	BOOL ok = FALSE;
 	QString cmd = cmdLine(m_workDir, program, arguments);
+	m_cmdLine = cmd;
 	QString wdir = QDir::toNativeSeparators(m_workDir);
 	ZeroMemory(&m_processInfo, sizeof(m_processInfo));
 

--- a/projects/lib/src/engineprocess_win.h
+++ b/projects/lib/src/engineprocess_win.h
@@ -165,6 +165,7 @@ class LIB_EXPORT EngineProcess : public QIODevice
 		DWORD m_exitCode;
 		ExitStatus m_exitStatus;
 		QString m_workDir;
+		QString m_cmdLine;
 		QString m_stdErrFile;
 		OpenMode m_stdErrFileMode;
 		PROCESS_INFORMATION m_processInfo;


### PR DESCRIPTION
This patch is untested yet (lack of MS Windows on my side) and might resolve #487.