### PR TITLE
drop Qt 5 from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,23 +11,13 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
           matrix:
-            qt_version: [5.15.2, 6.7.2]
+            qt_version: [6.8.3]
             os: [windows-latest, ubuntu-latest, macos-latest]
-            exclude:
-              - os: macos-latest
-                qt_version: 5.15.2
         steps:
             - uses: actions/checkout@v6
 
-            - name: install qt 5.x
-              uses: jurplel/install-qt-action@v4
-              if: startsWith(matrix.qt_version, '5.')
-              with:
-                version: ${{ matrix.qt_version }}
-
             - name: install qt 6.x
               uses: jurplel/install-qt-action@v4
-              if: startsWith(matrix.qt_version, '6.')
               with:
                 version: ${{ matrix.qt_version }}
                 modules: 'qt5compat'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt install qtbase5-dev qtbase5-dev-tools libqt5svg5-dev
+        sudo apt install qt6-base-dev qt6-svg-dev qt6-base-dev-tools qt6-5compat-dev
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Install dependencies
       run: |
-        sudo apt install qtbase5-dev qtbase5-dev-tools libqt5svg5-dev
+        sudo apt install qt6-base-dev qt6-svg-dev qt6-base-dev-tools qt6-5compat-dev
     - name: CMake
       run: |
         cmake -S . -B build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
           matrix:
-            qt_version: [6.7.2]
+            qt_version: [6.8.3]
             os: [ubuntu-latest]
         steps:
             - uses: actions/checkout@v6
@@ -84,7 +84,7 @@ jobs:
           ISDIR: 'C:\Program Files (x86)\Inno Setup 6'
         strategy:
           matrix:
-            qt_version: [6.7.2]
+            qt_version: [6.8.3]
             os: [windows-latest]
         steps:
             - uses: actions/checkout@v6


### PR DESCRIPTION
Qt 5 has been unsupported for some time so let's focus the effort on Qt 6 only.