### PR TITLE
fix clazy warnings

### DIFF
--- a/projects/gui/src/mainwindow.cpp
+++ b/projects/gui/src/mainwindow.cpp
@@ -1016,7 +1016,7 @@ void MainWindow::showAboutDialog()
 	html += "<h3>" + QString("Cute Chess %1")
 		.arg(CuteChessApplication::applicationVersion()) + "</h3>";
 	html += "<p>" + tr("Using Qt version %1").arg(qVersion()) + "</p>";
-	html += "<p>" + tr("Running on %1/%2").arg(QSysInfo::prettyProductName()).arg(QSysInfo::currentCpuArchitecture()) + "</p>";
+	html += "<p>" + tr("Running on %1/%2").arg(QSysInfo::prettyProductName(), QSysInfo::currentCpuArchitecture()) + "</p>";
 	html += "<p>" + tr("Copyright 2008-2020 "
 			   "Cute Chess authors") + "</p>";
 	html += "<p>" + tr("This is free software; see the source for copying "

--- a/projects/gui/src/tournamentresultsdlg.cpp
+++ b/projects/gui/src/tournamentresultsdlg.cpp
@@ -72,7 +72,7 @@ void TournamentResultsDialog::update()
 		double scoreRatio = std::numeric_limits<double>::quiet_NaN();
 		if (totalResults > 0)
 			scoreRatio = double(fcp.score()) / (totalResults * 2);
-		text = tr("Score of %1 vs %2: %3 - %4 - %5 [%6]\n")
+		text = tr("Score of %1 vs %2: %3 - %4 - %5 [%6]\n") // clazy:exclude=qstring-arg
 		       .arg(fcp.name())
 		       .arg(scp.name())
 		       .arg(fcp.wins())

--- a/projects/lib/src/chessgame.cpp
+++ b/projects/lib/src/chessgame.cpp
@@ -706,7 +706,7 @@ void ChessGame::startGame()
 		if (player->state() == ChessPlayer::Disconnected)
 		{
 			setError(tr("Could not initialize player %1: %2")
-			         .arg(player->name()).arg(player->errorString()));
+			         .arg(player->name(), player->errorString()));
 			m_result = Chess::Result(Chess::Result::ResultError);
 			stop();
 			emitStartFailed();

--- a/projects/lib/src/enginemanager.cpp
+++ b/projects/lib/src/enginemanager.cpp
@@ -108,8 +108,8 @@ void EngineManager::loadEngines(const QString& fileName)
 
 	if (parser.hasError())
 	{
-		qWarning("%s", qUtf8Printable(QString("bad engine configuration file line %1 in %2: %3")
-			.arg(parser.errorLineNumber()).arg(fileName).arg(parser.errorString()))); // clazy:exclude=qstring-arg
+		qWarning("%s", qUtf8Printable(QString("bad engine configuration file line %1 in %2: %3") // clazy:exclude=qstring-arg
+			.arg(parser.errorLineNumber()).arg(fileName).arg(parser.errorString())));
 		return;
 	}
 

--- a/projects/lib/tests/chessboard/tst_board.cpp
+++ b/projects/lib/tests/chessboard/tst_board.cpp
@@ -63,7 +63,7 @@ static quint64 perftVal(Chess::Board* board, int depth)
 		return moves.size();
 
 	QVector<Chess::Move>::const_iterator it;
-	for (it = moves.begin(); it != moves.end(); ++it)
+	for (it = moves.constBegin(); it != moves.constEnd(); ++it)
 	{
 		board->makeMove(*it);
 		nodeCount += perftVal(board, depth - 1);


### PR DESCRIPTION
Add exclude rules to couple findings which may create more problems when trying to fix them. Fix the location of one exclude rule to actually have an effect.