### PR TITLE
Adjudicate draw in case of a timeout if the opponent has no means to win

### DIFF
--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -920,4 +920,9 @@ Result Board::tablebaseResult(unsigned int* dtm) const
 	return Result();
 }
 
+bool Board::winPossible(Chess::Side) const
+{
+	return true;
+}
+
 } // namespace Chess

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -295,6 +295,12 @@ class LIB_EXPORT Board
 		 * The default implementation always returns a null result.
 		 */
 		virtual Result tablebaseResult(unsigned int* dtm = nullptr) const;
+		/*!
+		 * Returns true if it is possible for \a side to achieve a win
+		 * by any legal sequence of moves, else false. The default
+		 * implementation returns true.
+		 */
+		virtual bool winPossible(Side side) const;
 
 	protected:
 		/*!

--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -1474,4 +1474,26 @@ Result WesternBoard::result()
 	return Result();
 }
 
+bool Chess::WesternBoard::winPossible(Chess::Side side) const
+{
+	// Find any piece besides the King
+	int minIndex = 2 * m_arwidth + 1;
+	for (int i = minIndex; i < arraySize() - minIndex - 1; i++)
+	{
+		Piece piece = pieceAt(i);
+		if (piece.side() == side && i != kingSquare(side))
+			return true;
+	}
+	if (variantHasDrops())
+	{
+		const QList<Piece>& reserveTypes = reservePieceTypes();
+		for (const Piece& ptype: reserveTypes)
+		{
+			if (reserveCount(ptype) > 0 && ptype.side() == side)
+				return true;
+		}
+	}
+	return false;
+}
+
 } // namespace Chess

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -59,6 +59,7 @@ class LIB_EXPORT WesternBoard : public Board
 		virtual int height() const;
 		virtual Result result();
 		virtual int reversibleMoveCount() const;
+		virtual bool winPossible(Side side) const;
 
 	protected:
 		/*! The king's castling side. */

--- a/projects/lib/src/chessplayer.cpp
+++ b/projects/lib/src/chessplayer.cpp
@@ -260,6 +260,10 @@ void ChessPlayer::claimResult(const Chess::Result& result)
 
 void ChessPlayer::forfeit(Chess::Result::Type type, const QString& description)
 {
+	Chess::Side opp = m_side.opposite();
+	if (!opp.isNull() && !board()->winPossible(opp))
+		m_side = Chess::Side::NoSide;
+
 	if (m_side.isNull())
 	{
 		claimResult(Chess::Result(type, m_side, description));


### PR DESCRIPTION
A game is drawn in case of a timeout if the opponent has no means to give checkmate by any regular sequence of moves (Ref.: FIDE rule 6.9). Cutechess currently adjudicates a loss on timeout anyway.

This patch resolves simple cases of lone kings. It does not detect dead positions like impasse by pawn blockade.

`ChessPlayer::forfeit` calls a new virtual method `Board::winPossible(Side)` to check whether the opponent has any pieces beside their King. If not, then the game is drawn.

Resolves #710