### PR TITLE
fix: use full moves instead of plies in parsing and exporting of PGNs

### DIFF
--- a/projects/lib/src/moveevaluation.cpp
+++ b/projects/lib/src/moveevaluation.cpp
@@ -137,7 +137,7 @@ QString MoveEvaluation::scoreText() const
 		{
 			if (m_score < 0)
 				str += "-";
-			str += "M" + QString::number(absScore);
+			str += "M" + QString::number((absScore + 1) / 2);
 		}
 		else
 			str += QString::number(double(m_score) / 100.0, 'f', 2);

--- a/projects/lib/src/pgngame.cpp
+++ b/projects/lib/src/pgngame.cpp
@@ -574,10 +574,19 @@ QMap< int, int > PgnGame::extractScores() const
 		bool isMateScore = s.contains('M');
 		if (isMateScore)
 			s.remove('M');
-		int score = 100 * s.toDouble();
+		int score = 0;
 		if (isMateScore)
-			score = score > 0 ? MoveEvaluation::MATE_SCORE - score / 100 
-					  : score / 100 - MoveEvaluation::MATE_SCORE;
+		{
+			int mateMoves = qRound(s.toDouble());
+			if (mateMoves > 0)
+				score = MoveEvaluation::MATE_SCORE - (2 * mateMoves - 1);
+			else
+				score = -MoveEvaluation::MATE_SCORE - 2 * mateMoves;
+		}
+		else
+		{
+			score = 100 * s.toDouble();
+		}
 		scores[count] = score;
 	}
 	return scores;


### PR DESCRIPTION
This is especially important for "mate in x". Previously, the exported PGN would output it through plies, instead of full moves as in the specification.

In addition, when we are parsing a PGN, we also convert the full moves to the ply count.

Fixes #873