### PR TITLE
Fix illegal en passant

### DIFF
--- a/projects/lib/src/board/board.cpp
+++ b/projects/lib/src/board/board.cpp
@@ -710,6 +710,22 @@ void Board::makeMove(const Move& move, BoardTransition* transition)
 	xorKey(m_zobrist->side());
 	m_side = m_side.opposite();
 	m_moveHistory << md;
+
+	if (m_needsFutureDependentUpdate)
+	{
+		// We may need to recursively call makeMove multiple times
+		// if there is a dependency on more than 1 move in the future,
+		// so we should reset the flag here.
+		m_needsFutureDependentUpdate = false;
+		vApplyFutureDependentUpdate();
+	}
+}
+
+void Board::vApplyFutureDependentUpdate() {}
+
+void Board::setNeedsFutureDependentUpdateFlag()
+{
+	m_needsFutureDependentUpdate = true;
 }
 
 void Board::undoMove()

--- a/projects/lib/src/board/board.h
+++ b/projects/lib/src/board/board.h
@@ -350,6 +350,19 @@ class LIB_EXPORT Board
 		 */
 		virtual void vMakeMove(const Move& move,
 				       BoardTransition* transition) = 0;
+
+		/*!
+		 * Applies any modification that are dependent on the legality of a future state.
+		 *
+		 * This function is only to be called by makeMove after every other
+		 * state modifications have been done, and should take care of updating
+		 * properties that are dependent on the legality of a future move (eg: en passant square).
+		 */
+		virtual void vApplyFutureDependentUpdate();
+
+		/*! Signals that we should call vApplyFutureDependentUpdate in makeMove. */
+		void setNeedsFutureDependentUpdateFlag();
+
 		/*!
 		 * Reverses \a move on the board.
 		 *
@@ -543,6 +556,7 @@ class LIB_EXPORT Board
 		QString m_startingFen;
 		int m_maxPieceSymbolLength;
 		quint64 m_key;
+		bool m_needsFutureDependentUpdate;
 		Zobrist* m_zobrist;
 		QSharedPointer<Zobrist> m_sharedZobrist;
 		QVarLengthArray<PieceData> m_pieceData;

--- a/projects/lib/src/board/westernboard.h
+++ b/projects/lib/src/board/westernboard.h
@@ -217,6 +217,7 @@ class LIB_EXPORT WesternBoard : public Board
 		virtual Move moveFromSanString(const QString& str);
 		virtual void vMakeMove(const Move& move,
 				       BoardTransition* transition);
+		virtual void vApplyFutureDependentUpdate();
 		virtual void vUndoMove(const Move& move);
 		virtual void generateMovesForPiece(QVarLengthArray<Move>& moves,
 						   int pieceType,

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -208,6 +208,26 @@ void tst_Board::moveStrings_data() const
 		<< "h2a2"
 		<< "8/8/k1K5/8/8/8/7R/8 w - - 99 1"
 		<< "8/8/k1K5/8/8/8/R7/8 b - - 100 1";
+	QTest::newRow("illegal en passant discovered check") 
+		<< "standard"
+		<< "e7e5"
+		<< "3b3k/3Rp3/8/r2P4/7K/8/8/NR6 b - - 7 2"
+		<< "3b3k/3R4/8/r2Pp3/7K/8/8/NR6 w - - 0 3";
+	QTest::newRow("illegal en passant horizontal pin") 
+		<< "standard"
+		<< "e7e5"
+		<< "b6k/3Rp3/8/r2P3K/8/8/8/NR6 b - - 7 2"
+		<< "b6k/3R4/8/r2Pp2K/8/8/8/NR6 w - - 0 3";
+	QTest::newRow("illegal en passant diagonal pin") 
+		<< "standard"
+		<< "e7e5"
+		<< "b6k/3Rp3/8/r2P4/8/8/8/NR5K b - - 7 2"
+		<< "b6k/3R4/8/r2Pp3/8/8/8/NR5K w - - 0 3";
+	QTest::newRow("legal en passant") 
+		<< "standard"
+		<< "e7e5"
+		<< "b3r2k/3Rp3/8/3P4/8/8/8/NR2K3 b - - 7 2"
+		<< "b3r2k/3R4/8/3Pp3/8/8/8/NR2K3 w - e6 0 3";
 	QTest::newRow("atomic1")
 		<< "atomic"
 		<< "Rxh3"


### PR DESCRIPTION
This addresses https://github.com/cutechess/cutechess/issues/817

Adding some kind of `isEnPassantLegalAfterDoublePawnPush` function that would be called in `vMakeMove` is not reliable due to variants (I've run into issues with Horde and Grid so far, but I expect there would be others).

The general solution (which would work for any property dependent on a future move's legality) is to make the double pawn push entirely, then run a check for all pseudo-legal EP moves available and reset the the en passant square if none is legal.

This PR introduces a new flag to `Board` (`needsFutureDependentUpdate`) that is set inside `WesternBoard::vMakeMove` when a double pawn push with consequent pseudo-legal en passant is made. `Board::makeMove` then calls `WesternBoard::vApplyFutureDependentUpdate` which does the en passant legality check and resets the en passant square if no en passant move is legal.