### PR TITLE
gui: work around macOS 27 beta QMacStyle not drawing check option checkboxes

### DIFF
--- a/projects/gui/src/engineoptiondelegate.cpp
+++ b/projects/gui/src/engineoptiondelegate.cpp
@@ -25,6 +25,31 @@
 #include <QtDebug>
 #include "pathlineedit.h"
 
+#ifdef Q_OS_MACOS
+#include <QApplication>
+#include <QStyle>
+#include <QStyleOptionButton>
+#include <QPainter>
+#include <QPixmap>
+#include <QMouseEvent>
+#include <QKeyEvent>
+#include <QAbstractItemModel>
+
+namespace
+{
+// Rect of the check indicator within a value cell. Ask the style for the exact
+// rect it uses for item-view check indicators so the size and vertical
+// centering match everything else. Expects an option already passed through
+// initStyleOption() (so HasCheckIndicator and widget are set).
+QRect macCheckIndicatorRect(const QStyleOptionViewItem& option)
+{
+	QStyle* style = option.widget ? option.widget->style() : QApplication::style();
+	return style->subElementRect(QStyle::SE_ItemViewItemCheckIndicator,
+				     &option, option.widget);
+}
+} // anonymous namespace
+#endif
+
 EngineOptionDelegate::EngineOptionDelegate(QWidget* parent)
 	: QStyledItemDelegate(parent)
 {
@@ -179,3 +204,83 @@ void EngineOptionDelegate::setModelData(QWidget* editor,
 	}
 	QStyledItemDelegate::setModelData(editor, model, index);
 }
+
+#ifdef Q_OS_MACOS
+void EngineOptionDelegate::paint(QPainter* painter,
+				 const QStyleOptionViewItem& option,
+				 const QModelIndex& index) const
+{
+	const QVariant checkData = index.data(Qt::CheckStateRole);
+	if (!checkData.isValid())
+	{
+		QStyledItemDelegate::paint(painter, option, index);
+		return;
+	}
+
+	QStyleOptionViewItem opt(option);
+	initStyleOption(&opt, index);
+
+	// Resolve the indicator rect while HasCheckIndicator is still set, then
+	// paint the cell without it (QMacStyle never draws it anyway).
+	const QRect target = macCheckIndicatorRect(opt);
+	opt.features &= ~QStyleOptionViewItem::HasCheckIndicator;
+	opt.text.clear();
+	QStyledItemDelegate::paint(painter, opt, index);
+
+	// Draw the checkbox ourselves. QMacStyle ignores the option rect for
+	// PE_IndicatorCheckBox and paints at the painter origin, so render the
+	// indicator into an origin-anchored pixmap and blit it into place.
+	const qreal ratio = painter->device()->devicePixelRatioF();
+	QPixmap pixmap(target.size() * ratio);
+	pixmap.setDevicePixelRatio(ratio);
+	pixmap.fill(Qt::transparent);
+
+	QPainter pixmapPainter(&pixmap);
+	QStyleOptionButton indicator;
+	indicator.rect = QRect(QPoint(0, 0), target.size());
+	indicator.state = QStyle::State_Enabled
+		| (static_cast<Qt::CheckState>(checkData.toInt()) == Qt::Checked
+		   ? QStyle::State_On : QStyle::State_Off);
+	QApplication::style()->drawPrimitive(QStyle::PE_IndicatorCheckBox,
+					     &indicator, &pixmapPainter);
+	pixmapPainter.end();
+
+	painter->drawPixmap(target.topLeft(), pixmap);
+}
+
+bool EngineOptionDelegate::editorEvent(QEvent* event,
+				       QAbstractItemModel* model,
+				       const QStyleOptionViewItem& option,
+				       const QModelIndex& index)
+{
+	const QVariant checkData = index.data(Qt::CheckStateRole);
+	const Qt::ItemFlags flags = index.flags();
+	if (!checkData.isValid()
+	||  !(flags & Qt::ItemIsUserCheckable)
+	||  !(flags & Qt::ItemIsEnabled))
+		return QStyledItemDelegate::editorEvent(event, model, option, index);
+
+	// Toggle on a left-button release over the indicator, or Space / Select.
+	if (event->type() == QEvent::MouseButtonRelease)
+	{
+		QStyleOptionViewItem opt(option);
+		initStyleOption(&opt, index);
+		auto* mouseEvent = static_cast<QMouseEvent*>(event);
+		if (mouseEvent->button() != Qt::LeftButton
+		||  !macCheckIndicatorRect(opt).contains(mouseEvent->position().toPoint()))
+			return false;
+	}
+	else if (event->type() == QEvent::KeyPress)
+	{
+		auto* keyEvent = static_cast<QKeyEvent*>(event);
+		if (keyEvent->key() != Qt::Key_Space && keyEvent->key() != Qt::Key_Select)
+			return false;
+	}
+	else
+		return false;
+
+	const Qt::CheckState current = static_cast<Qt::CheckState>(checkData.toInt());
+	const Qt::CheckState next = (current == Qt::Checked) ? Qt::Unchecked : Qt::Checked;
+	return model->setData(index, next, Qt::CheckStateRole);
+}
+#endif

