### PR TITLE
fix pricipal variation parsing in xboardengine.cpp

### DIFF
--- a/projects/lib/src/moveevaluation.cpp
+++ b/projects/lib/src/moveevaluation.cpp
@@ -43,6 +43,7 @@ bool MoveEvaluation::operator==(const MoveEvaluation& other) const
 	&&  m_score == other.m_score
 	&&  m_time == other.m_time
 	&&  m_pvNumber == other.m_pvNumber
+	&&  m_pv == other.m_pv
 	&&  m_hashUsage == other.m_hashUsage
 	&&  m_ponderhitRate == other.m_ponderhitRate
 	&&  m_nodeCount == other.m_nodeCount
@@ -62,6 +63,7 @@ bool MoveEvaluation::operator!=(const MoveEvaluation& other) const
 	||  m_score != other.m_score
 	||  m_time != other.m_time
 	||  m_pvNumber != other.m_pvNumber
+	||  m_pv != other.m_pv
 	||  m_hashUsage != other.m_hashUsage
 	||  m_ponderhitRate != other.m_ponderhitRate
 	||  m_nodeCount != other.m_nodeCount
@@ -79,6 +81,7 @@ bool MoveEvaluation::isEmpty() const
 	&&  m_score == NULL_SCORE
 	&&  m_time < 500
 	&&  m_pvNumber == 0
+	&&  m_pv.isEmpty()
 	&&  m_hashUsage == 0
 	&&  m_ponderhitRate == 0
 	&&  m_nodeCount == 0

--- a/projects/lib/src/xboardengine.cpp
+++ b/projects/lib/src/xboardengine.cpp
@@ -603,7 +603,8 @@ int XboardEngine::adaptScore(int score) const
 
 void XboardEngine::parseLine(const QString& line)
 {
-	auto input = tokenize(line);
+	const QStringView trimmedLine(QStringView(line).trimmed());
+	auto input = tokenize(trimmedLine);
 	auto command = input.first;
 	if (command.isEmpty())
 		return;
@@ -652,7 +653,7 @@ void XboardEngine::parseLine(const QString& line)
 	else if (command.at(0).isDigit()
 	     && !command.contains(QChar('.')))	// principal variation
 	{
-		auto eval = parsePv(line);
+		auto eval = parsePv(trimmedLine);
 		if (!eval.isEmpty())
 		{
 			m_eval = eval;
@@ -824,12 +825,10 @@ MoveEvaluation XboardEngine::parsePv(QStringView pvString)
 	if (ok)
 		eval.setNodeCount(val);
 
-	tokens = tokenize(tokens.second);
-
 	// Principal variation
-	if (tokens.first.isEmpty())
+	if (tokens.second.isEmpty())
 		return MoveEvaluation();
-	eval.setPv(tokens.first.toString());
+	eval.setPv(tokens.second.toString());
 
 	return eval;
 }

--- a/projects/lib/tests/xboardengine/tst_xboardengine.cpp
+++ b/projects/lib/tests/xboardengine/tst_xboardengine.cpp
@@ -98,6 +98,16 @@ void tst_XboardEngine::testParsePv_data() const
 	QTest::newRow("search depth, evaluation, search time, node count and pv 2")
 	    << "12 -18 518 12708664 Nf6 Nc3 d5 exd5 Nxd5 Nf3 Nc6 Be2 Nf4 O-O Bf5 d3"
 	    << eval2;
+
+	MoveEvaluation eval3;
+	eval2.setDepth(12);
+	eval2.setScore(-18);
+	eval2.setTime(518 * 10);
+	eval2.setNodeCount(12708664);
+	eval2.setPv("Nf6 Nc3 d5 exd5 Nxd5 Nf3 Nc6 Be2 Nf4 O-O Bf5 d3");
+	QTest::newRow("search depth, evaluation, search time, node count and pv 3")
+		<< "\t12 -18 518 12708664 Nf6 Nc3 d5 exd5 Nxd5 Nf3 Nc6 Be2 Nf4 O-O Bf5 d3"
+		<< eval2;
 }
 
 void tst_XboardEngine::testParsePv()


### PR DESCRIPTION
This also fixes the comparison operators in MoveEvaluation, and the xboardengine tests.