### PR TITLE
(feat): added captured-pieces dialog and logic;

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ basil00
 Guy Vreuls (gvreuls)
 Олег Смирнов (sovaz1997)
 Daniel Dugovic (ddugovic)
+Iskandar Emomzoda (iskandarem)
 
 # Piece graphics:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased](https://github.com/cutechess/cutechess/tree/master)
 
 ### Added
+- dialog to show captured pieces (#813)
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ add_executable(gui
 	projects/gui/src/boardview/graphicsboard.cpp
 	projects/gui/src/boardview/graphicspiecereserve.cpp
 	projects/gui/src/boardview/piecechooser.cpp
+	projects/gui/src/capturedpieceswidget.cpp
 
 	projects/gui/src/mainwindow.cpp
 	projects/gui/src/gameviewer.cpp

--- a/projects/gui/src/capturedpieceswidget.cpp
+++ b/projects/gui/src/capturedpieceswidget.cpp
@@ -1,0 +1,193 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+
+#include "capturedpieceswidget.h"
+
+#include <QVBoxLayout>
+#include <QGraphicsView>
+#include <QGraphicsScene>
+#include <QSvgRenderer>
+#include <QMap>
+#include <memory>
+
+#include "boardview/graphicspiecereserve.h"
+#include "boardview/graphicspiece.h"
+
+#include <chessgame.h>
+#include <board/boardfactory.h>
+#include <board/board.h>
+
+namespace {
+const qreal s_squareSize = 24; // smaller thumbnails
+const qreal s_spacing = 4;
+const qreal s_rowSpacing = 15;
+}
+
+CapturedPiecesWidget::CapturedPiecesWidget(QWidget* parent)
+    : QWidget(parent), m_game(nullptr)
+{
+    QVBoxLayout* l = new QVBoxLayout(this);
+
+    m_view = new QGraphicsView(this);
+    m_view->setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+    m_scene = new QGraphicsScene(this);
+    m_view->setScene(m_scene);
+
+    l->addWidget(m_view);
+    setLayout(l);
+}
+
+void CapturedPiecesWidget::setGame(ChessGame* game)
+{
+    if (m_game)
+        disconnect(m_game, nullptr, this, nullptr);
+
+    m_game = game;
+
+    if (m_game)
+    {
+        connect(m_game, SIGNAL(moveMade(Chess::GenericMove,QString,QString)),
+                this, SLOT(updateCapturedPieces()));
+        connect(m_game, SIGNAL(fenChanged(QString)),
+                this, SLOT(updateCapturedPieces()));
+    }
+
+    updateCapturedPieces();
+}
+
+void CapturedPiecesWidget::updateCapturedPieces()
+{
+    m_scene->clear();
+
+    if (!m_game)
+        return;
+
+    Chess::Board* board = m_game->board();
+    if (!board)
+        return;
+
+    QSvgRenderer* renderer = new QSvgRenderer(QString(":/default.svg"), m_scene);
+
+    // Build captured piece lists (each element is the captured piece itself)
+    QVector<Chess::Piece> whiteCaptured; // pieces captured by White (these are Black pieces)
+    QVector<Chess::Piece> blackCaptured; // pieces captured by Black (these are White pieces)
+
+    if (board->variantHasDrops())
+    {
+        const auto types = board->reservePieceTypes();
+        for (const auto& ptype : types)
+        {
+            int cntWhite = board->reserveCount(Chess::Piece(Chess::Side::White, ptype.type()));
+            int cntBlack = board->reserveCount(Chess::Piece(Chess::Side::Black, ptype.type()));
+            for (int i = 0; i < cntWhite; ++i)
+                whiteCaptured.append(Chess::Piece(Chess::Side::Black, ptype.type()));
+            for (int i = 0; i < cntBlack; ++i)
+                blackCaptured.append(Chess::Piece(Chess::Side::White, ptype.type()));
+        }
+    }
+    else
+    {
+        std::unique_ptr<Chess::Board> startBoard(Chess::BoardFactory::create(board->variant()));
+        if (startBoard)
+        {
+            startBoard->initialize();
+            startBoard->reset();
+        }
+
+        QMap<int,int> startCounts[2];
+        QMap<int,int> currCounts[2];
+
+        if (startBoard)
+        {
+            for (int y = 0; y < startBoard->height(); ++y)
+                for (int x = 0; x < startBoard->width(); ++x)
+                {
+                    Chess::Square sq(x, y);
+                    Chess::Piece pc = startBoard->pieceAt(sq);
+                    if (pc.isValid())
+                        startCounts[pc.side()][pc.type()]++;
+                }
+        }
+
+        for (int y = 0; y < board->height(); ++y)
+            for (int x = 0; x < board->width(); ++x)
+            {
+                Chess::Square sq(x, y);
+                Chess::Piece pc = board->pieceAt(sq);
+                if (pc.isValid())
+                    currCounts[pc.side()][pc.type()]++;
+            }
+
+        for (auto it = startCounts[Chess::Side::Black].constBegin(); it != startCounts[Chess::Side::Black].constEnd(); ++it)
+        {
+            int type = it.key();
+            int captured = it.value() - currCounts[Chess::Side::Black].value(type, 0);
+            for (int i = 0; i < captured; ++i)
+                whiteCaptured.append(Chess::Piece(Chess::Side::Black, type));
+        }
+
+        for (auto it = startCounts[Chess::Side::White].constBegin(); it != startCounts[Chess::Side::White].constEnd(); ++it)
+        {
+            int type = it.key();
+            int captured = it.value() - currCounts[Chess::Side::White].value(type, 0);
+            for (int i = 0; i < captured; ++i)
+                blackCaptured.append(Chess::Piece(Chess::Side::White, type));
+        }
+    }
+
+    // Sort by piece type
+    auto cmp = [](const Chess::Piece &a, const Chess::Piece &b){ return a.type() < b.type(); };
+    std::sort(whiteCaptured.begin(), whiteCaptured.end(), cmp);
+    std::sort(blackCaptured.begin(), blackCaptured.end(), cmp);
+
+    // two rows — whiteCaptured on top, blackCaptured on bottom
+    qreal x = 0;
+    int SPACE_BETWEEN_PIECES = 24;
+    for (int i = 0; i < whiteCaptured.size(); ++i)
+    {
+        Chess::Piece pc = whiteCaptured.at(i);
+        GraphicsPiece* g = new GraphicsPiece(pc, s_squareSize, board->representation(pc), renderer);
+        m_scene->addItem(g);
+        g->setPos(x + i * (s_squareSize + s_spacing)+SPACE_BETWEEN_PIECES, SPACE_BETWEEN_PIECES);
+    }
+    for (int i = 0; i < blackCaptured.size(); ++i)
+    {
+        Chess::Piece pc = blackCaptured.at(i);
+        GraphicsPiece* g = new GraphicsPiece(pc, s_squareSize, board->representation(pc), renderer);
+        m_scene->addItem(g);
+        g->setPos(x + i * (s_squareSize + s_spacing)+SPACE_BETWEEN_PIECES, s_squareSize + s_rowSpacing+SPACE_BETWEEN_PIECES);
+    }
+
+    m_scene->setSceneRect(m_scene->itemsBoundingRect());
+    m_view->fitInView(m_scene->sceneRect(), Qt::KeepAspectRatio);
+
+
+
+    int cols = qMax(whiteCaptured.size(), blackCaptured.size());
+    qreal width = cols > 0 ? cols * (s_squareSize + s_spacing) - s_spacing : s_squareSize;
+    qreal height = s_squareSize * 2 + s_rowSpacing;
+    m_scene->setSceneRect(0, 0, width, height);
+
+    m_view->resetTransform();
+    m_view->setAlignment(Qt::AlignLeft | Qt::AlignTop);
+    m_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_view->setMinimumHeight(static_cast<int>(height + 4));
+}

--- a/projects/gui/src/capturedpieceswidget.h
+++ b/projects/gui/src/capturedpieceswidget.h
@@ -1,0 +1,60 @@
+/*
+    This file is part of Cute Chess.
+
+    Cute Chess is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Cute Chess is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Cute Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+/*
+    Captured pieces dock widget
+*/
+#ifndef CAPTUREDPIECESWIDGET_H
+#define CAPTUREDPIECESWIDGET_H
+
+#include <QWidget>
+#include <QPointer>
+
+class QGraphicsView;
+class QGraphicsScene;
+class ChessGame;
+
+class CapturedPiecesWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit CapturedPiecesWidget(QWidget* parent = nullptr);
+    void setGame(ChessGame* game);
+
+private slots:
+    void updateCapturedPieces();
+
+private:
+    QPointer<ChessGame> m_game;
+    QGraphicsView* m_view;
+    QGraphicsScene* m_scene;
+};
+
+#endif // CAPTUREDPIECESWIDGET_H

--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -58,6 +58,7 @@
 #include "evalwidget.h"
 #include "boardview/boardscene.h"
 #include "tournamentresultsdlg.h"
+#include "capturedpieceswidget.h"
 
 #if 0
 #include <modeltest.h>
@@ -387,6 +388,14 @@ void MainWindow::createDockWindows()
 	splitDockWidget(moveListDock, whiteEvalDock, Qt::Horizontal);
 	splitDockWidget(whiteEvalDock, blackEvalDock, Qt::Vertical);
 
+	// Captured pieces
+	QDockWidget* capturedDock = new QDockWidget(tr("Captured pieces"), this);
+	capturedDock->setObjectName("CapturedPiecesDock");
+	m_capturedPiecesWidget = new CapturedPiecesWidget(capturedDock);
+	capturedDock->setWidget(m_capturedPiecesWidget);
+	addDockWidget(Qt::RightDockWidgetArea, capturedDock);
+	splitDockWidget(capturedDock, moveListDock, Qt::Horizontal);
+
 	// Tags
 	QDockWidget* tagsDock = new QDockWidget(tr("Tags"), this);
 	tagsDock->setObjectName("TagsDock");
@@ -404,6 +413,7 @@ void MainWindow::createDockWindows()
 	// Add toggle view actions to the View menu
 	m_viewMenu->addAction(moveListDock->toggleViewAction());
 	m_viewMenu->addAction(tagsDock->toggleViewAction());
+	m_viewMenu->addAction(capturedDock->toggleViewAction());
 	m_viewMenu->addAction(engineDebugDock->toggleViewAction());
 	m_viewMenu->addAction(evalHistoryDock->toggleViewAction());
 	m_viewMenu->addAction(whiteEvalDock->toggleViewAction());
@@ -587,6 +597,9 @@ void MainWindow::setCurrentGame(const TabData& gameData)
 		for (auto evalWidget : m_evalWidgets)
 			evalWidget->setPlayer(nullptr);
 
+		if (m_capturedPiecesWidget)
+			m_capturedPiecesWidget->setGame(nullptr);
+
 		return;
 	}
 	else
@@ -631,6 +644,8 @@ void MainWindow::setCurrentGame(const TabData& gameData)
 
 	updateMenus();
 	updateWindowTitle();
+	if (m_capturedPiecesWidget)
+		m_capturedPiecesWidget->setGame(m_game);
 	unlockCurrentGame();
 }
 

--- a/projects/gui/src/mainwindow.h
+++ b/projects/gui/src/mainwindow.h
@@ -42,6 +42,7 @@ class Tournament;
 class GameTabBar;
 class EvalHistory;
 class EvalWidget;
+class CapturedPiecesWidget;
 
 /**
  * MainWindow
@@ -135,6 +136,7 @@ class MainWindow : public QMainWindow
 		GameViewer* m_gameViewer;
 		MoveList* m_moveList;
 		PgnTagsModel* m_tagsModel;
+		CapturedPiecesWidget* m_capturedPiecesWidget;
 
 		QAction* m_quitGameAct;
 		QAction* m_newGameAct;


### PR DESCRIPTION
Added a captured pieces widget that shows all captured material for both sides. Updates automatically after moves and works with both normal and drop variants.

Closes #813 