### PR TITLE
Replace remaining QRegExp usage

### DIFF
--- a/projects/lib/src/engineprocess_win.cpp
+++ b/projects/lib/src/engineprocess_win.cpp
@@ -19,7 +19,7 @@
 #include "engineprocess_win.h"
 #include <QDir>
 #include <QFile>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QMutexLocker>
 #include "pipereader_win.h"
 
@@ -355,12 +355,11 @@ void EngineProcess::start(const QString& program,
 {
 	QStringList args;
 
-	QRegExp rx("((?:[^\\s\"]+)|(?:\"(?:\\\\\"|[^\"])*\"))");
-	int pos = 0;
-	while ((pos = rx.indexIn(program, pos)) != -1)
+	QRegularExpression rx("((?:[^\\s\"]+)|(?:\"(?:\\\\\"|[^\"])*\"))");
+	auto matches = rx.globalMatch(program);
+	while (matches.hasNext())
 	{
-		args << rx.cap();
-		pos += rx.matchedLength();
+		args << matches.next().captured();
 	}
 	if (args.isEmpty())
 		return;


### PR DESCRIPTION
Replaces the final `QRegExp` use in the Windows engine-process command-line parser with `QRegularExpression::globalMatch()`. Each iterator result contributes its full captured match, preserving the existing tokenization behavior while removing the obsolete API dependency.

Validation:
- `git diff --check`
- Confirmed no `QRegExp` references remain under `projects/`
- Native build/tests not run locally because CMake and Qt are unavailable; the repository CI builds Windows, Linux, and macOS with Qt 6.8.

Fixes #396.