### PR TITLE
Option to control debugging on UCI engines

### DIFF
--- a/docs/cutechess-cli.6
+++ b/docs/cutechess-cli.6
@@ -295,8 +295,11 @@ games.
 Set the interval for printing outcomes to
 .Ar n
 games.
-.It Fl debug
+.It Fl debug Bo Cm all Bc
 Display all engine input and output.
+In addition, all eligible engines will be switched to debug mode if argument
+.Cm all
+is given.
 .It Fl openings Cm file Ns = Ns Ar file Cm format Ns = Ns Bo Cm epd | Cm pgn Ns Bc Cm order Ns = Ns Bo Cm random | Cm sequential Bc Cm plies Ns = Ns Ar plies Cm start Ns = Ns Ar start Cm policy Ns = Ns Bo Cm default | Cm encounter | Cm round Bc
 Pick game openings from
 .Ar file .
@@ -496,6 +499,8 @@ Enable pondering if the engine supports it.
 Set the search depth limit.
 .It Ic nodes Ns = Ns Ar count
 Set the node count limit.
+.It Ic debug
+Activate debug mode (per protocol, UCI only).
 .El
 .Sh EXAMPLES
 Play ten games between two Sloppy engines with a time control of 40

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -137,7 +137,9 @@ Options:
 			games set by '-rounds' and/or '-games' is reached.
   -ratinginterval N	Set the interval for printing the ratings to N games.
   -outcomeinterval N	Set the interval for printing outcomes to N games.
-  -debug		Display all engine input and output
+  -debug [all]		Display all engine input and output. In addition, all
+			eligible engines will be switched to debug mode if
+			argument 'all' is given.
   -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START policy=POLICY
 			Pick game openings from FILE. The file's format is
 			FORMAT, which can be either 'epd' or 'pgn' (default).
@@ -221,5 +223,6 @@ Engine options:
   nodes=N		Set the node count limit to N nodes
   ponder		Enable pondering if the engine supports it. By default
 			pondering is disabled.
+  debug			Activate debug mode per protocol (UCI only).
   option.OPTION=VALUE	Set custom option OPTION to value VALUE
 

--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -221,6 +221,10 @@ bool parseEngine(const QStringList& args, EngineData& data)
 		{
 			data.config.setPondering(true);
 		}
+		else if (name == "debug")
+		{
+			data.config.setDebugEnabled(true);
+		}
 		// Custom engine option
 		else if (name.startsWith("option."))
 			data.config.setOption(name.section('.', 1), val);
@@ -258,7 +262,7 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 	parser.addOption("-ratinginterval", QVariant::Int, 1, 1);
 	parser.addOption("-outcomeinterval", QVariant::Int, 1, 1);
 	parser.addOption("-resultformat", QVariant::String, 1, 1);
-	parser.addOption("-debug", QVariant::Bool, 0, 0);
+	parser.addOption("-debug", QVariant::String, 0, 1);
 	parser.addOption("-openings", QVariant::StringList);
 	parser.addOption("-bookmode", QVariant::String);
 	parser.addOption("-pgnout", QVariant::StringList, 1, 3);
@@ -463,6 +467,10 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		{
 			QLoggingCategory::defaultCategory()->setEnabled(QtDebugMsg, true);
 			match->setDebugMode(true);
+			if (value == "all")
+				eachOptions.append("debug");
+			else if (!value.isNull())
+				ok = false;
 		}
 		// Use an opening suite
 		else if (name == "-openings")

--- a/projects/gui/src/engineconfigurationdlg.cpp
+++ b/projects/gui/src/engineconfigurationdlg.cpp
@@ -91,11 +91,16 @@ EngineConfigurationDialog::EngineConfigurationDialog(
 		[=](const QString& text)
 	{
 		if (text == "xboard")
+		{
 			ui->m_whitePovCheck->setEnabled(true);
+			ui->m_debugCheck->setChecked(false);
+			ui->m_debugCheck->setEnabled(false);
+		}
 		else
 		{
 			ui->m_whitePovCheck->setChecked(false);
 			ui->m_whitePovCheck->setEnabled(false);
+			ui->m_debugCheck->setChecked(false);
 		}
 	});
 
