### PR TITLE
docs: document optional value for -debug option

### DIFF
--- a/docs/cutechess-cli.6.txt
+++ b/docs/cutechess-cli.6.txt
@@ -181,7 +181,7 @@ DESCRIPTION
      -outcomeinterval n
 	     Set the interval for printing outcomes to n games.
 
-     -debug  Display all engine input and output.
+     -debug [all]  Display all engine input and output.
 
      -openings file=file format=[epd | pgn] order=[random | sequential]
 	     plies=plies start=start policy=[default | encounter | round]

--- a/docs/cutechess-cli.6.txt
+++ b/docs/cutechess-cli.6.txt
@@ -181,7 +181,8 @@ DESCRIPTION
      -outcomeinterval n
 	     Set the interval for printing outcomes to n games.
 
-     -debug [all]  Display all engine input and output.
+     -debug [all]  Display all engine input and output.  Passing the
+                  value all also enables per-engine protocol debugging.
 
      -openings file=file format=[epd | pgn] order=[random | sequential]
 	     plies=plies start=start policy=[default | encounter | round]

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -137,7 +137,8 @@ Options:
 			games set by '-rounds' and/or '-games' is reached.
   -ratinginterval N	Set the interval for printing the ratings to N games.
   -outcomeinterval N	Set the interval for printing outcomes to N games.
-  -debug [all]		Display all engine input and output
+  -debug [all]		Display all engine input and output.
+			Pass 'all' to also enable per-engine protocol debugging
   -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START policy=POLICY
 			Pick game openings from FILE. The file's format is
 			FORMAT, which can be either 'epd' or 'pgn' (default).

--- a/projects/cli/res/doc/help.txt
+++ b/projects/cli/res/doc/help.txt
@@ -137,7 +137,7 @@ Options:
 			games set by '-rounds' and/or '-games' is reached.
   -ratinginterval N	Set the interval for printing the ratings to N games.
   -outcomeinterval N	Set the interval for printing outcomes to N games.
-  -debug		Display all engine input and output
+  -debug [all]		Display all engine input and output
   -openings file=FILE format=FORMAT order=ORDER plies=PLIES start=START policy=POLICY
 			Pick game openings from FILE. The file's format is
 			FORMAT, which can be either 'epd' or 'pgn' (default).


### PR DESCRIPTION
## Summary
- Fix the help text and man page to document that `-debug` accepts an optional value `[all]`

## Changes
| File | Change |
|------|--------|
| `projects/cli/res/doc/help.txt` | `-debug` → `-debug [all]` |
| `docs/cutechess-cli.6.txt` | `-debug` → `-debug [all]` |

## Context
The `-debug` option activates debug mode to display engine I/O. When passed `all` as a value, it also enables the per-protocol debug option for each engine. The documentation only said "Display all engine input and output" without mentioning the optional `[all]` argument, causing user confusion.

## Test Plan
- [x] Verified that code (`main.cpp:278`) declares `-debug` as `QVariant::String` with maxOccurrences=1
- [x] Verified that code (`main.cpp:486`) checks for `value == "all"` to enable per-engine debug
- [x] Documentation now matches the actual code behavior

Fixes #842