--- a/projects/gui/src/engineoptiondelegate.h
+++ b/projects/gui/src/engineoptiondelegate.h
@@ -34,6 +34,17 @@ class EngineOptionDelegate : public QStyledItemDelegate
 		virtual void setEditorData(QWidget* editor, const QModelIndex& index) const;
 		virtual void setModelData(QWidget* editor, QAbstractItemModel* model,
 					  const QModelIndex& index) const;
+#ifdef Q_OS_MACOS
+		// QMacStyle doesn't paint the item-view check indicator, so boolean
+		// options otherwise render as blank, un-clickable cells. Draw the
+		// checkbox and handle its toggling ourselves on macOS; other platforms
+		// keep Qt's built-in check-indicator handling unchanged.
+		virtual void paint(QPainter* painter, const QStyleOptionViewItem& option,
+				   const QModelIndex& index) const;
+		virtual bool editorEvent(QEvent* event, QAbstractItemModel* model,
+					 const QStyleOptionViewItem& option,
+					 const QModelIndex& index);
+#endif
 
 	public slots:
 		void setEngineDirectory(const QString& dir);


### PR DESCRIPTION
### Summary
On **macOS 27.0 beta 3 (26A5378j)**, boolean (`check`-type) engine options render as **blank, un-clickable cells** in the engine options table — the Value column shows nothing and the option can't be toggled.

### Cause
`QMacStyle` no longer paints the item-view check indicator for a `QTreeView`/`QTableView` cell on this beta (Apple reworked AppKit controls on top of SwiftUI; the same path also *crashes* QMacStyle when drawing an `NSSlider`). It renders correctly on **macOS 26.6**, under **Fusion**, and in a `QListView` — so it's a QMacStyle regression against the beta, not a cutechess bug.

Minimal pure-Qt reproduction (no cutechess):
```cpp
#include <QApplication>
#include <QTreeView>
#include <QStandardItemModel>
int main(int argc, char **argv) {
    QApplication app(argc, argv);
    QStandardItemModel model(1, 1);
    model.setData(model.index(0, 0), Qt::Checked, Qt::CheckStateRole);
    QTreeView view; view.setModel(&model); view.show();
    return app.exec();
}
```
| Environment | Result |
|---|---|
| macOS 27.0 beta 3, QMacStyle | ❌ blank |
| macOS 26.6, QMacStyle | ✅ checkbox |
| any macOS, `-style fusion` | ✅ checkbox |

### Change
Draw the checkbox and handle its toggling ourselves in `EngineOptionDelegate`, gated behind `#ifdef Q_OS_MACOS`. `paint()` sizes/positions the indicator from `SE_ItemViewItemCheckIndicator` and blits it from an origin-anchored pixmap (QMacStyle ignores the option rect for `PE_IndicatorCheckBox`); `editorEvent()` toggles `CheckStateRole` on a left-click of the indicator or Space/Select. The model is unchanged, so non-macOS builds are unaffected.

### Notes
- This is a **workaround for a beta-only regression** — Apple or Qt may fix it before macOS 27 ships, making it redundant (but harmless: it draws the same checkbox via the style).
- The guard is compile-time `Q_OS_MACOS`, so the custom drawing also runs on macOS versions where QMacStyle works (26.x, and presumably the 27 release). If preferred, I can scope it more tightly (runtime check / affected builds only), or hold until 27 ships — happy to adjust.