@@ -124,6 +129,9 @@ void EngineConfigurationDialog::applyEngineInformation(
 	if (engine.whiteEvalPov())
 		ui->m_whitePovCheck->setCheckState(Qt::Checked);
 
+	if (engine.debugEnabled())
+		ui->m_debugCheck->setCheckState(Qt::Checked);
+
 	const auto options = engine.options();
 	for (const EngineOption* option : options)
 		m_options << option->copy();
@@ -150,6 +158,7 @@ EngineConfiguration EngineConfigurationDialog::engineConfiguration()
 		engine.setInitStrings(initStr.split('\n'));
 
 	engine.setWhiteEvalPov(ui->m_whitePovCheck->checkState() == Qt::Checked);
+	engine.setDebugEnabled(ui->m_debugCheck->checkState() == Qt::Checked);
 
 	QList<EngineOption*> optionCopies;
 	for (const EngineOption* option : qAsConst(m_options))

--- a/projects/gui/ui/engineconfigdlg.ui
+++ b/projects/gui/ui/engineconfigdlg.ui
@@ -131,6 +131,13 @@
          </property>
         </widget>
        </item>
+       <item row="6" column="1">
+        <widget class="QCheckBox" name="m_debugCheck">
+         <property name="text">
+          <string>Debug</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">

--- a/projects/lib/src/chessengine.cpp
+++ b/projects/lib/src/chessengine.cpp
@@ -76,6 +76,7 @@ ChessEngine::ChessEngine(QObject* parent)
 	  m_pinging(false),
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
+	  m_debugEnabled(false),
 	  m_pingTimer(new QTimer(this)),
 	  m_quitTimer(new QTimer(this)),
 	  m_idleTimer(new QTimer(this)),
@@ -141,6 +142,8 @@ void ChessEngine::applyConfiguration(const EngineConfiguration& configuration)
 	m_whiteEvalPov = configuration.whiteEvalPov();
 	m_pondering = configuration.pondering();
 	m_restartMode = configuration.restartMode();
+	m_debugEnabled = configuration.debugEnabled();
+
 	setClaimsValidated(configuration.areClaimsValidated());
 }
 
@@ -274,6 +277,11 @@ bool ChessEngine::whiteEvalPov() const
 bool ChessEngine::pondering() const
 {
 	return m_pondering;
+}
+
+bool ChessEngine::debugEnabled() const
+{
+	return m_debugEnabled;
 }
 
 void ChessEngine::endGame(const Chess::Result& result)

--- a/projects/lib/src/chessengine.h
+++ b/projects/lib/src/chessengine.h
@@ -227,6 +227,16 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		 * the engine does not support pondering.
 		 */
 		bool pondering() const;
+
+		/*!
+		 * Returns true if debugging is enabled for the engine;
+		 * otherwise returns false.
+		 *
+		 * \note Even if debugging is enabled, it's still possible that
+		 * the engine does not support debugging.
+		 */
+		bool debugEnabled() const;
+
 		/*!
 		 * Gives id number of the engine
 		 */
@@ -289,6 +299,7 @@ class LIB_EXPORT ChessEngine : public ChessPlayer
 		bool m_pinging;
 		bool m_whiteEvalPov;
 		bool m_pondering;
+		bool m_debugEnabled;
 		QTimer* m_pingTimer;
 		QTimer* m_quitTimer;
 		QTimer* m_idleTimer;

--- a/projects/lib/src/engineconfiguration.cpp
+++ b/projects/lib/src/engineconfiguration.cpp
@@ -27,7 +27,8 @@ EngineConfiguration::EngineConfiguration()
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
-	  m_restartMode(RestartAuto)
+	  m_restartMode(RestartAuto),
+	  m_debugEnabled(false)
 {
 }
 
