### PR TITLE
skip Qt 5 build on macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ jobs:
           matrix:
             qt_version: [5.15.2, 6.5.2]
             os: [windows-latest, ubuntu-latest, macos-latest]
+            exclude:
+              - os: macos-latest
+                qt_version: 5.15.2
         steps:
             - uses: actions/checkout@v3
 


### PR DESCRIPTION
The latest versions of MacOS do not support building with Qt 5 so skip it.