### PR TITLE
fix cases of negative time when timemargin is > 0

### DIFF
--- a/projects/lib/src/timecontrol.cpp
+++ b/projects/lib/src/timecontrol.cpp
@@ -367,6 +367,10 @@ void TimeControl::update(bool applyIncrement)
 	else
 	{
 	        int newTimeLeft = m_timeLeft - m_lastMoveTime;
+
+		if (newTimeLeft < 0)
+			newTimeLeft = 0;
+		
 		if (applyIncrement)
 			newTimeLeft += m_increment;
 		setTimeLeft(newTimeLeft);


### PR DESCRIPTION
currently when timemargin/expirymargin is set, there can be cases where the updated time left can be negative. this is of course undefined behavior for engines. as such, with this pr, it resets the time to 0 before increment is applied when the time goes negative but hasn't exceeded the expiry margin.

fix https://github.com/cutechess/cutechess/issues/809