### PR TITLE
Fix error in standard algebraic notation disambiguity logic

### DIFF
--- a/projects/lib/src/board/westernboard.cpp
+++ b/projects/lib/src/board/westernboard.cpp
@@ -246,6 +246,8 @@ QString WesternBoard::sanMoveString(const Move& move)
 		QVarLengthArray<Move> moves;
 		generateMoves(moves, piece.type());
 
+		bool needSomething = false;
+
 		for (int i = 0; i < moves.size(); i++)
 		{
 			const Move& move2 = moves[i];
@@ -258,11 +260,14 @@ QString WesternBoard::sanMoveString(const Move& move)
 				continue;
 
 			Square square2(chessSquare(move2.sourceSquare()));
-			if (square2.file() != square.file())
-				needFile = true;
-			else if (square2.rank() != square.rank())
+			if (square2.file() == square.file())
 				needRank = true;
+			else if (square2.rank() == square.rank())
+				needFile = true;
+			needSomething = true;
 		}
+		if (needSomething && !needRank)
+			needFile = true;
 	}
 	if (needFile)
 		str += QChar('a' + square.file());


### PR DESCRIPTION
In the position "8/1k5p/4P3/1q3b2/6PP/7K/5QR1/1q1q4 b - - 0 53" the move b5d3 is Q5d3+ not Qb5d3+.