### PR TITLE
chore: update sprt completion conditions to match theory

### DIFF
--- a/projects/lib/src/sprt.cpp
+++ b/projects/lib/src/sprt.cpp
@@ -193,9 +193,9 @@ Sprt::Status Sprt::status() const
 	status.lBound = std::log(m_beta / (1.0 - m_alpha));
 	status.uBound = std::log((1.0 - m_beta) / m_alpha);
 
-	if (status.llr > status.uBound)
+	if (status.llr >= status.uBound)
 		status.result = AcceptH1;
-	else if (status.llr < status.lBound)
+	else if (status.llr <= status.lBound)
 		status.result = AcceptH0;
 
 	return status;


### PR DESCRIPTION
The conditions which must be met for $H_0$ or $H_1$ to be accepted have been updated to use closed intervals $\left]-\infty, B\right]$ and $\left[A, \infty\right[$ respectively, matching the theory found in the original paper by [Abraham Wald](https://doi.org/10.1214%2Faoms%2F1177731118).