### PR TITLE
Fix CLI -debug option parsing for bare flag usage. Closes #842

### DIFF
--- a/projects/cli/src/main.cpp
+++ b/projects/cli/src/main.cpp
@@ -483,9 +483,11 @@ EngineMatch* parseMatch(const QStringList& args, QObject* parent)
 		{
 			QLoggingCategory::defaultCategory()->setEnabled(QtDebugMsg, true);
 			match->setDebugMode(true);
-			if (value == "all")
+			if (value.typeId() == QMetaType::Bool)
+				; // No explicit argument given: enable debug mode only.
+			else if (value.toString() == "all")
 				eachOptions.append("debug");
-			else if (!value.isNull())
+			else if (!value.toString().isEmpty())
 				ok = false;
 		}
 		// Use an opening suite


### PR DESCRIPTION
## Summary

This PR fixes the CLI handling of the `-debug` option when it is used as a bare flag.

Previously, invoking `-debug` without an argument could still trigger an “Invalid value for option `-debug`” warning, even though the option is intended to be optional. This change makes the flag work as a standalone switch, while still supporting `-debug all` and continuing to reject other invalid values.

## What changed

- Accept `-debug` as a valid bare flag
- Preserve support for `-debug all`
- Keep validation for unsupported values

## Why

The option was being treated as if it required a parameter, which did not match the intended behavior of the CLI.

## Testing

- Verified that `-debug` no longer produces the invalid-value warning
- Verified that `-debug all` still enables the expected behavior