@@ -41,7 +42,8 @@ EngineConfiguration::EngineConfiguration(const QString& name,
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
-	  m_restartMode(RestartAuto)
+	  m_restartMode(RestartAuto),
+	  m_debugEnabled(false)
 {
 }
 
@@ -50,7 +52,8 @@ EngineConfiguration::EngineConfiguration(const QVariant& variant)
 	  m_whiteEvalPov(false),
 	  m_pondering(false),
 	  m_validateClaims(true),
-	  m_restartMode(RestartAuto)
+	  m_restartMode(RestartAuto),
+	  m_debugEnabled(false)
 {
 	const QVariantMap map = variant.toMap();
 
@@ -80,6 +83,8 @@ EngineConfiguration::EngineConfiguration(const QVariant& variant)
 
 	if (map.contains("validateClaims"))
 		setClaimsValidated(map["validateClaims"].toBool());
+	if (map.contains("debug"))
+		setDebugEnabled(map["debug"].toBool());
 
 	if (map.contains("variants"))
 		setSupportedVariants(map["variants"].toStringList());
@@ -109,7 +114,8 @@ EngineConfiguration::EngineConfiguration(const EngineConfiguration& other)
 	  m_whiteEvalPov(other.m_whiteEvalPov),
 	  m_pondering(other.m_pondering),
 	  m_validateClaims(other.m_validateClaims),
-	  m_restartMode(other.m_restartMode)
+	  m_restartMode(other.m_restartMode),
+	  m_debugEnabled(other.debugEnabled())
 {
 	const auto options = other.options();
 	for (const EngineOption* option : options)
@@ -134,6 +140,7 @@ EngineConfiguration& EngineConfiguration::operator=(EngineConfiguration&& other)
 	m_pondering = other.m_pondering;
 	m_validateClaims = other.m_validateClaims;
 	m_restartMode = other.m_restartMode;
+	m_debugEnabled =other.m_debugEnabled;
 	m_options = other.m_options;
 
 	// other's destructor will cause a mess if its m_options isn't cleared
@@ -170,6 +177,8 @@ QVariant EngineConfiguration::toVariant() const
 
 	if (!m_validateClaims)
 		map.insert("validateClaims", false);
+	if (m_debugEnabled)
+		map.insert("debug", true);
 
 	if (m_variants.count("standard") != m_variants.count())
 		map.insert("variants", m_variants);
@@ -361,6 +370,16 @@ void EngineConfiguration::setClaimsValidated(bool validate)
 	m_validateClaims = validate;
 }
 
+bool EngineConfiguration::debugEnabled() const
+{
+	return m_debugEnabled;
+}
+
+void EngineConfiguration::setDebugEnabled(bool enabled)
+{
+	m_debugEnabled = enabled;
+}
+
 EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& other)
 {
 	if (this != &other)
@@ -377,6 +396,7 @@ EngineConfiguration& EngineConfiguration::operator=(const EngineConfiguration& o
 		m_pondering = other.m_pondering;
 		m_validateClaims = other.m_validateClaims;
 		m_restartMode = other.m_restartMode;
+		m_debugEnabled = other.m_debugEnabled;
 
 		qDeleteAll(m_options);
 		m_options.clear();

--- a/projects/lib/src/engineconfiguration.h
+++ b/projects/lib/src/engineconfiguration.h
@@ -207,6 +207,14 @@ class LIB_EXPORT EngineConfiguration
 		void setClaimsValidated(bool validate);
 
 		/*!
+		 * Returns true if debug mode is enabled for the engine,
+		 * else false.
+		 */
+		bool debugEnabled() const;
+		/*! Sets the debug mode to \a enabled */
+		void setDebugEnabled(bool enabled);
+
+		/*!
 		 * Assigns \a other to this engine configuration and returns
 		 * a reference to this object.
 		 */
@@ -226,6 +234,7 @@ class LIB_EXPORT EngineConfiguration
 		bool m_pondering;
 		bool m_validateClaims;
 		RestartMode m_restartMode;
+		bool m_debugEnabled;
 };
 
 #endif // ENGINE_CONFIGURATION_H

--- a/projects/lib/src/uciengine.cpp
+++ b/projects/lib/src/uciengine.cpp
@@ -148,6 +148,9 @@ void UciEngine::startGame()
 		m_startFen = board()->fenString(Chess::Board::XFen);
 	setVariant(board()->variant());
 
+	if (debugEnabled())
+		write("debug on");
+
 	write("ucinewgame");
 
 	if (m_canPonder)


### PR DESCRIPTION
This pull request adds support for protocol based debugging for UCI engines. In the CLI debugging can be switched on individually per engine by adding `debug` to the `-engine` section, and generally (only active for eligible engines) by adding `debug` to the `-each` section. This can also be accomplished by adding the parameter `all` to the `-debug` option:
`-debug all` is equivalent to `-debug -each debug`. As before the `-debug` option alone only switches on cutechess's own debugging: It shows the communication with the engines and displays all engine input and output.

In the GUI a new checkbox in `EngineConfigurationDialog`  is used to individually enable UCI engine debugging.

![d01](https://user-images.githubusercontent.com/6425738/153711754-b3c3441a-e985-4e5a-a1f5-214970b8e4ad.png)



This PR adds the methods `debugEnabled` and `setDebugEnabled` to `EngineConfiguration` and introduces the formal engine option "debug" e.g. 
`cutechess-cli -engine debug option.op1 ...`  or `cutechess-cli -each ponder debug ...` .

The new method `ChessEngine::debugEnabled()` is added.  `UciEngine::startGame` sends "debug on" if` debugEnabled()`.
The Xboard protocol does not support debugging in the same way.

Add support for GUI:
Add `m_debugCheck` to `EngineConfigDlg` and supporting logic to `EngineConfigurationDlg`.

Add support for CLI:
Add option argument "all", so `-debug all` is equivalent to `-debug -each debug`.

Resolves #505