### PR TITLE
re-enable local CodeQL queries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,6 +57,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        queries: +./.lgtm/cpp-queries
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.lgtm/cpp-queries/qlpack.yml
+++ b/.lgtm/cpp-queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: cutechess/cpp-queries
+version: 1.0.0
+dependencies:
+  codeql/cpp-all: "*"
+extractor: cpp


### PR DESCRIPTION
These local queries were developed some years ago but were disabled when the LGTM service (predecessor to CodeQL) was deprecated.

Reference the directory where the local queries are located with the `queries` parameter in the `codeql/init` step. Add a QL pack configuration so that CodeQL understand this directory contains the queries.